### PR TITLE
Go port: HUD — HP / depth / gear status line

### DIFF
--- a/go/internal/ui/tcell/screen.go
+++ b/go/internal/ui/tcell/screen.go
@@ -59,8 +59,9 @@ func (sc *Screen) Render(v ui.View) {
 			sc.s.SetContent(x, y, c.Glyph, nil, st)
 		}
 	}
+	drawString(sc.s, 0, v.H, v.Status)
 	for i, msg := range v.Messages {
-		drawString(sc.s, 0, v.H+i, msg)
+		drawString(sc.s, 0, v.H+1+i, msg)
 	}
 	sc.s.Show()
 }

--- a/go/internal/ui/ui.go
+++ b/go/internal/ui/ui.go
@@ -4,6 +4,8 @@
 package ui
 
 import (
+	"fmt"
+
 	"github.com/c0ze/tsl/internal/content"
 	"github.com/c0ze/tsl/internal/game"
 )
@@ -19,6 +21,7 @@ type Cell struct {
 type View struct {
 	W, H     int
 	Cells    []Cell // len W*H, row-major
+	Status   string // HUD line (HP, depth, gear)
 	Messages []string
 }
 
@@ -98,8 +101,22 @@ func BuildView(g *game.Game) View {
 	if l.InBounds(g.Player) {
 		*v.At(g.Player.X, g.Player.Y) = Cell{Glyph: PlayerGlyph, Color: PlayerColor}
 	}
+	v.Status = statusLine(g)
 	v.Messages = lastN(g.Messages, 4)
 	return v
+}
+
+// statusLine summarises the player's vitals and gear for the HUD.
+func statusLine(g *game.Game) string {
+	wield, wear := "none", "none"
+	if g.Weapon != nil {
+		wield = g.Weapon.Def.Name
+	}
+	if g.Armor != nil {
+		wear = g.Armor.Def.Name
+	}
+	return fmt.Sprintf("HP %d/%d   Depth %d   Wield: %s   Wear: %s",
+		g.PlayerHP, g.PlayerMax, g.Depth, wield, wear)
 }
 
 // lastN returns up to the last n elements of s.

--- a/go/internal/ui/ui.go
+++ b/go/internal/ui/ui.go
@@ -109,10 +109,10 @@ func BuildView(g *game.Game) View {
 // statusLine summarises the player's vitals and gear for the HUD.
 func statusLine(g *game.Game) string {
 	wield, wear := "none", "none"
-	if g.Weapon != nil {
+	if g.Weapon != nil && g.Weapon.Def != nil {
 		wield = g.Weapon.Def.Name
 	}
-	if g.Armor != nil {
+	if g.Armor != nil && g.Armor.Def != nil {
 		wear = g.Armor.Def.Name
 	}
 	return fmt.Sprintf("HP %d/%d   Depth %d   Wield: %s   Wear: %s",

--- a/go/internal/ui/ui_test.go
+++ b/go/internal/ui/ui_test.go
@@ -1,6 +1,7 @@
 package ui
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/c0ze/tsl/internal/content"
@@ -40,6 +41,18 @@ func (s *scriptPrompter) Menu(MenuSpec) (int, bool) { return 0, false }
 type nullRenderer struct{ frames int }
 
 func (n *nullRenderer) Render(View) { n.frames++ }
+
+func TestBuildViewStatusLine(t *testing.T) {
+	g := testGame(t, []string{".@."})
+	g.PlayerHP, g.PlayerMax, g.Depth = 14, 20, 2
+	g.Weapon = &game.Item{Def: &content.ItemDef{Name: "dagger"}}
+	v := BuildView(g)
+	for _, want := range []string{"HP 14/20", "Depth 2", "Wield: dagger", "Wear: none"} {
+		if !strings.Contains(v.Status, want) {
+			t.Errorf("status %q missing %q", v.Status, want)
+		}
+	}
+}
 
 func TestBuildViewPlacesPlayer(t *testing.T) {
 	g := testGame(t, []string{"...", ".@.", "..."})


### PR DESCRIPTION
## Summary

Adds a HUD status line under the map (was deliberately deferred — HP/depth/gear previously only surfaced via combat messages).

- `ui.View` gains a `Status` string; `BuildView` fills it: `HP cur/max   Depth N   Wield: <weapon>   Wear: <armor>`.
- `ui/tcell` renders it on the line below the map, with messages beneath.
- Pure UI-layer change — the engine already holds all the state.

## Test Plan
- [x] `cd go && go test ./...` — all packages pass
- [x] new `TestBuildViewStatusLine` asserts HP/depth/wielded gear appear in `View.Status`
- [x] `go vet`/gofmt clean
- [ ] Manual: `go run ./cmd/tsl` — status line shows under the map (terminal ≥ ~29 rows)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an on-screen status display showing player HP (current/max), dungeon depth, and equipped items; message area now renders below the status line.
* **Tests**
  * Added unit tests to verify correct status line generation across player states and equipment configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->