### PR TITLE
Depth-scaled spawns (#16 slice): min_depth + first depth-gated tanks

### DIFF
--- a/docs/superpowers/plans/2026-06-08-depth-scaled-spawns.md
+++ b/docs/superpowers/plans/2026-06-08-depth-scaled-spawns.md
@@ -6,7 +6,7 @@
 
 **Architecture:** `MonsterDef.MinDepth` gates eligibility; `gen.Rooms` takes the current depth and `placeMonsters` filters the pool to `MinDepth <= depth`. The depth is already threaded by `Game.NewLevelFn(depth)` (cmd) and starts at 1. The big branching-named-level graph (the rest of #16) is a **later increment with its own design doc**; this slice keeps the linear depth model and `MaxDepth = 3`.
 
-**Tech Stack:** Go 1.21 (`GOTOOLCHAIN=local`). Commands from `/Users/arda/projects/tsl/go`, prefixed `GOTOOLCHAIN=local`; prepend `env -u GOROOT` if a GOROOT error appears.
+**Tech Stack:** Go 1.21 (`GOTOOLCHAIN=local`). Commands run from the `go/` directory at the repo root, prefixed `GOTOOLCHAIN=local`; prepend `env -u GOROOT` if a GOROOT error appears.
 
 ---
 

--- a/docs/superpowers/plans/2026-06-08-depth-scaled-spawns.md
+++ b/docs/superpowers/plans/2026-06-08-depth-scaled-spawns.md
@@ -1,0 +1,103 @@
+# Depth-Scaled Spawns Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Make monster spawning depth-aware (`min_depth`) so tougher monsters appear only on deeper floors — the first, highest-value slice of #16. Unblocks #13's deferred tanks.
+
+**Architecture:** `MonsterDef.MinDepth` gates eligibility; `gen.Rooms` takes the current depth and `placeMonsters` filters the pool to `MinDepth <= depth`. The depth is already threaded by `Game.NewLevelFn(depth)` (cmd) and starts at 1. The big branching-named-level graph (the rest of #16) is a **later increment with its own design doc**; this slice keeps the linear depth model and `MaxDepth = 3`.
+
+**Tech Stack:** Go 1.21 (`GOTOOLCHAIN=local`). Commands from `/Users/arda/projects/tsl/go`, prefixed `GOTOOLCHAIN=local`; prepend `env -u GOROOT` if a GOROOT error appears.
+
+---
+
+## Task 0: Branch
+`depth-spawns` off `master`.
+
+## Task 1: `min_depth` gating
+
+**Files:** `internal/content/content.go`, `internal/gen/gen.go`, `cmd/tsl/main.go`, `internal/gen/gen_test.go`, `internal/content/content_test.go`
+
+**Step 1 (test, gen):** Add to `gen_test.go`:
+```go
+func TestPlaceMonstersRespectsMinDepth(t *testing.T) {
+	c := testContent()
+	c.Monsters = map[string]*content.MonsterDef{
+		"deepling": {ID: "deepling", Name: "deepling", Glyph: "D", Color: content.ColorRed, HP: 3, Attack: 1, Dodge: 1, Damage: "1d2", MinDepth: 5},
+	}
+	if l, _, _, err := Rooms(rng.NewWithSeed(7), c, 60, 24, 1); err != nil {
+		t.Fatal(err)
+	} else if len(l.Creatures) != 0 {
+		t.Errorf("min_depth 5 monster must not spawn at depth 1, got %d", len(l.Creatures))
+	}
+	if l, _, _, err := Rooms(rng.NewWithSeed(7), c, 60, 24, 5); err != nil {
+		t.Fatal(err)
+	} else if len(l.Creatures) == 0 {
+		t.Error("min_depth 5 monster should spawn at depth 5")
+	}
+}
+```
+Also update the existing `Rooms(...)` calls in `gen_test.go` to pass a trailing depth arg (`, 1` — except the new test which passes its own). The `TestRoomsPlacesMonsters` call should pass depth `1`.
+
+**Step 2 (run, expect FAIL):**
+```bash
+GOTOOLCHAIN=local go test ./internal/gen/ -run TestPlaceMonstersRespectsMinDepth 2>&1 | tail
+```
+(Compile failure: `Rooms` arity + `MinDepth` field.)
+
+**Step 3 (implement):**
+- `content.go` `MonsterDef`: add `MinDepth int `toml:"min_depth"`` (after `Corpse`). In `validateMonster`, add `if m.MinDepth < 0 { return fmt.Errorf("min_depth must be >= 0, got %d", m.MinDepth) }`.
+- `gen.go`: change signature to `func Rooms(r *rng.MT, c *content.Content, w, h, depth int) (...)` and pass `depth` to `placeMonsters(r, c, lvl, rooms, start, depth)`. In `placeMonsters(..., depth int)`, when building `ids`, `for id, m := range c.Monsters { if m.MinDepth > depth { continue }; ids = append(ids, id) }`.
+- `cmd/tsl/main.go`: both `gen.Rooms(r, c, mapW, mapH)` calls → add depth. `newGame` initial level is depth 1: `gen.Rooms(r, c, mapW, mapH, 1)`. The `NewLevelFn` closure already receives `depth`: `gen.Rooms(r, c, mapW, mapH, depth)`.
+
+**Step 4 (run, expect PASS):**
+```bash
+GOTOOLCHAIN=local go test ./internal/gen/ ./internal/content/ ./cmd/... 2>&1 | tail
+```
+
+**Step 5 (commit):** `feat(gen): depth-scaled monster spawning (min_depth)`
+
+## Task 2: depth-gated tanks (data)
+
+**Files:** `internal/gen/...` none; `data/monsters.toml`, `data/data_test.go`
+
+**Step 1 (test):** extend `TestEmbeddedRoster` (or add `TestDepthGatedRoster`) asserting `c.Monsters["scarecrow"].MinDepth == 2` and `c.Monsters["slime"].MinDepth == 3`.
+
+**Step 2 (run, expect FAIL).**
+
+**Step 3 (data):** add to `monsters.toml` (stats inspired by C `monster.c`; glyphs from `glyph.c`; no corpse — straw/ooze isn't edible):
+```toml
+[monster.scarecrow]
+name = "scarecrow"
+glyph = "C"
+color = "brown"
+hp = 15
+attack = 4
+dodge = 0
+damage = "1d6"
+speed = 80
+min_depth = 2
+
+[monster.slime]
+name = "slime"
+glyph = "x"
+color = "green"
+hp = 18
+attack = 3
+dodge = 0
+damage = "1d4"
+speed = 80
+min_depth = 3
+```
+
+**Step 4 (run, expect PASS)** — golden + full content validation.
+
+**Step 5 (commit):** `feat(data): depth-gated tanks — scarecrow (d2), slime (d3)`
+
+## Task 3: Verify, push, PR, loop
+```bash
+gofmt -l . && GOTOOLCHAIN=local go vet ./... && GOTOOLCHAIN=local go test ./... && GOTOOLCHAIN=local go build -o /tmp/tsl ./cmd/tsl && echo ALL_GREEN
+```
+Commit plan doc; push `depth-spawns`; `gh pr create` (part of #16, documents that this is the spawn-scaling slice; named branching levels to follow). Then CodeRabbit loop → merge `--delete-branch` → pull master.
+
+## Done when
+Deeper floors spawn the tanks (scarecrow d2+, slime d3); floor 1 stays early-tier; suite green. PR notes the named-level-graph remainder of #16 as the next increment.

--- a/go/cmd/tsl/main.go
+++ b/go/cmd/tsl/main.go
@@ -66,7 +66,7 @@ func run() (string, error) {
 // wires a level generator so the player can descend.
 func newGame(c *content.Content, seed uint32) (*game.Game, error) {
 	r := rng.NewWithSeed(seed)
-	lvl, start, _, err := gen.Rooms(r, c, mapW, mapH)
+	lvl, start, _, err := gen.Rooms(r, c, mapW, mapH, 1)
 	if err != nil {
 		return nil, err
 	}
@@ -85,7 +85,7 @@ func newGame(c *content.Content, seed uint32) (*game.Game, error) {
 		return nil, err
 	}
 	g.NewLevelFn = func(depth int) (*game.Level, game.Pos, error) {
-		l, s, _, err := gen.Rooms(r, c, mapW, mapH)
+		l, s, _, err := gen.Rooms(r, c, mapW, mapH, depth)
 		return l, s, err
 	}
 	return g, nil

--- a/go/data/data_test.go
+++ b/go/data/data_test.go
@@ -28,3 +28,17 @@ func TestEmbeddedRoster(t *testing.T) {
 		t.Error("ratman glyph should be 'r'")
 	}
 }
+
+// TestDepthGatedTanks checks the tougher monsters only appear on deeper floors.
+func TestDepthGatedTanks(t *testing.T) {
+	c, err := content.Load(Files)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if s := c.Monsters["scarecrow"]; s == nil || s.MinDepth != 2 {
+		t.Errorf("scarecrow should be gated to depth 2, got %+v", s)
+	}
+	if s := c.Monsters["slime"]; s == nil || s.MinDepth != 3 {
+		t.Errorf("slime should be gated to depth 3, got %+v", s)
+	}
+}

--- a/go/data/monsters.toml
+++ b/go/data/monsters.toml
@@ -68,3 +68,26 @@ dodge = 2
 damage = "1d4"
 speed = 65
 corpse = "corpse"
+
+# Depth-gated tanks (no corpse — straw/ooze isn't edible). See #16 depth scaling.
+[monster.scarecrow]
+name = "scarecrow"
+glyph = "C"
+color = "brown"
+hp = 15
+attack = 4
+dodge = 0
+damage = "1d6"
+speed = 80
+min_depth = 2
+
+[monster.slime]
+name = "slime"
+glyph = "x"
+color = "green"
+hp = 18
+attack = 3
+dodge = 0
+damage = "1d4"
+speed = 80
+min_depth = 3

--- a/go/internal/content/content.go
+++ b/go/internal/content/content.go
@@ -49,16 +49,17 @@ func (t *TileDef) Rune() rune {
 
 // MonsterDef defines a kind of monster.
 type MonsterDef struct {
-	ID     string `toml:"-"`
-	Name   string `toml:"name"`
-	Glyph  string `toml:"glyph"`
-	Color  Color  `toml:"color"`
-	HP     int    `toml:"hp"`
-	Attack int    `toml:"attack"`
-	Dodge  int    `toml:"dodge"`
-	Damage string `toml:"damage"` // dice spec, e.g. "1d4"
-	Speed  int    `toml:"speed"`  // energy gained per turn; <= 0 defaults to 100
-	Corpse string `toml:"corpse"` // item id dropped on death ("" = none); must be a food item
+	ID       string `toml:"-"`
+	Name     string `toml:"name"`
+	Glyph    string `toml:"glyph"`
+	Color    Color  `toml:"color"`
+	HP       int    `toml:"hp"`
+	Attack   int    `toml:"attack"`
+	Dodge    int    `toml:"dodge"`
+	Damage   string `toml:"damage"`    // dice spec, e.g. "1d4"
+	Speed    int    `toml:"speed"`     // energy gained per turn; <= 0 defaults to 100
+	Corpse   string `toml:"corpse"`    // item id dropped on death ("" = none); must be a food item
+	MinDepth int    `toml:"min_depth"` // earliest depth this monster spawns (0/1 = from depth 1)
 }
 
 // Rune returns the monster's glyph as a rune.
@@ -237,6 +238,9 @@ func validateMonster(m *MonsterDef) error {
 	}
 	if !validDamageSpec(m.Damage) {
 		return fmt.Errorf("damage %q is not a valid dice spec", m.Damage)
+	}
+	if m.MinDepth < 0 {
+		return fmt.Errorf("min_depth must be >= 0, got %d", m.MinDepth)
 	}
 	return nil
 }

--- a/go/internal/gen/gen.go
+++ b/go/internal/gen/gen.go
@@ -33,7 +33,7 @@ func (r rect) intersects(o rect) bool {
 // the player start (center of the first room), and the down-stairs position
 // (center of the last room). Each room is joined to the previous by a corridor,
 // so the level is fully connected.
-func Rooms(r *rng.MT, c *content.Content, w, h int) (*game.Level, game.Pos, game.Pos, error) {
+func Rooms(r *rng.MT, c *content.Content, w, h, depth int) (*game.Level, game.Pos, game.Pos, error) {
 	floor, wall, stairs := c.Tiles["floor"], c.Tiles["wall"], c.Tiles["stairs_down"]
 	if floor == nil || wall == nil || stairs == nil {
 		return nil, game.Pos{}, game.Pos{}, fmt.Errorf("gen: tiles floor/wall/stairs_down must all be defined")
@@ -71,7 +71,7 @@ func Rooms(r *rng.MT, c *content.Content, w, h int) (*game.Level, game.Pos, game
 	start := rooms[0].center()
 	down := rooms[len(rooms)-1].center()
 	lvl.Set(down, stairs)
-	placeMonsters(r, c, lvl, rooms, start)
+	placeMonsters(r, c, lvl, rooms, start, depth)
 	placeItems(r, c, lvl, rooms, start)
 	return lvl, start, down, nil
 }
@@ -139,9 +139,12 @@ func placeItems(r *rng.MT, c *content.Content, lvl *game.Level, rooms []rect, st
 }
 
 // placeMonsters drops 0-2 monsters into each room except the starting room.
-func placeMonsters(r *rng.MT, c *content.Content, lvl *game.Level, rooms []rect, start game.Pos) {
+func placeMonsters(r *rng.MT, c *content.Content, lvl *game.Level, rooms []rect, start game.Pos, depth int) {
 	ids := make([]string, 0, len(c.Monsters))
-	for id := range c.Monsters {
+	for id, m := range c.Monsters {
+		if m.MinDepth > depth {
+			continue // not deep enough for this monster yet
+		}
 		ids = append(ids, id)
 	}
 	if len(ids) == 0 {

--- a/go/internal/gen/gen_test.go
+++ b/go/internal/gen/gen_test.go
@@ -52,11 +52,11 @@ func glyphGrid(l *game.Level) string {
 
 func TestRoomsDeterministic(t *testing.T) {
 	c := testContent()
-	l1, s1, d1, err := Rooms(rng.NewWithSeed(42), c, 60, 24)
+	l1, s1, d1, err := Rooms(rng.NewWithSeed(42), c, 60, 24, 1)
 	if err != nil {
 		t.Fatal(err)
 	}
-	l2, s2, d2, err := Rooms(rng.NewWithSeed(42), c, 60, 24)
+	l2, s2, d2, err := Rooms(rng.NewWithSeed(42), c, 60, 24, 1)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -71,7 +71,7 @@ func TestRoomsDeterministic(t *testing.T) {
 func TestRoomsConnectivityAndPlacement(t *testing.T) {
 	c := testContent()
 	for seed := uint32(1); seed <= 20; seed++ {
-		l, start, down, err := Rooms(rng.NewWithSeed(seed), c, 60, 24)
+		l, start, down, err := Rooms(rng.NewWithSeed(seed), c, 60, 24, 1)
 		if err != nil {
 			t.Fatalf("seed %d: %v", seed, err)
 		}
@@ -95,7 +95,7 @@ func TestRoomsPlacesItems(t *testing.T) {
 	c.Items = map[string]*content.ItemDef{
 		"potion": {ID: "potion", Name: "potion", Glyph: "!", Color: content.ColorRed, Kind: "potion", Use: "heal", Power: 8},
 	}
-	l, _, _, err := Rooms(rng.NewWithSeed(3), c, 60, 24)
+	l, _, _, err := Rooms(rng.NewWithSeed(3), c, 60, 24, 1)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -114,7 +114,7 @@ func TestPlaceItemsSkipsNoSpawn(t *testing.T) {
 	c.Items = map[string]*content.ItemDef{
 		"corpse": {ID: "corpse", Name: "corpse", Glyph: "%", Color: content.ColorBrown, Kind: "food", Use: "eat", Power: 3, NoSpawn: true},
 	}
-	l, _, _, err := Rooms(rng.NewWithSeed(3), c, 60, 24)
+	l, _, _, err := Rooms(rng.NewWithSeed(3), c, 60, 24, 1)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -123,12 +123,29 @@ func TestPlaceItemsSkipsNoSpawn(t *testing.T) {
 	}
 }
 
+func TestPlaceMonstersRespectsMinDepth(t *testing.T) {
+	c := testContent()
+	c.Monsters = map[string]*content.MonsterDef{
+		"deepling": {ID: "deepling", Name: "deepling", Glyph: "D", Color: content.ColorRed, HP: 3, Attack: 1, Dodge: 1, Damage: "1d2", MinDepth: 5},
+	}
+	if l, _, _, err := Rooms(rng.NewWithSeed(7), c, 60, 24, 1); err != nil {
+		t.Fatal(err)
+	} else if len(l.Creatures) != 0 {
+		t.Errorf("min_depth 5 monster must not spawn at depth 1, got %d", len(l.Creatures))
+	}
+	if l, _, _, err := Rooms(rng.NewWithSeed(7), c, 60, 24, 5); err != nil {
+		t.Fatal(err)
+	} else if len(l.Creatures) == 0 {
+		t.Error("min_depth 5 monster should spawn at depth 5")
+	}
+}
+
 func TestRoomsPlacesMonsters(t *testing.T) {
 	c := testContent()
 	c.Monsters = map[string]*content.MonsterDef{
 		"rat": {ID: "rat", Name: "rat", Glyph: "r", Color: content.ColorBrown, HP: 3, Attack: 2, Dodge: 1, Damage: "1d2"},
 	}
-	l, _, _, err := Rooms(rng.NewWithSeed(7), c, 60, 24)
+	l, _, _, err := Rooms(rng.NewWithSeed(7), c, 60, 24, 1)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
First slice of #16. Makes monster spawning **depth-aware** so tougher monsters appear only on deeper floors — the prerequisite that unblocks #13's deferred tanks.

## What
- `MonsterDef.min_depth` (validated `>= 0`); the generator filters its spawn pool to `min_depth <= depth`.
- `gen.Rooms` now takes the current `depth` (already threaded by `Game.NewLevelFn(depth)`, starting at 1).
- Two depth-gated tanks added: **scarecrow** (`C`, 15 HP, depth 2+) and **slime** (`x`, 18 HP, depth 3+). No corpse — straw/ooze isn't edible.

## Scope
- Keeps the **linear depth model** and `MaxDepth = 3` for now. The full **branching named-level graph** (the Dungeon → Catacombs → … → Chapel with per-level spawn tables) is the **next increment of #16, with its own design doc** — flagged because it's a real architecture change.
- Stats inspired by C `monster.c` (`attr_health`/`attr_speed`); glyphs from `glyph.c`. Tunable.

## Tests
`gen` test proves a `min_depth 5` monster doesn't spawn at depth 1 but does at depth 5; `data` golden test pins scarecrow→d2, slime→d3. Existing `Rooms(...)` call sites updated for the new depth arg. `gofmt`/`vet`/`test ./...` green.

Part of #16.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Depth-aware monster spawning — stronger monsters only appear on deeper dungeon floors.

* **New Content**
  * Added Scarecrow (from floor 2+) and Slime (from floor 3+).

* **Tests**
  * Added validation tests to ensure monsters respect depth gating.

* **Documentation**
  * Added implementation plan for depth-scaled spawn mechanics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->