### PR TITLE
Dungeon 2b (#16): the full 10-level branching map

### DIFF
--- a/docs/superpowers/plans/2026-06-08-dungeon-full-map-2b.md
+++ b/docs/superpowers/plans/2026-06-08-dungeon-full-map-2b.md
@@ -1,0 +1,45 @@
+# Dungeon Full Map 2b Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Complete the faithful 10-level branching map on the 2a engine. Pure data (`levels.toml`) plus a golden-test update — no engine changes.
+
+**Tech Stack:** Go 1.21 (`GOTOOLCHAIN=local`). Commands run from the `go/` directory at the repo root.
+
+## The map (faithful to `common/places.c`)
+
+| level (id) | links to | win |
+|---|---|---|
+| the Dungeon (`dungeon`, start) | catacombs, ominous_cave | |
+| the Catacombs (`catacombs`) | dungeon, laboratory | |
+| the Ominous Cave (`ominous_cave`) | dungeon, comm_hub, underpass | |
+| the Laboratory (`laboratory`) | catacombs, drowned_city | |
+| the Communications Hub (`comm_hub`) | ominous_cave, frozen_vault | |
+| the Underpass (`underpass`) | ominous_cave, drowned_city | |
+| the Drowned City (`drowned_city`) | laboratory, dragons_lair, underpass | |
+| the Vault of the Frozen Saint (`frozen_vault`) | comm_hub, dragons_lair | |
+| the Dragons Lair (`dragons_lair`) | chapel, drowned_city, frozen_vault | |
+| the Chapel of Fallen Stars (`chapel`) | dragons_lair | **win** |
+
+All links are reciprocal, so the graph is fully connected and bidirectional.
+
+## Notes / divergences
+- **Win moves to the Chapel** (was temporarily the Ominous Cave in 2a). The Chapel keeps the temporary `win = true` until 2c replaces it with the real ascension altar + the mummylich/dragon.
+- **Sizes stay ~60x24** for every level (fits an 80-col terminal; the engine renders the whole level with no camera yet). The faithful wide Chapel (160 cols) waits for a viewport.
+- **Spawn tables** draw from the current 8-monster roster (ratman, ghoul, graveling, gnoblin, crypt_vermin, merman, scarecrow, slime), themed and tougher the deeper you go (e.g. the Drowned City favors mermen; the Dragons Lair and Chapel are scarecrow/slime/ghoul-heavy). Special-AI monsters + the Dragon/mummylich bosses come with later increments.
+
+## Task 1: golden test (failing first)
+**File:** `data/data_test.go`
+- Update `TestEmbeddedDungeon`: assert all 10 level ids present, exactly one `Start` (dungeon), exactly one `Win` (chapel).
+- Run: expect FAIL (only 3 levels exist).
+
+## Task 2: rewrite `levels.toml`
+**File:** `data/levels.toml`
+- Define all 10 levels per the table, each with a themed weighted spawn table and a `monsters` count (~8 early, ~12–14 deep). Exactly one `start` (dungeon), one `win` (chapel).
+- Run: `GOTOOLCHAIN=local go test ./data/ ./internal/content/ ./cmd/...` — expect PASS (validation: links/spawns resolve, one start).
+
+## Task 3: verify, push, PR, loop
+`gofmt -l . && go vet ./... && go test ./... && go build -o /tmp/tsl ./cmd/tsl`. Commit plan + data. Push `dungeon-full-map`; PR notes 2b completes the map; 2c (altar + bosses) next. CodeRabbit loop → merge → pull master.
+
+## Done when
+All 10 named levels are reachable via the graph, the Chapel is the win, the shipped data validates, and `TestNewGameFromShippedData` still boots. Suite green.

--- a/go/data/data_test.go
+++ b/go/data/data_test.go
@@ -50,21 +50,28 @@ func TestEmbeddedDungeon(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Load: %v", err)
 	}
-	starts := 0
-	for _, l := range c.Levels {
-		if l.Start {
-			starts++
-		}
-	}
-	if starts != 1 {
-		t.Errorf("want exactly one start level, got %d", starts)
-	}
-	for _, id := range []string{"dungeon", "catacombs", "ominous_cave"} {
+	all := []string{"dungeon", "catacombs", "ominous_cave", "laboratory", "comm_hub", "underpass", "drowned_city", "frozen_vault", "dragons_lair", "chapel"}
+	for _, id := range all {
 		if _, ok := c.Levels[id]; !ok {
 			t.Errorf("missing level %q", id)
 		}
 	}
-	if d := c.Levels["dungeon"]; d == nil || !d.Start {
-		t.Error("the Dungeon should be the start level")
+	if len(c.Levels) != len(all) {
+		t.Errorf("level count = %d, want %d", len(c.Levels), len(all))
+	}
+	starts, wins := 0, 0
+	for _, l := range c.Levels {
+		if l.Start {
+			starts++
+		}
+		if l.Win {
+			wins++
+		}
+	}
+	if d := c.Levels["dungeon"]; starts != 1 || d == nil || !d.Start {
+		t.Errorf("want exactly one start (the Dungeon), got %d", starts)
+	}
+	if ch := c.Levels["chapel"]; wins != 1 || ch == nil || !ch.Win {
+		t.Errorf("want exactly one win (the Chapel), got %d", wins)
 	}
 }

--- a/go/data/levels.toml
+++ b/go/data/levels.toml
@@ -1,8 +1,9 @@
-# Level graph. [level.<id>] → LevelDef. Exactly one level has start = true.
-# Stairs (portals) connect linked levels; the player explores to find them and
-# levels persist once visited. `win = true` is a temporary goal until the
-# Chapel ascension altar (#16 increment 2c). This is the 3-level starter subset
-# of the full map (see the design spec); the rest land in 2b.
+# The dungeon graph (faithful to common/places.c). [level.<id>] → LevelDef.
+# Exactly one level has start = true (the Dungeon); exactly one has win = true
+# (the Chapel — a temporary goal until the ascension altar + bosses in 2c).
+# Links are reciprocal, so the graph is fully connected and bidirectional.
+# All levels are ~60x24 to fit a terminal (the faithful wide Chapel awaits a
+# camera/viewport). Spawn tables draw from the current roster, tougher deeper.
 
 [level.dungeon]
 name = "the Dungeon"
@@ -28,7 +29,7 @@ weight = 1
 name = "the Catacombs"
 width = 60
 height = 24
-links = ["dungeon", "ominous_cave"]
+links = ["dungeon", "laboratory"]
 monsters = 10
 [[level.catacombs.spawn]]
 monster = "ghoul"
@@ -47,18 +48,139 @@ weight = 1
 name = "the Ominous Cave"
 width = 60
 height = 24
-links = ["dungeon", "catacombs"]
-monsters = 10
-win = true
+links = ["dungeon", "comm_hub", "underpass"]
+monsters = 9
 [[level.ominous_cave.spawn]]
 monster = "graveling"
-weight = 2
-[[level.ominous_cave.spawn]]
-monster = "merman"
-weight = 2
+weight = 3
 [[level.ominous_cave.spawn]]
 monster = "crypt_vermin"
 weight = 2
 [[level.ominous_cave.spawn]]
+monster = "ratman"
+weight = 2
+[[level.ominous_cave.spawn]]
+monster = "merman"
+weight = 1
+
+[level.laboratory]
+name = "the Laboratory"
+width = 60
+height = 24
+links = ["catacombs", "drowned_city"]
+monsters = 10
+[[level.laboratory.spawn]]
+monster = "gnoblin"
+weight = 2
+[[level.laboratory.spawn]]
+monster = "scarecrow"
+weight = 2
+[[level.laboratory.spawn]]
+monster = "crypt_vermin"
+weight = 2
+[[level.laboratory.spawn]]
 monster = "slime"
+weight = 1
+
+[level.comm_hub]
+name = "the Communications Hub"
+width = 60
+height = 24
+links = ["ominous_cave", "frozen_vault"]
+monsters = 10
+[[level.comm_hub.spawn]]
+monster = "gnoblin"
+weight = 3
+[[level.comm_hub.spawn]]
+monster = "scarecrow"
+weight = 2
+[[level.comm_hub.spawn]]
+monster = "crypt_vermin"
+weight = 2
+
+[level.underpass]
+name = "the Underpass"
+width = 60
+height = 24
+links = ["ominous_cave", "drowned_city"]
+monsters = 10
+[[level.underpass.spawn]]
+monster = "ratman"
+weight = 2
+[[level.underpass.spawn]]
+monster = "graveling"
+weight = 2
+[[level.underpass.spawn]]
+monster = "crypt_vermin"
+weight = 3
+[[level.underpass.spawn]]
+monster = "merman"
+weight = 1
+
+[level.drowned_city]
+name = "the Drowned City"
+width = 60
+height = 24
+links = ["laboratory", "dragons_lair", "underpass"]
+monsters = 12
+[[level.drowned_city.spawn]]
+monster = "merman"
+weight = 4
+[[level.drowned_city.spawn]]
+monster = "slime"
+weight = 2
+[[level.drowned_city.spawn]]
+monster = "crypt_vermin"
+weight = 2
+
+[level.frozen_vault]
+name = "the Vault of the Frozen Saint"
+width = 60
+height = 24
+links = ["comm_hub", "dragons_lair"]
+monsters = 10
+[[level.frozen_vault.spawn]]
+monster = "scarecrow"
+weight = 3
+[[level.frozen_vault.spawn]]
+monster = "ghoul"
+weight = 2
+[[level.frozen_vault.spawn]]
+monster = "slime"
+weight = 2
+
+[level.dragons_lair]
+name = "the Dragons Lair"
+width = 60
+height = 24
+links = ["chapel", "drowned_city", "frozen_vault"]
+monsters = 14
+[[level.dragons_lair.spawn]]
+monster = "ghoul"
+weight = 3
+[[level.dragons_lair.spawn]]
+monster = "scarecrow"
+weight = 3
+[[level.dragons_lair.spawn]]
+monster = "slime"
+weight = 3
+
+[level.chapel]
+name = "the Chapel of Fallen Stars"
+width = 60
+height = 24
+links = ["dragons_lair"]
+monsters = 12
+win = true
+[[level.chapel.spawn]]
+monster = "ghoul"
+weight = 3
+[[level.chapel.spawn]]
+monster = "scarecrow"
+weight = 2
+[[level.chapel.spawn]]
+monster = "slime"
+weight = 3
+[[level.chapel.spawn]]
+monster = "merman"
 weight = 1


### PR DESCRIPTION
Completes the dungeon map on the 2a engine — **pure data** (`levels.toml`) plus a golden-test update, no engine changes.

## The map (faithful to `common/places.c`)
the Dungeon (start) ↔ Catacombs ↔ Laboratory ↔ Drowned City ↔ Dragons Lair ↔ **Chapel of Fallen Stars** (win), with the Ominous Cave → Communications Hub / Underpass branch and the Vault of the Frozen Saint feeding the Dragons Lair. All 10 levels, reciprocal links → fully connected & bidirectional.

| level | links |
|---|---|
| the Dungeon (start) | catacombs, ominous_cave |
| the Catacombs | dungeon, laboratory |
| the Ominous Cave | dungeon, comm_hub, underpass |
| the Laboratory | catacombs, drowned_city |
| the Communications Hub | ominous_cave, frozen_vault |
| the Underpass | ominous_cave, drowned_city |
| the Drowned City | laboratory, dragons_lair, underpass |
| the Vault of the Frozen Saint | comm_hub, dragons_lair |
| the Dragons Lair | chapel, drowned_city, frozen_vault |
| the Chapel of Fallen Stars | dragons_lair · **win** |

## Notes
- **Win moved to the Chapel** (was temporarily the Ominous Cave in 2a) — still a temporary `win` flag until 2c swaps in the real ascension altar + the mummylich/dragon.
- Per-level **spawn tables** are themed and tougher deeper (the Drowned City favors mermen; the Dragons Lair & Chapel are scarecrow/slime/ghoul-heavy). Special-AI monsters + bosses come later.
- Sizes stay ~60x24 (fits a terminal; the faithful wide Chapel awaits a viewport).

## Tests
`TestEmbeddedDungeon` now asserts all 10 levels, exactly one start (Dungeon) + one win (Chapel); full content validation (links/spawns resolve) runs on load; `TestNewGameFromShippedData` still boots. `gofmt`/`vet`/`test ./...` green.

Part of #16. Next: 2c (ascension altar + mummylich + dragon).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added implementation plan for completing the dungeon expansion

* **New Features**
  * Expanded dungeon with new levels and updated interconnections
  * Designated Chapel as the winning location

* **Tests**
  * Enhanced validation testing for dungeon structure, level count, and win conditions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->