### PR TITLE
Dungeon endgame 2c (#16): ascension altar + mummylich + dragon

### DIFF
--- a/docs/superpowers/plans/2026-06-08-dungeon-endgame-2c.md
+++ b/docs/superpowers/plans/2026-06-08-dungeon-endgame-2c.md
@@ -1,0 +1,59 @@
+# Dungeon Endgame 2c Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Turn the Chapel into the real ending — an **ascension altar** you step onto to win, guarded by the **elder mummylich**, with the **Dragon** in the Dragons Lair. Completes #16 and delivers the iconic 0.40 finale.
+
+**Architecture:** A tile can be a win tile (`TileDef.win`); stepping onto it wins. A level def gains `altar` (place a win tile) and `boss` (place one guaranteed monster). This **replaces** the temporary `LevelDef.win` (arrival-wins) with reach-the-altar-wins. Fail-fast validation keeps content honest.
+
+**Tech Stack:** Go 1.21 (`GOTOOLCHAIN=local`). Commands run from the `go/` directory at the repo root. TDD, commit per task, suite green between commits.
+
+## Task 1: content — win tile + level altar/boss
+
+**Files:** `internal/content/content.go`, `internal/content/content_test.go`
+
+- `TileDef`: add `Win bool` (toml `win`) — stepping onto it wins.
+- `LevelDef`: **remove** `Win`; add `Altar bool` (toml `altar`) and `Boss string` (toml `boss`).
+- `validateLevels`: if `l.Boss != ""`, require it names a defined monster; if `l.Altar`, require a tile id `altar` exists with `Win == true`.
+
+Tests: a level with `boss` to an unknown monster is rejected; `altar = true` with no win-tile defined is rejected; a valid altar+boss level loads.
+
+Commit: `feat(content): win tile + level altar/boss (replaces arrival-win)`
+
+## Task 2: engine — win on stepping onto a win tile
+
+**Files:** `internal/game/combat.go` (PlayerStep), `internal/game/dungeon.go` (Travel), `internal/game/dungeon_test.go`, `internal/ui/ui_test.go`
+
+- In `PlayerStep`, after a successful `Move`, if the new tile's `Def.Win` is set: set `g.Won`, log `"You ascend to demigodhood. You win!"`, and return (no monster turn).
+- In `Travel`, **remove** the `def.Win` arrival-win block.
+- Update `dungeon_test.go`: drop `TestTravelWinsOnWinLevel` + the `bWins` param; keep move + persistence tests. Add (in the game package) a step-onto-win-tile test.
+- Update `ui_test.go`: `travelGame` no longer sets a win level; rename the win test to assert travel changes the current level (the altar win is covered in the game package).
+
+Commit: `feat(game): win by stepping onto an altar (win) tile`
+
+## Task 3: gen — place boss + altar
+
+**Files:** `internal/gen/gen.go`, `internal/gen/gen_test.go`
+
+- In `LevelFromDef`: if `def.Boss != ""`, place one `c.Monsters[def.Boss]` in a distinct non-start room (full HP). If `def.Altar`, set a distinct room's center to `c.Tiles["altar"]`.
+- Tests: a def with `boss` places exactly one boss of that id; a def with `altar` puts a win tile on the map.
+
+Commit: `feat(gen): place guaranteed boss + ascension altar`
+
+## Task 4: data — altar, bosses, Chapel & Lair
+
+**Files:** `data/tiles.toml`, `data/monsters.toml`, `data/levels.toml`, `data/data_test.go`
+
+- `tiles.toml`: `altar` tile (glyph `_`, cyan, passable, transparent, `win = true`).
+- `monsters.toml`: `elder_mummylich` (glyph `E`, magenta, hp 40, attack 6, dodge 3, damage `1d8`, speed 110) and `dragon` (glyph `D`, red, hp 50, attack 7, dodge 3, damage `1d10`, speed 110).
+- `levels.toml`: Chapel — remove `win = true`, add `altar = true` and `boss = "elder_mummylich"`. Dragons Lair — add `boss = "dragon"`.
+- `data_test.go`: `TestEmbeddedDungeon` — Chapel has `Altar` + boss `elder_mummylich`, no `Win`; Dragons Lair boss `dragon`; the `altar` tile is a win tile.
+
+Commit: `feat(data): ascension altar + elder mummylich + dragon`
+
+## Task 5: verify, push, PR, loop
+
+`gofmt -l . && go vet ./... && go test ./... && go build -o /tmp/tsl ./cmd/tsl`. Commit plan. Push `dungeon-endgame`; PR documents the finale (altar win + bosses), notes balance is tunable (bosses are deadly but the win is reach-the-altar, so beatable without killing them) and that gear breadth (#14) will make the fights fairer. CodeRabbit loop → merge → pull master.
+
+## Done when
+Reaching the Chapel, you face the elder mummylich and can step onto the `_` altar to win with "You ascend to demigodhood." The Dragon guards the Dragons Lair. Suite green; closes #16.

--- a/go/data/data_test.go
+++ b/go/data/data_test.go
@@ -59,19 +59,22 @@ func TestEmbeddedDungeon(t *testing.T) {
 	if len(c.Levels) != len(all) {
 		t.Errorf("level count = %d, want %d", len(c.Levels), len(all))
 	}
-	starts, wins := 0, 0
+	starts := 0
 	for _, l := range c.Levels {
 		if l.Start {
 			starts++
-		}
-		if l.Win {
-			wins++
 		}
 	}
 	if d := c.Levels["dungeon"]; starts != 1 || d == nil || !d.Start {
 		t.Errorf("want exactly one start (the Dungeon), got %d", starts)
 	}
-	if ch := c.Levels["chapel"]; wins != 1 || ch == nil || !ch.Win {
-		t.Errorf("want exactly one win (the Chapel), got %d", wins)
+	if ch := c.Levels["chapel"]; ch == nil || !ch.Altar || ch.Boss != "elder_mummylich" {
+		t.Errorf("Chapel should have the altar + mummylich boss, got %+v", ch)
+	}
+	if dl := c.Levels["dragons_lair"]; dl == nil || dl.Boss != "dragon" {
+		t.Errorf("Dragons Lair should have the dragon boss, got %+v", dl)
+	}
+	if a := c.Tiles["altar"]; a == nil || !a.Win {
+		t.Error("altar tile should be a win tile")
 	}
 }

--- a/go/data/levels.toml
+++ b/go/data/levels.toml
@@ -155,6 +155,7 @@ width = 60
 height = 24
 links = ["chapel", "drowned_city", "frozen_vault"]
 monsters = 14
+boss = "dragon"
 [[level.dragons_lair.spawn]]
 monster = "ghoul"
 weight = 3
@@ -171,7 +172,8 @@ width = 60
 height = 24
 links = ["dragons_lair"]
 monsters = 12
-win = true
+altar = true
+boss = "elder_mummylich"
 [[level.chapel.spawn]]
 monster = "ghoul"
 weight = 3

--- a/go/data/monsters.toml
+++ b/go/data/monsters.toml
@@ -91,3 +91,25 @@ dodge = 0
 damage = "1d4"
 speed = 80
 min_depth = 3
+
+# Bosses (#16 2c). Deadly guardians — but you win by reaching the altar, so you
+# needn't kill them. Stats are tunable; gear breadth (#14) will make this fairer.
+[monster.elder_mummylich]
+name = "elder mummylich"
+glyph = "E"
+color = "magenta"
+hp = 40
+attack = 6
+dodge = 3
+damage = "1d8"
+speed = 110
+
+[monster.dragon]
+name = "dragon"
+glyph = "D"
+color = "red"
+hp = 50
+attack = 7
+dodge = 3
+damage = "1d10"
+speed = 110

--- a/go/data/tiles.toml
+++ b/go/data/tiles.toml
@@ -17,3 +17,11 @@ glyph = ">"
 color = "normal"
 passable = true
 transparent = true
+
+# The ascension altar in the Chapel — stepping onto it wins the game.
+[tile.altar]
+glyph = "_"
+color = "cyan"
+passable = true
+transparent = true
+win = true

--- a/go/internal/content/content.go
+++ b/go/internal/content/content.go
@@ -108,7 +108,6 @@ type LevelDef struct {
 	Links    []string     `toml:"links"` // ids of connected levels
 	Monsters int          `toml:"monsters"`
 	Spawn    []SpawnEntry `toml:"spawn"`
-	Win      bool         `toml:"win"`   // arriving here wins (temporary; removed in 2c)
 	Altar    bool         `toml:"altar"` // place an ascension altar (a win tile)
 	Boss     string       `toml:"boss"`  // a guaranteed monster placed once on the level
 }

--- a/go/internal/content/content.go
+++ b/go/internal/content/content.go
@@ -38,6 +38,7 @@ type TileDef struct {
 	Color       Color  `toml:"color"`
 	Passable    bool   `toml:"passable"`
 	Transparent bool   `toml:"transparent"`
+	Win         bool   `toml:"win"` // stepping onto this tile wins (the ascension altar)
 }
 
 // Rune returns the tile's glyph as a rune. Glyph is guaranteed by validateTile
@@ -107,7 +108,9 @@ type LevelDef struct {
 	Links    []string     `toml:"links"` // ids of connected levels
 	Monsters int          `toml:"monsters"`
 	Spawn    []SpawnEntry `toml:"spawn"`
-	Win      bool         `toml:"win"` // arriving here wins (temporary, pre-2c)
+	Win      bool         `toml:"win"`   // arriving here wins (temporary; removed in 2c)
+	Altar    bool         `toml:"altar"` // place an ascension altar (a win tile)
+	Boss     string       `toml:"boss"`  // a guaranteed monster placed once on the level
 }
 
 // Content is the fully-loaded, validated game content.
@@ -255,6 +258,16 @@ func validateLevels(c *Content) error {
 		}
 		if l.Monsters > 0 && len(l.Spawn) == 0 {
 			return fmt.Errorf("level %q: monsters > 0 but spawn table is empty", id)
+		}
+		if l.Boss != "" {
+			if _, ok := c.Monsters[l.Boss]; !ok {
+				return fmt.Errorf("level %q: boss %q is not a defined monster", id, l.Boss)
+			}
+		}
+		if l.Altar {
+			if t, ok := c.Tiles["altar"]; !ok || !t.Win {
+				return fmt.Errorf("level %q: altar set but no win tile %q is defined", id, "altar")
+			}
 		}
 	}
 	if starts != 1 {

--- a/go/internal/content/content_test.go
+++ b/go/internal/content/content_test.go
@@ -355,3 +355,47 @@ func TestLoadRejectsZeroSpawnWeight(t *testing.T) {
 		t.Fatal("expected error: spawn weight must be >= 1")
 	}
 }
+
+func writeEndgameFixture(t *testing.T, tilesExtra, levelsBody string) string {
+	t.Helper()
+	dir := t.TempDir()
+	w := func(name, body string) {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	w("tiles.toml", "[tile.floor]\nglyph=\".\"\ncolor=\"normal\"\npassable=true\ntransparent=true\n"+tilesExtra)
+	w("monsters.toml", "[monster.ratman]\nname=\"ratman\"\nglyph=\"r\"\ncolor=\"brown\"\nhp=3\nattack=2\ndodge=1\ndamage=\"1d2\"\n")
+	w("levels.toml", levelsBody)
+	return dir
+}
+
+const altarTileTOML = "[tile.altar]\nglyph=\"_\"\ncolor=\"cyan\"\npassable=true\ntransparent=true\nwin=true\n"
+
+func TestLoadAltarBossLevel(t *testing.T) {
+	body := "[level.chapel]\nname=\"Chapel\"\nwidth=60\nheight=24\nstart=true\nlinks=[\"chapel\"]\naltar=true\nboss=\"ratman\"\n"
+	c, err := Load(os.DirFS(writeEndgameFixture(t, altarTileTOML, body)))
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if ch := c.Levels["chapel"]; ch == nil || !ch.Altar || ch.Boss != "ratman" {
+		t.Errorf("unexpected chapel: %+v", ch)
+	}
+	if a := c.Tiles["altar"]; a == nil || !a.Win {
+		t.Error("altar tile should have win=true")
+	}
+}
+
+func TestLoadRejectsUnknownBoss(t *testing.T) {
+	body := "[level.a]\nname=\"A\"\nwidth=60\nheight=24\nstart=true\nlinks=[\"a\"]\nboss=\"dragon\"\n"
+	if _, err := Load(os.DirFS(writeEndgameFixture(t, altarTileTOML, body))); err == nil {
+		t.Fatal("expected error: boss references unknown monster")
+	}
+}
+
+func TestLoadRejectsAltarWithoutWinTile(t *testing.T) {
+	body := "[level.a]\nname=\"A\"\nwidth=60\nheight=24\nstart=true\nlinks=[\"a\"]\naltar=true\n"
+	if _, err := Load(os.DirFS(writeEndgameFixture(t, "", body))); err == nil {
+		t.Fatal("expected error: altar level needs a defined win tile")
+	}
+}

--- a/go/internal/game/combat.go
+++ b/go/internal/game/combat.go
@@ -33,7 +33,7 @@ func (g *Game) log(format string, args ...any) {
 // PlayerStep performs the player's turn: bump-attack a monster in direction d,
 // otherwise move. Then every monster acts.
 func (g *Game) PlayerStep(d Direction) {
-	if g.Dead {
+	if g.Dead || g.Won {
 		return
 	}
 	dx, dy := d.Delta()
@@ -44,6 +44,11 @@ func (g *Game) PlayerStep(d Direction) {
 		acted = true
 	} else if g.Move(d) {
 		acted = true
+		if g.Level.At(g.Player).Def.Win {
+			g.Won = true
+			g.log("You ascend to demigodhood. You win!")
+			return // winning ends the turn immediately
+		}
 	}
 	if acted { // a blocked move into a wall doesn't pass the turn
 		g.monstersAct()

--- a/go/internal/game/combat_test.go
+++ b/go/internal/game/combat_test.go
@@ -101,6 +101,18 @@ func TestKillCreatureDropsCorpse(t *testing.T) {
 	}
 }
 
+func TestPlayerStepOntoAltarWins(t *testing.T) {
+	g := combatGame() // 10x3 floor, player at (1,1)
+	g.Level.Set(Pos{2, 1}, &content.TileDef{ID: "altar", Glyph: "_", Passable: true, Transparent: true, Win: true})
+	g.PlayerStep(DirE)
+	if !g.Won {
+		t.Error("stepping onto a win tile should win")
+	}
+	if g.Player != (Pos{2, 1}) {
+		t.Errorf("player should be on the altar at {2 1}, got %v", g.Player)
+	}
+}
+
 func TestKillCreatureNoCorpse(t *testing.T) {
 	g := combatGame()
 	ghost := &Creature{Def: &content.MonsterDef{ID: "ghost", Name: "ghost"}, Pos: Pos{2, 1}, HP: 1}

--- a/go/internal/game/dungeon.go
+++ b/go/internal/game/dungeon.go
@@ -96,10 +96,6 @@ func (g *Game) Travel() {
 	}
 	def := g.Dungeon.defs[g.Level.ID]
 	g.log("You enter %s.", def.Name)
-	if def.Win {
-		g.Won = true
-		g.log("You ascend to demigodhood. You win!")
-	}
 }
 
 // EnterStart places the player on the current (start) level's entry tile and

--- a/go/internal/game/dungeon_test.go
+++ b/go/internal/game/dungeon_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 // fakeDungeon builds a tiny 2-level graph (a↔b) with a fake builder; each level
-// has one portal (at 3,1) to the other. b is a win level iff bWins.
+// has one portal (at 3,1) to the other.
 func fakeDungeon(t *testing.T) *Game {
 	t.Helper()
 	floor := &content.TileDef{ID: "floor", Glyph: ".", Passable: true, Transparent: true}

--- a/go/internal/game/dungeon_test.go
+++ b/go/internal/game/dungeon_test.go
@@ -8,12 +8,12 @@ import (
 
 // fakeDungeon builds a tiny 2-level graph (a↔b) with a fake builder; each level
 // has one portal (at 3,1) to the other. b is a win level iff bWins.
-func fakeDungeon(t *testing.T, bWins bool) *Game {
+func fakeDungeon(t *testing.T) *Game {
 	t.Helper()
 	floor := &content.TileDef{ID: "floor", Glyph: ".", Passable: true, Transparent: true}
 	defs := map[string]*content.LevelDef{
 		"a": {ID: "a", Name: "Level A", W: 5, H: 3, Start: true, Links: []string{"b"}},
-		"b": {ID: "b", Name: "Level B", W: 5, H: 3, Links: []string{"a"}, Win: bWins},
+		"b": {ID: "b", Name: "Level B", W: 5, H: 3, Links: []string{"a"}},
 	}
 	build := func(def *content.LevelDef) (*Level, error) {
 		l := NewLevel(def.W, def.H, floor)
@@ -32,7 +32,7 @@ func fakeDungeon(t *testing.T, bWins bool) *Game {
 }
 
 func TestTravelMovesToLinkedLevel(t *testing.T) {
-	g := fakeDungeon(t, false)
+	g := fakeDungeon(t)
 	g.Player = Pos{3, 1} // stand on A's portal to B
 	g.Travel()
 	if g.Dungeon.current != "b" {
@@ -43,17 +43,8 @@ func TestTravelMovesToLinkedLevel(t *testing.T) {
 	}
 }
 
-func TestTravelWinsOnWinLevel(t *testing.T) {
-	g := fakeDungeon(t, true)
-	g.Player = Pos{3, 1}
-	g.Travel()
-	if !g.Won {
-		t.Error("arriving at a win level should win")
-	}
-}
-
 func TestTravelPersistsLevelState(t *testing.T) {
-	g := fakeDungeon(t, false)
+	g := fakeDungeon(t)
 	g.Player = Pos{3, 1}
 	g.Travel() // → B
 	b := g.Level

--- a/go/internal/gen/gen.go
+++ b/go/internal/gen/gen.go
@@ -196,6 +196,22 @@ func LevelFromDef(r *rng.MT, c *content.Content, def *content.LevelDef) (*game.L
 		lvl.Set(pos, stairs)
 		lvl.Portals = append(lvl.Portals, game.Portal{Pos: pos, Target: target})
 	}
+	if def.Altar {
+		altar := c.Tiles["altar"]
+		if altar == nil {
+			return nil, fmt.Errorf("gen: level %q has altar but no \"altar\" tile defined", def.ID)
+		}
+		lvl.Set(rooms[len(rooms)-1].center(), altar)
+	}
+	if def.Boss != "" {
+		bdef := c.Monsters[def.Boss]
+		if bdef == nil {
+			return nil, fmt.Errorf("gen: level %q boss %q is not a defined monster", def.ID, def.Boss)
+		}
+		if pos, ok := bossSpot(r, lvl, rooms[len(rooms)-1]); ok {
+			lvl.Creatures = append(lvl.Creatures, &game.Creature{Def: bdef, Pos: pos, HP: bdef.HP})
+		}
+	}
 	placeSpawnMonsters(r, c, lvl, rooms, def)
 	placeItems(r, c, lvl, rooms, lvl.Start)
 	return lvl, nil
@@ -220,6 +236,18 @@ func placeSpawnMonsters(r *rng.MT, c *content.Content, lvl *game.Level, rooms []
 		mdef := c.Monsters[pickSpawn(r, def.Spawn, total)]
 		lvl.Creatures = append(lvl.Creatures, &game.Creature{Def: mdef, Pos: pos, HP: mdef.HP})
 	}
+}
+
+// bossSpot finds a passable tile in room free of the altar and other creatures,
+// for placing a guaranteed boss. Returns false if none is found.
+func bossSpot(r *rng.MT, lvl *game.Level, room rect) (game.Pos, bool) {
+	for try := 0; try < 30; try++ {
+		p := game.Pos{X: room.x + r.Intn(room.w), Y: room.y + r.Intn(room.h)}
+		if lvl.Passable(p) && lvl.At(p).Def.ID != "altar" && lvl.CreatureAt(p) == nil {
+			return p, true
+		}
+	}
+	return game.Pos{}, false
 }
 
 // pickSpawn returns a monster id from the weighted spawn table (total is the sum

--- a/go/internal/gen/gen_test.go
+++ b/go/internal/gen/gen_test.go
@@ -188,6 +188,38 @@ func TestLevelFromDefSpawnsOnlyFromTable(t *testing.T) {
 	}
 }
 
+func TestLevelFromDefPlacesBossAndAltar(t *testing.T) {
+	c := levelDefContent()
+	c.Monsters["mummylich"] = &content.MonsterDef{ID: "mummylich", Name: "elder mummylich", Glyph: "E", Color: content.ColorMagenta, HP: 40, Attack: 6, Dodge: 3, Damage: "1d8"}
+	c.Tiles["altar"] = &content.TileDef{ID: "altar", Glyph: "_", Color: content.ColorCyan, Passable: true, Transparent: true, Win: true}
+	def := &content.LevelDef{ID: "chapel", Name: "Chapel", W: 60, H: 24, Links: []string{"x"}, Altar: true, Boss: "mummylich"}
+	lvl, err := LevelFromDef(rng.NewWithSeed(1), c, def)
+	if err != nil {
+		t.Fatal(err)
+	}
+	bosses := 0
+	for _, m := range lvl.Creatures {
+		if m.Def.ID == "mummylich" {
+			bosses++
+		}
+	}
+	if bosses != 1 {
+		t.Errorf("want exactly 1 boss, got %d", bosses)
+	}
+	found := false
+	for y := 0; y < lvl.H && !found; y++ {
+		for x := 0; x < lvl.W; x++ {
+			if lvl.At(game.Pos{X: x, Y: y}).Def.Win {
+				found = true
+				break
+			}
+		}
+	}
+	if !found {
+		t.Error("expected an altar (win) tile on the level")
+	}
+}
+
 func TestLevelFromDefDeterministic(t *testing.T) {
 	c := levelDefContent()
 	def := &content.LevelDef{ID: "x", Name: "X", W: 60, H: 24, Links: []string{"y"}, Monsters: 5, Spawn: []content.SpawnEntry{{Monster: "ratman", Weight: 1}}}

--- a/go/internal/ui/ui_test.go
+++ b/go/internal/ui/ui_test.go
@@ -184,7 +184,7 @@ func travelGame(t *testing.T) *game.Game {
 	floor := &content.TileDef{ID: "floor", Glyph: ".", Color: content.ColorNormal, Passable: true, Transparent: true}
 	defs := map[string]*content.LevelDef{
 		"start": {ID: "start", Name: "the Start", W: 5, H: 3, Start: true, Links: []string{"end"}},
-		"end":   {ID: "end", Name: "the End", W: 5, H: 3, Links: []string{"start"}, Win: true},
+		"end":   {ID: "end", Name: "the End", W: 5, H: 3, Links: []string{"start"}},
 	}
 	build := func(def *content.LevelDef) (*game.Level, error) {
 		l := game.NewLevel(def.W, def.H, floor)
@@ -201,15 +201,15 @@ func travelGame(t *testing.T) *game.Game {
 	return g
 }
 
-func TestRunTravelToWin(t *testing.T) {
+func TestRunTravelChangesLevel(t *testing.T) {
 	g := travelGame(t)
-	g.Player = game.Pos{X: 3, Y: 1} // on the start portal to the win level
-	p := &scriptPrompter{actions: []Action{{Kind: ActTravel}}}
+	g.Player = game.Pos{X: 3, Y: 1} // on the start portal
+	p := &scriptPrompter{actions: []Action{{Kind: ActTravel}, {Kind: ActQuit}}}
 	if err := Run(g, p, &nullRenderer{}); err != nil {
 		t.Fatal(err)
 	}
-	if !g.Won {
-		t.Error("traveling to the win level should win and end the loop")
+	if g.LocationName() != "the End" {
+		t.Errorf("after travel, location = %q, want the End", g.LocationName())
 	}
 }
 


### PR DESCRIPTION
The finale — turns the Chapel into a real ending and **closes #16**.

## What
- **Ascension altar**: a new `altar` tile (`_`, `win = true`). Step onto it → *"You ascend to demigodhood. You win!"* (`PlayerStep` checks the destination tile). This **replaces** the temporary "arriving at the Chapel wins" (`LevelDef.win` is retired).
- **Bosses**: `LevelDef.boss` places one guaranteed monster per level. The **elder mummylich** (`E`, 40 HP) guards the Chapel; the **Dragon** (`D`, 50 HP) guards the Dragons Lair. `LevelDef.altar` places the altar tile (in the Chapel).
- **Fail-fast validation**: a `boss` must name a defined monster; an `altar` level requires the `altar` win tile to exist.

## Gameplay
Travel down to the Chapel, face the mummylich, and reach the `_` altar to ascend. You **don't** have to kill the bosses — the win is reaching the altar — so it's beatable even before gear breadth (#14) makes the fights fair. Boss stats are deliberately tough but tunable.

## Tests
content (altar win tile, boss-ref + altar validation), game (stepping onto a win tile wins), gen (places exactly one boss + an altar tile), data golden (Chapel altar+mummylich, Lair dragon, altar is a win tile), and `TestNewGameFromShippedData` boots the full game. `gofmt`/`vet`/`test ./...` green.

Done atomically: `LevelDef.win` removal + Travel/test/data fixups in one green commit.

**Closes #16.** Next on the dungeon: nicer level themes/sizes (a viewport for the wide Chapel) and the special-AI monsters — but the faithful structure + endgame are complete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Altar-based victory: stepping on the Chapel altar now wins the game.
  * Chapel now contains an altar and a guaranteed boss (Elder Mummylich); Dragons Lair includes Dragon as a boss.
* **Behavior**
  * Win triggers on altar interaction; traveling to a level no longer auto-triggers a win.
* **Tests**
  * Updated and added tests validating altar loading, boss placement, and player-win on altar.
* **Documentation**
  * Added endgame plan and content validation guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->