### PR TITLE
Gear breadth 14a (#14): melee weapons + body armor

### DIFF
--- a/docs/superpowers/plans/2026-06-08-gear-breadth-14a.md
+++ b/docs/superpowers/plans/2026-06-08-gear-breadth-14a.md
@@ -1,0 +1,25 @@
+# Gear Breadth 14a Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add a real weapon + body-armor table so the dagger isn't the only option (and the bosses become beatable). First slice of #14 — **pure data**; the engine already equips weapons/armor and uses their stats in combat.
+
+**Tech Stack:** Go 1.21 (`GOTOOLCHAIN=local`). Commands run from the `go/` directory at the repo root. TDD: golden test first, then data.
+
+## Scope
+- Melee weapons (kind `weapon`, `attack` bonus + `damage` dice): machete (1d6), quarterstaff (1d6), cleaver (1d8), crystal sword (2d4), doomblade (2d6). The dagger (1d4) stays the weak baseline.
+- Body armors (kind `armor`, `dodge` bonus): filthy rags (1), fish-scale (3), chainmail (4), rune armor (5). Leather (2) stays.
+- These spawn as floor loot and equip through the existing inventory flow (`g` to pick up, `i` → select → equip). No engine changes.
+- **Out of scope (later 14 increments):** equip slots beyond body (feet/head/cloak), autoequip-on-pickup, ranged weapons + ammo.
+
+## Task 1: golden test (failing first)
+**File:** `data/data_test.go` — add `TestEmbeddedGear`: assert e.g. `crystal_sword` (kind weapon, attack 4, damage `2d4`) and `chainmail` (kind armor, dodge 4) load from the shipped content. Run: expect FAIL.
+
+## Task 2: data
+**File:** `data/items.toml` — add the weapons + armors above. Run `go test ./data/ ./internal/content/ ./cmd/...` — expect PASS (content validation: weapon damage specs are well-formed).
+
+## Task 3: verify, push, PR, loop
+`gofmt -l . && go vet ./... && go test ./... && go build -o /tmp/tsl ./cmd/tsl`. Commit plan + data. Push `gear-breadth`; PR notes this is the data slice of #14 (slots/autoequip/ranged follow). CodeRabbit loop → merge → pull master.
+
+## Done when
+The dungeon scatters a variety of weapons/armor; equipping a crystal sword + chainmail makes the mummylich winnable. Suite green.

--- a/go/data/data_test.go
+++ b/go/data/data_test.go
@@ -43,6 +43,20 @@ func TestDepthGatedTanks(t *testing.T) {
 	}
 }
 
+// TestEmbeddedGear checks the shipped weapon/armor table loaded.
+func TestEmbeddedGear(t *testing.T) {
+	c, err := content.Load(Files)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if w := c.Items["crystal_sword"]; w == nil || w.Kind != "weapon" || w.Attack != 4 || w.Damage != "2d4" {
+		t.Errorf("crystal_sword def unexpected: %+v", w)
+	}
+	if a := c.Items["chainmail"]; a == nil || a.Kind != "armor" || a.Dodge != 4 {
+		t.Errorf("chainmail def unexpected: %+v", a)
+	}
+}
+
 // TestEmbeddedDungeon validates the shipped level graph loads with exactly one
 // start and the expected starter levels.
 func TestEmbeddedDungeon(t *testing.T) {

--- a/go/data/items.toml
+++ b/go/data/items.toml
@@ -22,6 +22,76 @@ color = "brown"
 kind = "armor"
 dodge = 2
 
+# Melee weapons (better than the starting dagger; found as floor loot).
+[item.machete]
+name = "machete"
+glyph = ")"
+color = "normal"
+kind = "weapon"
+attack = 3
+damage = "1d6"
+
+[item.quarterstaff]
+name = "quarterstaff"
+glyph = "/"
+color = "brown"
+kind = "weapon"
+attack = 2
+damage = "1d6"
+
+[item.cleaver]
+name = "cleaver"
+glyph = ")"
+color = "normal"
+kind = "weapon"
+attack = 3
+damage = "1d8"
+
+[item.crystal_sword]
+name = "crystal sword"
+glyph = ")"
+color = "cyan"
+kind = "weapon"
+attack = 4
+damage = "2d4"
+
+[item.doomblade]
+name = "doomblade"
+glyph = ")"
+color = "red"
+kind = "weapon"
+attack = 5
+damage = "2d6"
+
+# Body armor (dodge bonus).
+[item.filthy_rags]
+name = "filthy rags"
+glyph = "["
+color = "brown"
+kind = "armor"
+dodge = 1
+
+[item.fish_scale_armor]
+name = "fish-scale armor"
+glyph = "["
+color = "green"
+kind = "armor"
+dodge = 3
+
+[item.chainmail]
+name = "chainmail"
+glyph = "["
+color = "normal"
+kind = "armor"
+dodge = 4
+
+[item.rune_armor]
+name = "rune armor"
+glyph = "["
+color = "magenta"
+kind = "armor"
+dodge = 5
+
 # Food. Eaten with `e` to restore HP. Corpses are nospawn (drops only).
 [item.ration]
 name = "ration"


### PR DESCRIPTION
First slice of #14 — **pure data**. The engine already equips weapons/armor and uses their stats in combat, so this just fills out the table.

## What
- **Weapons** (`attack` + `damage`): machete (1d6), quarterstaff (1d6), cleaver (1d8), crystal sword (2d4), doomblade (2d6). The dagger (1d4) stays the weak baseline.
- **Body armor** (`dodge`): filthy rags (1), fish-scale (3), chainmail (4), rune armor (5). Leather (2) stays.
- They scatter as floor loot and equip through the existing flow (`g` to grab, `i` → select → equip).

## Why
The bosses (mummylich, dragon) were brutal because the dagger was the only weapon. Now a crystal sword + chainmail makes the Chapel winnable.

## Scope
Out of scope for later 14 increments: equip **slots** beyond body (feet/head/cloak), autoequip-on-pickup, and ranged weapons + ammo.

## Tests
`TestEmbeddedGear` pins crystal_sword (weapon, 2d4) + chainmail (armor, dodge 4); content validation checks the weapon damage specs; `TestNewGameFromShippedData` still boots. `gofmt`/`vet`/`test ./...` green.

Part of #14.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added five new melee weapons (crystal sword, doomblade, machete, quarterstaff, cleaver) with combat attributes.
  * Added four new armor pieces (chainmail, fish scale armor, rune armor, filthy rags) with defensive properties.

* **Tests**
  * Added test validating equipment definitions and combat stats.

* **Documentation**
  * Added implementation plan for gear expansion initiative.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->