### PR TITLE
Player loadout (#14): autoequip on pickup + starting kit

### DIFF
--- a/go/cmd/tsl/main.go
+++ b/go/cmd/tsl/main.go
@@ -92,12 +92,12 @@ func newGame(c *content.Content, seed uint32) (*game.Game, error) {
 // equipStartingKit gives the player a basic dagger + leather armor, equipped, so
 // the early game is playable before better gear is found.
 func equipStartingKit(g *game.Game, c *content.Content) {
-	if d := c.Items["dagger"]; d != nil {
+	if d := c.Items["dagger"]; d != nil && d.Kind == "weapon" {
 		it := &game.Item{Def: d}
 		g.Inventory = append(g.Inventory, it)
 		g.Weapon = it
 	}
-	if a := c.Items["leather_armor"]; a != nil {
+	if a := c.Items["leather_armor"]; a != nil && a.Kind == "armor" {
 		it := &game.Item{Def: a}
 		g.Inventory = append(g.Inventory, it)
 		g.Armor = it

--- a/go/cmd/tsl/main.go
+++ b/go/cmd/tsl/main.go
@@ -85,7 +85,23 @@ func newGame(c *content.Content, seed uint32) (*game.Game, error) {
 		Behaviors: behaviors.Registry(),
 	}
 	g.EnterStart()
+	equipStartingKit(g, c)
 	return g, nil
+}
+
+// equipStartingKit gives the player a basic dagger + leather armor, equipped, so
+// the early game is playable before better gear is found.
+func equipStartingKit(g *game.Game, c *content.Content) {
+	if d := c.Items["dagger"]; d != nil {
+		it := &game.Item{Def: d}
+		g.Inventory = append(g.Inventory, it)
+		g.Weapon = it
+	}
+	if a := c.Items["leather_armor"]; a != nil {
+		it := &game.Item{Def: a}
+		g.Inventory = append(g.Inventory, it)
+		g.Armor = it
+	}
 }
 
 // startLevelID returns the id of the single level flagged start.

--- a/go/cmd/tsl/main_test.go
+++ b/go/cmd/tsl/main_test.go
@@ -100,6 +100,9 @@ func TestNewGameFromShippedData(t *testing.T) {
 	if !g.Level.Passable(g.Player) {
 		t.Errorf("player start %v not passable", g.Player)
 	}
+	if g.Weapon == nil || g.Armor == nil {
+		t.Error("player should start with a dagger + leather armor equipped")
+	}
 }
 
 func TestNewGameStartsOnStartLevel(t *testing.T) {

--- a/go/internal/game/use.go
+++ b/go/internal/game/use.go
@@ -13,7 +13,25 @@ func (g *Game) PlayerPickup() {
 	g.Level.RemoveItem(it)
 	g.Inventory = append(g.Inventory, it)
 	g.log("You pick up the %s.", it.Def.Name)
+	g.autoEquip(it)
 	g.monstersAct()
+}
+
+// autoEquip wields/wears a just-picked-up weapon or armor when its slot is empty
+// (the faithful 0.40 default; it never auto-downgrades an equipped item).
+func (g *Game) autoEquip(it *Item) {
+	switch it.Def.Kind {
+	case "weapon":
+		if g.Weapon == nil {
+			g.Weapon = it
+			g.log("You wield the %s.", it.Def.Name)
+		}
+	case "armor":
+		if g.Armor == nil {
+			g.Armor = it
+			g.log("You wear the %s.", it.Def.Name)
+		}
+	}
 }
 
 // PlayerUse equips a weapon/armor or invokes a consumable's behavior, then

--- a/go/internal/game/use_test.go
+++ b/go/internal/game/use_test.go
@@ -100,3 +100,23 @@ func TestEdibleInventoryFiltersFood(t *testing.T) {
 		t.Errorf("EdibleInventory = %v, want [ration]", food)
 	}
 }
+
+func TestPickupAutoEquipsWhenSlotEmpty(t *testing.T) {
+	g := useGame()
+	sword := &Item{Def: &content.ItemDef{ID: "sword", Name: "sword", Kind: "weapon", Attack: 4, Damage: "2d4"}, Pos: g.Player}
+	g.Level.Items = append(g.Level.Items, sword)
+	g.PlayerPickup()
+	if g.Weapon != sword {
+		t.Fatal("first weapon should auto-equip when the slot is empty")
+	}
+	// a second weapon must NOT auto-replace the equipped one
+	dagger := &Item{Def: &content.ItemDef{ID: "dagger", Name: "dagger", Kind: "weapon", Attack: 2, Damage: "1d4"}, Pos: g.Player}
+	g.Level.Items = append(g.Level.Items, dagger)
+	g.PlayerPickup()
+	if g.Weapon != sword {
+		t.Error("second weapon should not auto-replace the equipped one")
+	}
+	if len(g.Inventory) != 2 {
+		t.Errorf("both weapons should be carried, inventory = %d", len(g.Inventory))
+	}
+}

--- a/go/internal/game/use_test.go
+++ b/go/internal/game/use_test.go
@@ -119,4 +119,11 @@ func TestPickupAutoEquipsWhenSlotEmpty(t *testing.T) {
 	if len(g.Inventory) != 2 {
 		t.Errorf("both weapons should be carried, inventory = %d", len(g.Inventory))
 	}
+	// armor auto-equips into the empty armor slot
+	mail := &Item{Def: &content.ItemDef{ID: "chainmail", Name: "chainmail", Kind: "armor", Dodge: 4}, Pos: g.Player}
+	g.Level.Items = append(g.Level.Items, mail)
+	g.PlayerPickup()
+	if g.Armor != mail {
+		t.Error("armor should auto-equip when the slot is empty")
+	}
 }


### PR DESCRIPTION
A small, faithful #14 slice that makes equipment actually flow.

## What
- **Starting kit**: the player now begins with a **dagger + leather armor equipped** (built in `newGame` from content), so the early game is playable instead of bare-handed.
- **Autoequip on pickup**: picking up a weapon/armor whose slot is empty wields/wears it automatically — the faithful 0.40 default. It never auto-**downgrades** an equipped item (a second weapon just goes to the pack), so you keep your best gear.

## Tests
game: first weapon auto-equips when the slot is empty; a second one does not replace it (both carried). cmd: `TestNewGameFromShippedData` now asserts the player starts armed + armored. `gofmt`/`vet`/`test ./...` green.

## Scope
Still ahead in #14: equip **slots** beyond body (feet/head/cloak), a `noautoequip` toggle (needs a config system), and ranged weapons + ammo.

Part of #14.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Players now spawn with starter equipment (dagger and leather armor).
  * Weapons and armor auto-equip when picked up if the corresponding slot is empty.

* **Tests**
  * Added tests verifying spawn equipment and pickup auto-equip behavior for weapon and armor slots.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->