### PR TITLE
Status effects 15a (#15): the effect system + poison & regen

### DIFF
--- a/docs/superpowers/plans/2026-06-08-status-effects-15a.md
+++ b/docs/superpowers/plans/2026-06-08-status-effects-15a.md
@@ -1,0 +1,44 @@
+# Status Effects 15a Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** The status-effect system — the keystone for #15 (potions/scrolls) and #18 (traps/poison). First slice: the framework + **poison** and **regeneration**, plus the red **mushroom** (heal + poison, completing the #12 eat mechanic) and a **regeneration potion**.
+
+## Design
+- `Effect{Kind string, Turns int}` on the player: `Game.Effects []Effect`. (Player-only for now; monster-targeted effects arrive with wands/targeting in a later increment.)
+- `AddEffect(kind, turns)` — adds, or refreshes to the longer duration if already active.
+- `tickEffects()` — runs once per player action (hooked at the top of `monstersAct`): `poison` does −1 HP/turn (can kill, cause "poison"); `regen` does +1 HP/turn (clamped to max); each effect's `Turns` decrements and expires at 0. If poison kills, the world doesn't act further that turn.
+- `EffectsSummary()` → e.g. "Poisoned, Regenerating" for the HUD.
+- Consumables apply effects via behaviors: `regenerate` (potion) and `eat_mushroom` (food: heal + poison).
+
+**Scope note:** later 15 increments add blindness (FOV) + sleep + the bad-potion line; wands + **interactive targeting**; scrolls + spellbooks. Speed/haste (scheduler-coupled) is its own slice.
+
+## Task 1: engine — effects framework
+**Files:** `internal/game/effects.go` (new), `internal/game/game.go` (add `Effects []Effect`), `internal/game/combat.go` (hook), `internal/game/effects_test.go` (new)
+- `Effect`, `Game.Effects`, `AddEffect`, `tickEffects`, `EffectsSummary`. Call `g.tickEffects()` at the top of `monstersAct`; if `g.Dead` after it, return.
+- Tests: poison damages each turn and can kill (cause "poison"); regen heals + clamps + expires after its turns; `AddEffect` refreshes to the longer duration.
+- Commit: `feat(game): status-effect framework (poison, regen)`
+
+## Task 2: behaviors — regenerate + eat_mushroom
+**Files:** `internal/behaviors/behaviors.go`, `internal/behaviors/behaviors_test.go`
+- `regenerate`: `AddEffect("regen", it.Def.Power)`. `eat_mushroom`: `restoreHP` then `AddEffect("poison", 6)`. Register both.
+- Tests: regenerate adds a regen effect; eat_mushroom heals and adds poison.
+- Commit: `feat(behaviors): regenerate + eat_mushroom (apply effects)`
+
+## Task 3: ui — HUD shows active effects
+**Files:** `internal/ui/ui.go` (statusLine), `internal/ui/ui_test.go`
+- Append `[Poisoned, …]` to the status line when `EffectsSummary()` is non-empty.
+- Test: a poisoned game shows "Poisoned" in the status.
+- Commit: `feat(ui): show active status effects in the HUD`
+
+## Task 4: data — mushroom + regen potion
+**Files:** `data/items.toml`, `data/data_test.go`
+- `red_mushroom` (food, use `eat_mushroom`, power 4, glyph `%`, red) and `potion_regeneration` (potion, use `regenerate`, power 8, glyph `!`, green).
+- Golden test asserts both load.
+- Commit: `feat(data): red mushroom (heal+poison) + regeneration potion`
+
+## Task 5: verify, push, PR, loop
+`gofmt -l . && go vet ./... && go test ./... && go build -o /tmp/tsl ./cmd/tsl`. Commit plan. Push `status-effects`; PR documents the framework + that blindness/sleep/wands/scrolls follow. CodeRabbit loop → merge → pull master.
+
+## Done when
+Eating the red mushroom heals you but poisons you (HP drains for a few turns, shown in the HUD); a regeneration potion heals you over time. Suite green.

--- a/go/data/data_test.go
+++ b/go/data/data_test.go
@@ -57,6 +57,20 @@ func TestEmbeddedGear(t *testing.T) {
 	}
 }
 
+// TestEmbeddedConsumables checks the status-effect consumables loaded.
+func TestEmbeddedConsumables(t *testing.T) {
+	c, err := content.Load(Files)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if m := c.Items["red_mushroom"]; m == nil || m.Kind != "food" || m.Use != "eat_mushroom" {
+		t.Errorf("red_mushroom def unexpected: %+v", m)
+	}
+	if p := c.Items["potion_regeneration"]; p == nil || p.Kind != "potion" || p.Use != "regenerate" {
+		t.Errorf("potion_regeneration def unexpected: %+v", p)
+	}
+}
+
 // TestEmbeddedDungeon validates the shipped level graph loads with exactly one
 // start and the expected starter levels.
 func TestEmbeddedDungeon(t *testing.T) {

--- a/go/data/items.toml
+++ b/go/data/items.toml
@@ -137,3 +137,20 @@ kind = "food"
 use = "eat"
 power = 1
 nospawn = true
+
+# Status-effect consumables (#15).
+[item.potion_regeneration]
+name = "potion of regeneration"
+glyph = "!"
+color = "green"
+kind = "potion"
+use = "regenerate"
+power = 8
+
+[item.red_mushroom]
+name = "red mushroom"
+glyph = "%"
+color = "red"
+kind = "food"
+use = "eat_mushroom"
+power = 4

--- a/go/internal/behaviors/behaviors.go
+++ b/go/internal/behaviors/behaviors.go
@@ -12,8 +12,10 @@ import (
 // Registry returns the name→behavior map referenced by item `use` fields.
 func Registry() map[string]game.Behavior {
 	return map[string]game.Behavior{
-		"heal": heal,
-		"eat":  eat,
+		"heal":         heal,
+		"eat":          eat,
+		"regenerate":   regenerate,
+		"eat_mushroom": eatMushroom,
 	}
 }
 
@@ -39,4 +41,17 @@ func eat(g *game.Game, it *game.Item) []string {
 		return []string{fmt.Sprintf("You eat the %s and recover %d HP.", it.Def.Name, recovered)}
 	}
 	return []string{fmt.Sprintf("You eat the %s.", it.Def.Name)}
+}
+
+// regenerate grants healing-over-time for Power turns.
+func regenerate(g *game.Game, it *game.Item) []string {
+	g.AddEffect("regen", it.Def.Power)
+	return []string{fmt.Sprintf("You quaff the %s; your wounds begin to close.", it.Def.Name)}
+}
+
+// eatMushroom heals by Power but poisons the eater (the faithful red mushroom).
+func eatMushroom(g *game.Game, it *game.Item) []string {
+	recovered := restoreHP(g, it.Def.Power)
+	g.AddEffect("poison", 6)
+	return []string{fmt.Sprintf("You eat the %s and recover %d HP, but you feel ill.", it.Def.Name, recovered)}
 }

--- a/go/internal/behaviors/behaviors_test.go
+++ b/go/internal/behaviors/behaviors_test.go
@@ -40,3 +40,36 @@ func TestEatRestoresHPClamped(t *testing.T) {
 		t.Error("expected an eat message")
 	}
 }
+
+func TestRegenerateAddsEffect(t *testing.T) {
+	regen, ok := Registry()["regenerate"]
+	if !ok {
+		t.Fatal("regenerate behavior not registered")
+	}
+	g := &game.Game{PlayerHP: 10, PlayerMax: 20}
+	regen(g, &game.Item{Def: &content.ItemDef{Name: "potion of regeneration", Power: 8}})
+	if len(g.Effects) != 1 || g.Effects[0].Kind != "regen" || g.Effects[0].Turns != 8 {
+		t.Errorf("expected a regen effect for 8 turns, got %v", g.Effects)
+	}
+}
+
+func TestEatMushroomHealsAndPoisons(t *testing.T) {
+	eat, ok := Registry()["eat_mushroom"]
+	if !ok {
+		t.Fatal("eat_mushroom behavior not registered")
+	}
+	g := &game.Game{PlayerHP: 10, PlayerMax: 20}
+	eat(g, &game.Item{Def: &content.ItemDef{Name: "red mushroom", Power: 4}})
+	if g.PlayerHP != 14 {
+		t.Errorf("HP = %d, want 14 (healed 4)", g.PlayerHP)
+	}
+	poisoned := false
+	for _, e := range g.Effects {
+		if e.Kind == "poison" {
+			poisoned = true
+		}
+	}
+	if !poisoned {
+		t.Error("eating the red mushroom should poison the player")
+	}
+}

--- a/go/internal/game/combat.go
+++ b/go/internal/game/combat.go
@@ -123,6 +123,10 @@ func (g *Game) monsterAttacks(m *Creature) {
 // holds, so faster monsters act more often (the C's move_counter / TURN_TIME
 // model). Leftover energy carries to the next turn.
 func (g *Game) monstersAct() {
+	g.tickEffects()
+	if g.Dead {
+		return // status effects (e.g. poison) killed the player
+	}
 	// snapshot to avoid mutation surprises when creatures are removed
 	snapshot := make([]*Creature, len(g.Level.Creatures))
 	copy(snapshot, g.Level.Creatures)

--- a/go/internal/game/effects.go
+++ b/go/internal/game/effects.go
@@ -1,0 +1,76 @@
+package game
+
+import "strings"
+
+// Effect is a timed status effect on the player.
+type Effect struct {
+	Kind  string
+	Turns int
+}
+
+// effectLabels maps effect kinds to their HUD labels.
+var effectLabels = map[string]string{
+	"poison": "Poisoned",
+	"regen":  "Regenerating",
+}
+
+// AddEffect applies a status effect for the given number of turns, refreshing an
+// already-active effect of the same kind to the longer duration.
+func (g *Game) AddEffect(kind string, turns int) {
+	for i := range g.Effects {
+		if g.Effects[i].Kind == kind {
+			if turns > g.Effects[i].Turns {
+				g.Effects[i].Turns = turns
+			}
+			return
+		}
+	}
+	g.Effects = append(g.Effects, Effect{Kind: kind, Turns: turns})
+}
+
+// tickEffects applies each active effect's per-turn outcome, then decrements and
+// expires them. Called once per player action (from monstersAct).
+func (g *Game) tickEffects() {
+	if len(g.Effects) == 0 {
+		return
+	}
+	kept := g.Effects[:0]
+	for _, e := range g.Effects {
+		switch e.Kind {
+		case "poison":
+			g.PlayerHP--
+			if g.PlayerHP <= 0 && !g.Dead {
+				g.PlayerHP = 0
+				g.Dead = true
+				g.DeathCause = "poison"
+				g.log("The poison overcomes you. You die.")
+			}
+		case "regen":
+			if g.PlayerHP < g.PlayerMax {
+				g.PlayerHP++
+			}
+		}
+		e.Turns--
+		if e.Turns > 0 {
+			kept = append(kept, e)
+		}
+	}
+	g.Effects = kept
+}
+
+// EffectsSummary is a comma-separated list of active effect labels for the HUD,
+// or "" when there are none.
+func (g *Game) EffectsSummary() string {
+	if len(g.Effects) == 0 {
+		return ""
+	}
+	labels := make([]string, 0, len(g.Effects))
+	for _, e := range g.Effects {
+		if l := effectLabels[e.Kind]; l != "" {
+			labels = append(labels, l)
+		} else {
+			labels = append(labels, e.Kind)
+		}
+	}
+	return strings.Join(labels, ", ")
+}

--- a/go/internal/game/effects.go
+++ b/go/internal/game/effects.go
@@ -17,6 +17,9 @@ var effectLabels = map[string]string{
 // AddEffect applies a status effect for the given number of turns, refreshing an
 // already-active effect of the same kind to the longer duration.
 func (g *Game) AddEffect(kind string, turns int) {
+	if kind == "" || turns <= 0 {
+		return
+	}
 	for i := range g.Effects {
 		if g.Effects[i].Kind == kind {
 			if turns > g.Effects[i].Turns {
@@ -39,12 +42,6 @@ func (g *Game) tickEffects() {
 		switch e.Kind {
 		case "poison":
 			g.PlayerHP--
-			if g.PlayerHP <= 0 && !g.Dead {
-				g.PlayerHP = 0
-				g.Dead = true
-				g.DeathCause = "poison"
-				g.log("The poison overcomes you. You die.")
-			}
 		case "regen":
 			if g.PlayerHP < g.PlayerMax {
 				g.PlayerHP++
@@ -56,6 +53,14 @@ func (g *Game) tickEffects() {
 		}
 	}
 	g.Effects = kept
+	// Resolve death once, after the net HP change of this turn, so a regen can
+	// offset poison instead of leaving Dead set while HP is still positive.
+	if g.PlayerHP <= 0 && !g.Dead {
+		g.PlayerHP = 0
+		g.Dead = true
+		g.DeathCause = "poison"
+		g.log("The poison overcomes you. You die.")
+	}
 }
 
 // EffectsSummary is a comma-separated list of active effect labels for the HUD,

--- a/go/internal/game/effects_test.go
+++ b/go/internal/game/effects_test.go
@@ -52,3 +52,25 @@ func TestEffectsSummary(t *testing.T) {
 		t.Errorf("summary = %q, want \"Poisoned, Regenerating\"", got)
 	}
 }
+
+// Poison + regen must net out cleanly and never leave Dead set with HP > 0
+// (order-independent death resolution).
+func TestPoisonAndRegenNetOut(t *testing.T) {
+	g := &Game{PlayerHP: 1, PlayerMax: 20}
+	g.AddEffect("poison", 3)
+	g.AddEffect("regen", 3)
+	g.tickEffects() // -1 +1 = net 0
+	if g.Dead || g.PlayerHP != 1 {
+		t.Errorf("expected alive at HP 1, got dead=%v hp=%d", g.Dead, g.PlayerHP)
+	}
+}
+
+func TestAddEffectRejectsBadInput(t *testing.T) {
+	g := &Game{PlayerHP: 10, PlayerMax: 10}
+	g.AddEffect("", 5)        // empty kind
+	g.AddEffect("poison", 0)  // non-positive duration
+	g.AddEffect("poison", -3) // negative duration
+	if len(g.Effects) != 0 {
+		t.Errorf("bad inputs should add no effects, got %v", g.Effects)
+	}
+}

--- a/go/internal/game/effects_test.go
+++ b/go/internal/game/effects_test.go
@@ -1,0 +1,54 @@
+package game
+
+import "testing"
+
+func TestPoisonDamagesAndKills(t *testing.T) {
+	g := &Game{PlayerHP: 3, PlayerMax: 20}
+	g.AddEffect("poison", 5)
+	g.tickEffects() // 3 -> 2
+	if g.PlayerHP != 2 {
+		t.Errorf("HP = %d, want 2 after one poison tick", g.PlayerHP)
+	}
+	for i := 0; i < 5 && !g.Dead; i++ {
+		g.tickEffects()
+	}
+	if !g.Dead || g.DeathCause != "poison" {
+		t.Errorf("poison should kill (dead=%v cause=%q)", g.Dead, g.DeathCause)
+	}
+}
+
+func TestRegenHealsClampsExpires(t *testing.T) {
+	g := &Game{PlayerHP: 18, PlayerMax: 20}
+	g.AddEffect("regen", 3)
+	g.tickEffects() // 18 -> 19
+	g.tickEffects() // 19 -> 20
+	g.tickEffects() // clamp at 20; effect expires
+	if g.PlayerHP != 20 {
+		t.Errorf("HP = %d, want 20 (clamped)", g.PlayerHP)
+	}
+	if len(g.Effects) != 0 {
+		t.Errorf("regen should have expired, effects = %v", g.Effects)
+	}
+}
+
+func TestAddEffectRefreshesToLonger(t *testing.T) {
+	g := &Game{PlayerHP: 10, PlayerMax: 10}
+	g.AddEffect("poison", 3)
+	g.AddEffect("poison", 6) // refresh to the longer duration
+	if len(g.Effects) != 1 || g.Effects[0].Turns != 6 {
+		t.Errorf("expected one poison effect with 6 turns, got %v", g.Effects)
+	}
+	g.AddEffect("poison", 2) // shorter — no change
+	if g.Effects[0].Turns != 6 {
+		t.Errorf("shorter refresh should not shorten, got %d", g.Effects[0].Turns)
+	}
+}
+
+func TestEffectsSummary(t *testing.T) {
+	g := &Game{PlayerHP: 10, PlayerMax: 10}
+	g.AddEffect("poison", 3)
+	g.AddEffect("regen", 3)
+	if got := g.EffectsSummary(); got != "Poisoned, Regenerating" {
+		t.Errorf("summary = %q, want \"Poisoned, Regenerating\"", got)
+	}
+}

--- a/go/internal/game/game.go
+++ b/go/internal/game/game.go
@@ -103,6 +103,7 @@ type Game struct {
 	Behaviors  map[string]Behavior
 	Won        bool
 	DeathCause string
+	Effects    []Effect
 }
 
 // Move attempts to move the player one step in d. It returns true if the player

--- a/go/internal/ui/ui.go
+++ b/go/internal/ui/ui.go
@@ -120,8 +120,12 @@ func statusLine(g *game.Game) string {
 	if loc == "" {
 		loc = "the dungeon"
 	}
-	return fmt.Sprintf("HP %d/%d   %s   Wield: %s   Wear: %s",
+	s := fmt.Sprintf("HP %d/%d   %s   Wield: %s   Wear: %s",
 		g.PlayerHP, g.PlayerMax, loc, wield, wear)
+	if eff := g.EffectsSummary(); eff != "" {
+		s += "   [" + eff + "]"
+	}
+	return s
 }
 
 // lastN returns up to the last n elements of s.

--- a/go/internal/ui/ui_test.go
+++ b/go/internal/ui/ui_test.go
@@ -54,6 +54,16 @@ func TestBuildViewStatusLine(t *testing.T) {
 	}
 }
 
+func TestBuildViewShowsEffects(t *testing.T) {
+	g := testGame(t, []string{".@."})
+	g.PlayerHP, g.PlayerMax = 10, 20
+	g.AddEffect("poison", 3)
+	v := BuildView(g)
+	if !strings.Contains(v.Status, "Poisoned") {
+		t.Errorf("status %q should show Poisoned", v.Status)
+	}
+}
+
 func TestBuildViewPlacesPlayer(t *testing.T) {
 	g := testGame(t, []string{"...", ".@.", "..."})
 	g.UpdateFOV()


### PR DESCRIPTION
The **keystone of #15** — a status-effect system, with poison and regeneration as the first two effects (and the content that uses them).

## What
- **Effect framework** (`game/effects.go`): timed `Effect{Kind, Turns}` on the player (`Game.Effects`). `AddEffect` adds/refreshes; `tickEffects` (hooked once per player action at the top of `monstersAct`) applies each effect, decrements, and expires it.
- **poison**: −1 HP/turn (can kill — death cause "poison"). **regen**: +1 HP/turn, clamped to max.
- **HUD** shows active effects, e.g. `[Poisoned, Regenerating]`.
- **Behaviors**: `regenerate` (potion → regen for N turns) and `eat_mushroom` (heal + poison).
- **Content**: the red **mushroom** (food: heal 4 **+ poison** — this completes the eat mechanic deferred from #12) and a **potion of regeneration** (heal-over-time).

## Why it matters
This unblocks a lot of #15/#18: more potions/scrolls, trap effects, and (with targeting later) monster-applied effects all hang off this system.

## Scope / next
Player-only effects for now. Later increments: blindness (FOV) + sleep + the harmful-potion line; **wands + interactive targeting** (offensive magic, monster-targeted effects); scrolls + spellbooks. Speed/haste (scheduler-coupled) is its own slice.

## Tests
game: poison damages/kills, regen heals+clamps+expires, AddEffect refresh, EffectsSummary; behaviors: regenerate + eat_mushroom; ui: HUD shows "Poisoned"; data golden: mushroom + regen potion load; `TestNewGameFromShippedData` confirms the new behaviors are registered. `gofmt`/`vet`/`test ./...` green.

Part of #15.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a status-effects system (poison, regeneration) with timed effects and death/heal resolution.
  * Added two consumables: red mushroom (heals but inflicts poison) and regeneration potion (heals over time).
  * HUD now shows active status effects in the status line.

* **Tests**
  * Added comprehensive tests for effects behavior, item behaviors, UI rendering, and embedded consumable data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->