### PR TITLE
Hazard tiles 18a (#18): dart traps that poison

### DIFF
--- a/docs/superpowers/plans/2026-06-08-hazard-tiles-18a.md
+++ b/docs/superpowers/plans/2026-06-08-hazard-tiles-18a.md
@@ -41,4 +41,4 @@
 `gofmt -l . && go vet ./... && go test ./... && go build -o /tmp/tsl ./cmd/tsl`. Commit plan. Push `hazard-tiles`; PR notes hidden/detection traps + doors/light are later #18 slices. CodeRabbit loop → merge → pull master.
 
 ## Done when
-Deeper floors hide `^` dart traps that poison you on contact (shown in the HUD). Suite green.
+Deeper floors show visible `^` dart traps that poison you on contact (shown in the HUD). Suite green.

--- a/docs/superpowers/plans/2026-06-08-hazard-tiles-18a.md
+++ b/docs/superpowers/plans/2026-06-08-hazard-tiles-18a.md
@@ -1,0 +1,44 @@
+# Hazard Tiles 18a Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Traps — a tile that applies a status effect when stepped on. First #18 slice, built on the #15 effect system. Faithful to 0.40's traps (visible for now; hidden/detection later).
+
+**Tech Stack:** Go 1.21 (`GOTOOLCHAIN=local`). Commands run from the `go/` directory at the repo root. TDD, commit per task, suite green between commits.
+
+## Design
+- `TileDef` gains `Effect string` (a status-effect kind) + `EffectTurns int`. Stepping onto such a tile calls `AddEffect(Effect, EffectTurns)`.
+- `LevelDef` gains `Traps int` — how many `dart_trap` tiles the generator scatters.
+- Validation: a tile with `Effect` set needs `EffectTurns > 0`; a level with `Traps > 0` needs a `dart_trap` tile defined (with an effect), so bad content fails at load (not mid-game).
+
+## Task 1: content — tile effect + level traps
+**Files:** `internal/content/content.go`, `internal/content/content_test.go`
+- `TileDef.Effect` (`toml:"effect"`), `TileDef.EffectTurns` (`toml:"effect_turns"`). `validateTile`: if `Effect != ""`, require `EffectTurns > 0`.
+- `LevelDef.Traps` (`toml:"traps"`). In `validateLevels`: `Traps >= 0`; if `Traps > 0`, require `c.Tiles["dart_trap"]` to exist with a non-empty `Effect`.
+- Tests: effect tile loads; effect with 0 turns rejected; level traps>0 without a dart_trap tile rejected.
+- Commit: `feat(content): tile status-effect + level trap count`
+
+## Task 2: game — apply tile effect on step
+**Files:** `internal/game/combat.go` (PlayerStep), `internal/game/combat_test.go`
+- After a successful `Move`, if the tile's `Def.Effect != ""`, `AddEffect(Def.Effect, Def.EffectTurns)` and log "You trigger a trap!".
+- Test: stepping onto an effect tile applies the effect.
+- Commit: `feat(game): stepping onto a hazard tile applies its effect`
+
+## Task 3: gen — scatter traps
+**Files:** `internal/gen/gen.go`, `internal/gen/gen_test.go`
+- In `LevelFromDef`, place `def.Traps` `dart_trap` tiles on passable, non-start, non-portal floor tiles.
+- Test: a def with `Traps: N` and a dart_trap tile produces tiles whose `Def.Effect != ""`.
+- Commit: `feat(gen): scatter trap tiles per level`
+
+## Task 4: data — dart_trap + level traps
+**Files:** `data/tiles.toml`, `data/levels.toml`, `data/data_test.go`
+- `dart_trap` tile (glyph `^`, red, passable, transparent, `effect = "poison"`, `effect_turns = 5`).
+- Add `traps` counts to a few deeper levels (e.g. catacombs 3, laboratory 4, dragons_lair 5).
+- Golden: the dart_trap tile is a poison effect tile.
+- Commit: `feat(data): dart trap (poison) + traps on deeper levels`
+
+## Task 5: verify, push, PR, loop
+`gofmt -l . && go vet ./... && go test ./... && go build -o /tmp/tsl ./cmd/tsl`. Commit plan. Push `hazard-tiles`; PR notes hidden/detection traps + doors/light are later #18 slices. CodeRabbit loop → merge → pull master.
+
+## Done when
+Deeper floors hide `^` dart traps that poison you on contact (shown in the HUD). Suite green.

--- a/go/data/data_test.go
+++ b/go/data/data_test.go
@@ -71,6 +71,26 @@ func TestEmbeddedConsumables(t *testing.T) {
 	}
 }
 
+// TestEmbeddedTraps checks the dart trap tile + that some levels use traps.
+func TestEmbeddedTraps(t *testing.T) {
+	c, err := content.Load(Files)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if tr := c.Tiles["dart_trap"]; tr == nil || tr.Effect != "poison" || tr.EffectTurns <= 0 {
+		t.Errorf("dart_trap tile unexpected: %+v", tr)
+	}
+	trapped := false
+	for _, l := range c.Levels {
+		if l.Traps > 0 {
+			trapped = true
+		}
+	}
+	if !trapped {
+		t.Error("expected at least one level with traps")
+	}
+}
+
 // TestEmbeddedDungeon validates the shipped level graph loads with exactly one
 // start and the expected starter levels.
 func TestEmbeddedDungeon(t *testing.T) {

--- a/go/data/levels.toml
+++ b/go/data/levels.toml
@@ -31,6 +31,7 @@ width = 60
 height = 24
 links = ["dungeon", "laboratory"]
 monsters = 10
+traps = 3
 [[level.catacombs.spawn]]
 monster = "ghoul"
 weight = 3
@@ -69,6 +70,7 @@ width = 60
 height = 24
 links = ["catacombs", "drowned_city"]
 monsters = 10
+traps = 4
 [[level.laboratory.spawn]]
 monster = "gnoblin"
 weight = 2
@@ -156,6 +158,7 @@ height = 24
 links = ["chapel", "drowned_city", "frozen_vault"]
 monsters = 14
 boss = "dragon"
+traps = 5
 [[level.dragons_lair.spawn]]
 monster = "ghoul"
 weight = 3

--- a/go/data/tiles.toml
+++ b/go/data/tiles.toml
@@ -25,3 +25,12 @@ color = "cyan"
 passable = true
 transparent = true
 win = true
+
+# A dart trap — poisons whoever steps on it (#18).
+[tile.dart_trap]
+glyph = "^"
+color = "red"
+passable = true
+transparent = true
+effect = "poison"
+effect_turns = 5

--- a/go/internal/content/content.go
+++ b/go/internal/content/content.go
@@ -38,7 +38,9 @@ type TileDef struct {
 	Color       Color  `toml:"color"`
 	Passable    bool   `toml:"passable"`
 	Transparent bool   `toml:"transparent"`
-	Win         bool   `toml:"win"` // stepping onto this tile wins (the ascension altar)
+	Win         bool   `toml:"win"`          // stepping onto this tile wins (the ascension altar)
+	Effect      string `toml:"effect"`       // status effect applied when stepped on ("" = none)
+	EffectTurns int    `toml:"effect_turns"` // duration of Effect
 }
 
 // Rune returns the tile's glyph as a rune. Glyph is guaranteed by validateTile
@@ -110,6 +112,7 @@ type LevelDef struct {
 	Spawn    []SpawnEntry `toml:"spawn"`
 	Altar    bool         `toml:"altar"` // place an ascension altar (a win tile)
 	Boss     string       `toml:"boss"`  // a guaranteed monster placed once on the level
+	Traps    int          `toml:"traps"` // number of dart_trap tiles to scatter
 }
 
 // Content is the fully-loaded, validated game content.
@@ -268,6 +271,14 @@ func validateLevels(c *Content) error {
 				return fmt.Errorf("level %q: altar set but no win tile %q is defined", id, "altar")
 			}
 		}
+		if l.Traps < 0 {
+			return fmt.Errorf("level %q: traps must be >= 0, got %d", id, l.Traps)
+		}
+		if l.Traps > 0 {
+			if t, ok := c.Tiles["dart_trap"]; !ok || t.Effect == "" {
+				return fmt.Errorf("level %q: traps set but no dart_trap effect tile is defined", id)
+			}
+		}
 	}
 	if starts != 1 {
 		return fmt.Errorf("levels: need exactly one start level, found %d", starts)
@@ -307,6 +318,9 @@ func validateTile(t *TileDef) error {
 	}
 	if !validColors[t.Color] {
 		return fmt.Errorf("invalid color %q", t.Color)
+	}
+	if t.Effect != "" && t.EffectTurns <= 0 {
+		return fmt.Errorf("tile effect %q needs effect_turns > 0", t.Effect)
 	}
 	return nil
 }

--- a/go/internal/content/content_test.go
+++ b/go/internal/content/content_test.go
@@ -399,3 +399,28 @@ func TestLoadRejectsAltarWithoutWinTile(t *testing.T) {
 		t.Fatal("expected error: altar level needs a defined win tile")
 	}
 }
+
+func TestLoadTileEffect(t *testing.T) {
+	dir := writeTiles(t, "[tile.floor]\nglyph=\".\"\ncolor=\"normal\"\npassable=true\ntransparent=true\n\n[tile.dart_trap]\nglyph=\"^\"\ncolor=\"red\"\npassable=true\ntransparent=true\neffect=\"poison\"\neffect_turns=5\n")
+	c, err := Load(os.DirFS(dir))
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if tr := c.Tiles["dart_trap"]; tr == nil || tr.Effect != "poison" || tr.EffectTurns != 5 {
+		t.Errorf("dart_trap def unexpected: %+v", tr)
+	}
+}
+
+func TestLoadRejectsEffectTileWithoutTurns(t *testing.T) {
+	dir := writeTiles(t, "[tile.floor]\nglyph=\".\"\ncolor=\"normal\"\npassable=true\ntransparent=true\n\n[tile.bad]\nglyph=\"^\"\ncolor=\"red\"\npassable=true\ntransparent=true\neffect=\"poison\"\n")
+	if _, err := Load(os.DirFS(dir)); err == nil {
+		t.Fatal("expected error: effect tile needs effect_turns > 0")
+	}
+}
+
+func TestLoadRejectsTrapsWithoutTrapTile(t *testing.T) {
+	body := "[level.a]\nname=\"A\"\nwidth=60\nheight=24\nstart=true\nlinks=[\"a\"]\ntraps=3\n"
+	if _, err := Load(os.DirFS(writeLevelsFixture(t, body))); err == nil {
+		t.Fatal("expected error: traps>0 needs a dart_trap tile")
+	}
+}

--- a/go/internal/game/combat.go
+++ b/go/internal/game/combat.go
@@ -44,10 +44,15 @@ func (g *Game) PlayerStep(d Direction) {
 		acted = true
 	} else if g.Move(d) {
 		acted = true
-		if g.Level.At(g.Player).Def.Win {
+		tile := g.Level.At(g.Player).Def
+		if tile.Win {
 			g.Won = true
 			g.log("You ascend to demigodhood. You win!")
 			return // winning ends the turn immediately
+		}
+		if tile.Effect != "" {
+			g.AddEffect(tile.Effect, tile.EffectTurns)
+			g.log("You trigger a trap!")
 		}
 	}
 	if acted { // a blocked move into a wall doesn't pass the turn

--- a/go/internal/game/combat_test.go
+++ b/go/internal/game/combat_test.go
@@ -113,6 +113,24 @@ func TestPlayerStepOntoAltarWins(t *testing.T) {
 	}
 }
 
+func TestPlayerStepTriggersTrap(t *testing.T) {
+	g := combatGame() // 10x3 floor, player at (1,1)
+	g.Level.Set(Pos{2, 1}, &content.TileDef{ID: "dart_trap", Glyph: "^", Passable: true, Transparent: true, Effect: "poison", EffectTurns: 5})
+	g.PlayerStep(DirE)
+	if g.Player != (Pos{2, 1}) {
+		t.Fatalf("player should have stepped onto the trap, at %v", g.Player)
+	}
+	poisoned := false
+	for _, e := range g.Effects {
+		if e.Kind == "poison" {
+			poisoned = true
+		}
+	}
+	if !poisoned {
+		t.Error("stepping on a dart trap should poison the player")
+	}
+}
+
 func TestKillCreatureNoCorpse(t *testing.T) {
 	g := combatGame()
 	ghost := &Creature{Def: &content.MonsterDef{ID: "ghost", Name: "ghost"}, Pos: Pos{2, 1}, HP: 1}

--- a/go/internal/gen/gen.go
+++ b/go/internal/gen/gen.go
@@ -214,7 +214,30 @@ func LevelFromDef(r *rng.MT, c *content.Content, def *content.LevelDef) (*game.L
 	}
 	placeSpawnMonsters(r, c, lvl, rooms, def)
 	placeItems(r, c, lvl, rooms, lvl.Start)
+	if def.Traps > 0 {
+		placeTraps(r, c, lvl, rooms, def.Traps)
+	}
 	return lvl, nil
+}
+
+// placeTraps scatters up to n dart_trap tiles onto plain floor tiles, avoiding
+// the start, portals, and other special tiles.
+func placeTraps(r *rng.MT, c *content.Content, lvl *game.Level, rooms []rect, n int) {
+	trap := c.Tiles["dart_trap"]
+	if trap == nil {
+		return
+	}
+	for k := 0; k < n; k++ {
+		room := rooms[r.Intn(len(rooms))]
+		pos := game.Pos{X: room.x + r.Intn(room.w), Y: room.y + r.Intn(room.h)}
+		if pos == lvl.Start || !lvl.Passable(pos) || lvl.PortalAt(pos) != nil {
+			continue
+		}
+		if lvl.At(pos).Def.ID != "floor" {
+			continue // don't overwrite stairs, the altar, etc.
+		}
+		lvl.Set(pos, trap)
+	}
 }
 
 // placeSpawnMonsters scatters def.Monsters monsters drawn from def's weighted

--- a/go/internal/gen/gen_test.go
+++ b/go/internal/gen/gen_test.go
@@ -220,6 +220,27 @@ func TestLevelFromDefPlacesBossAndAltar(t *testing.T) {
 	}
 }
 
+func TestLevelFromDefScattersTraps(t *testing.T) {
+	c := levelDefContent()
+	c.Tiles["dart_trap"] = &content.TileDef{ID: "dart_trap", Glyph: "^", Color: content.ColorRed, Passable: true, Transparent: true, Effect: "poison", EffectTurns: 5}
+	def := &content.LevelDef{ID: "x", Name: "X", W: 60, H: 24, Links: []string{"y"}, Traps: 5}
+	lvl, err := LevelFromDef(rng.NewWithSeed(3), c, def)
+	if err != nil {
+		t.Fatal(err)
+	}
+	traps := 0
+	for y := 0; y < lvl.H; y++ {
+		for x := 0; x < lvl.W; x++ {
+			if lvl.At(game.Pos{X: x, Y: y}).Def.Effect != "" {
+				traps++
+			}
+		}
+	}
+	if traps == 0 {
+		t.Error("expected some trap tiles placed")
+	}
+}
+
 func TestLevelFromDefDeterministic(t *testing.T) {
 	c := levelDefContent()
 	def := &content.LevelDef{ID: "x", Name: "X", W: 60, H: 24, Links: []string{"y"}, Monsters: 5, Spawn: []content.SpawnEntry{{Monster: "ratman", Weight: 1}}}


### PR DESCRIPTION
First #18 slice, built on the #15 effect system — **traps**.

## What
- **Tile effects**: a `TileDef` can carry an `effect` + `effect_turns`. Stepping onto such a tile applies that status effect (`PlayerStep` → `AddEffect`).
- **`dart_trap`** tile (`^`, red) → applies **poison** for 5 turns; you see "You trigger a trap!" and `[Poisoned]` in the HUD.
- **`LevelDef.traps`**: the generator scatters N dart traps onto plain floor (never the start, portals, or special tiles). Catacombs (3), Laboratory (4), Dragons Lair (5) now have them.
- Fail-fast validation: an effect tile needs `effect_turns > 0`; a level with `traps > 0` needs a `dart_trap` effect tile defined (so it can't fail mid-game).

## Scope / next
Traps are **visible** for now. Later #18 slices: hidden traps + a trap-detection/search mechanic, plus doors and light/lanterns.

## Tests
content (effect tile + traps validation, 3 cases), game (stepping onto an effect tile poisons), gen (a `traps` def scatters effect tiles), data golden (dart_trap is a poison tile + some level uses traps), shipped-data boot. `gofmt`/`vet`/`test ./...` green.

Part of #18.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added visible dart-trap hazard tiles (glyph ^) to deeper levels; stepping on them during combat applies a 5-turn poison effect and they are shown in the HUD.
* **Documentation**
  * Added an implementation/rollout plan describing generation, scattering, and validation for hazard tiles.
* **Tests**
  * Added content and gameplay tests to verify trap definitions, per-level trap counts, and that stepping triggers poison.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->