### PR TITLE
Wands + targeting 15c (#15): zap a wand at a creature

### DIFF
--- a/docs/superpowers/plans/2026-06-08-wand-targeting-15c.md
+++ b/docs/superpowers/plans/2026-06-08-wand-targeting-15c.md
@@ -1,0 +1,46 @@
+# Wands + Targeting 15c Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Interactive targeting + wands — the biggest missing mechanic. Press `z`, pick a wand, aim a cursor at a creature, and blast it. A force-bolt wand that damages a targeted creature.
+
+## Design
+- **Targeting** is a new `Prompter.Target(origin game.Pos) (game.Pos, bool)`: the front-end shows a movable cursor over the last-rendered map; arrows/hjkl move it, Enter confirms, Esc cancels.
+- **Wands** are `kind = "wand"` items with a `damage` dice spec and per-instance **charges** (`Item.Charges`, seeded from the def's `power` when generated). `Game.ZapWand(it, target)` spends a charge, rolls damage against the creature at the target (kills via `killCreature`), and passes a turn.
+- **Run** gets an `ActZap` (`z`): filter inventory to wands → `Menu` to pick → `Target` → `ZapWand`.
+
+**Scope:** instant hit on the target tile's creature (no beam path / line-of-sight blocking yet); damage wands only. Later: status-effect wands (monster effects), beams, charges UI, auto-target nearest.
+
+## Task 1: content — wand kind
+**Files:** `internal/content/content.go`, `internal/content/content_test.go`
+- Add `"wand"` to `validItemKinds`; in `validateItem`, a `wand` needs a valid `damage` spec (like a weapon). Tests: wand loads; bad-damage wand rejected.
+- Commit: `feat(content): wand item kind`
+
+## Task 2: game — charges + ZapWand
+**Files:** `internal/game/item.go` (Item.Charges), `internal/game/use.go` (WandInventory), `internal/game/combat.go` (ZapWand), tests
+- `Item.Charges int`. `WandInventory() []*Item`. `ZapWand(it *Item, target Pos)`: if `Charges <= 0` log "no charges" (no turn); else spend a charge, `dmg := RNG.RollSpec(it.Def.Damage)`, hit the creature at target (`killCreature` if dead) or "fizzles", then `monstersAct()`.
+- Tests: zap damages + kills a creature; spends a charge; empty wand does nothing.
+- Commit: `feat(game): wand charges + ZapWand (targeted damage)`
+
+## Task 3: gen — seed wand charges
+**Files:** `internal/gen/gen.go` (placeItems), `internal/gen/gen_test.go`
+- When placing a `wand` item, set `Charges = Def.Power`. Test: a placed wand has charges.
+- Commit: `feat(gen): seed wand charges from power`
+
+## Task 4: ui — targeting + ActZap
+**Files:** `internal/ui/ui.go`, `internal/ui/ui_test.go`, `internal/ui/tcell/screen.go`, `internal/ui/tcell/screen_test.go`
+- `Prompter.Target(origin game.Pos) (game.Pos, bool)`; `ActZap` in the enum; `Run` ActZap case (wand menu → target → ZapWand). Add `Target` to the test prompters.
+- tcell: `Screen.last ui.View` saved in `Render`; `Target` redraws `last` + a `*` cursor, moves on arrows/hjkl, Enter/Esc; `z` → `ActZap` in `keyToAction`.
+- Tests: ui Run zaps a creature via a fake Target; tcell `z` → ActZap.
+- Commit: `feat(ui): interactive targeting + z to zap a wand`
+
+## Task 5: data — force-bolt wand
+**Files:** `data/items.toml`, `data/data_test.go`
+- `wand_force_bolt` (kind wand, glyph `/`, blue, damage `2d6`, power 5 = charges). Golden test.
+- Commit: `feat(data): wand of force bolt`
+
+## Task 6: verify, push, PR, loop
+`gofmt -l . && go vet ./... && go test ./... && go build -o /tmp/tsl ./cmd/tsl`. Push `wand-targeting`; PR. CodeRabbit loop → merge → pull master.
+
+## Done when
+Find a wand, press `z`, aim at a monster, and blast it (charges deplete). Suite green.

--- a/go/data/data_test.go
+++ b/go/data/data_test.go
@@ -91,6 +91,17 @@ func TestEmbeddedTraps(t *testing.T) {
 	}
 }
 
+// TestEmbeddedWand checks the force-bolt wand loaded.
+func TestEmbeddedWand(t *testing.T) {
+	c, err := content.Load(Files)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if w := c.Items["wand_force_bolt"]; w == nil || w.Kind != "wand" || w.Damage != "2d6" || w.Power != 5 {
+		t.Errorf("wand_force_bolt def unexpected: %+v", w)
+	}
+}
+
 // TestEmbeddedDungeon validates the shipped level graph loads with exactly one
 // start and the expected starter levels.
 func TestEmbeddedDungeon(t *testing.T) {

--- a/go/data/items.toml
+++ b/go/data/items.toml
@@ -33,7 +33,7 @@ damage = "1d6"
 
 [item.quarterstaff]
 name = "quarterstaff"
-glyph = "/"
+glyph = ")"
 color = "brown"
 kind = "weapon"
 attack = 2

--- a/go/data/items.toml
+++ b/go/data/items.toml
@@ -154,3 +154,12 @@ color = "red"
 kind = "food"
 use = "eat_mushroom"
 power = 4
+
+# Wand (#15) — zap (z) to blast a targeted creature; power = charges.
+[item.wand_force_bolt]
+name = "wand of force bolt"
+glyph = "/"
+color = "blue"
+kind = "wand"
+damage = "2d6"
+power = 5

--- a/go/internal/content/content.go
+++ b/go/internal/content/content.go
@@ -92,7 +92,7 @@ func (i *ItemDef) Rune() rune {
 	return r
 }
 
-var validItemKinds = map[string]bool{"potion": true, "weapon": true, "armor": true, "food": true}
+var validItemKinds = map[string]bool{"potion": true, "weapon": true, "armor": true, "food": true, "wand": true}
 
 // SpawnEntry is one weighted entry in a level's monster spawn table.
 type SpawnEntry struct {
@@ -368,6 +368,10 @@ func validateItem(i *ItemDef) error {
 	case "weapon":
 		if !validDamageSpec(i.Damage) {
 			return fmt.Errorf("weapon damage %q is not a valid dice spec", i.Damage)
+		}
+	case "wand":
+		if !validDamageSpec(i.Damage) {
+			return fmt.Errorf("wand damage %q is not a valid dice spec", i.Damage)
 		}
 	case "food":
 		if strings.TrimSpace(i.Use) == "" {

--- a/go/internal/content/content_test.go
+++ b/go/internal/content/content_test.go
@@ -424,3 +424,33 @@ func TestLoadRejectsTrapsWithoutTrapTile(t *testing.T) {
 		t.Fatal("expected error: traps>0 needs a dart_trap tile")
 	}
 }
+
+func writeItemsFixture(t *testing.T, itemsBody string) string {
+	t.Helper()
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "tiles.toml"), []byte("[tile.floor]\nglyph=\".\"\ncolor=\"normal\"\npassable=true\ntransparent=true\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "items.toml"), []byte(itemsBody), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return dir
+}
+
+func TestLoadWandItem(t *testing.T) {
+	dir := writeItemsFixture(t, "[item.zap]\nname=\"zap wand\"\nglyph=\"/\"\ncolor=\"blue\"\nkind=\"wand\"\ndamage=\"2d6\"\npower=5\n")
+	c, err := Load(os.DirFS(dir))
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if w := c.Items["zap"]; w == nil || w.Kind != "wand" || w.Damage != "2d6" {
+		t.Errorf("wand def unexpected: %+v", w)
+	}
+}
+
+func TestLoadRejectsWandBadDamage(t *testing.T) {
+	dir := writeItemsFixture(t, "[item.zap]\nname=\"zap\"\nglyph=\"/\"\ncolor=\"blue\"\nkind=\"wand\"\ndamage=\"oops\"\n")
+	if _, err := Load(os.DirFS(dir)); err == nil {
+		t.Fatal("expected error: wand needs a valid damage spec")
+	}
+}

--- a/go/internal/game/combat.go
+++ b/go/internal/game/combat.go
@@ -107,6 +107,31 @@ func (g *Game) killCreature(m *Creature) {
 	g.Level.RemoveCreature(m)
 }
 
+// ZapWand fires a wand at target: it spends a charge and damages the creature
+// there (killing it if reduced to 0), then passes a turn. A wand with no charges
+// fizzles without costing a turn.
+func (g *Game) ZapWand(it *Item, target Pos) {
+	if g.Dead || g.Won {
+		return
+	}
+	if it.Charges <= 0 {
+		g.log("The %s has no charges left.", it.Def.Name)
+		return
+	}
+	it.Charges--
+	if m := g.Level.CreatureAt(target); m != nil {
+		dmg := g.RNG.RollSpec(it.Def.Damage)
+		m.HP -= dmg
+		g.log("The %s blasts the %s for %d.", it.Def.Name, m.Def.Name, dmg)
+		if m.HP <= 0 {
+			g.killCreature(m)
+		}
+	} else {
+		g.log("The bolt fizzles against nothing.")
+	}
+	g.monstersAct()
+}
+
 func (g *Game) monsterAttacks(m *Creature) {
 	if !g.RNG.Chance(m.Def.Attack, g.playerDodgeStat()) {
 		g.log("The %s misses you.", m.Def.Name)

--- a/go/internal/game/combat_test.go
+++ b/go/internal/game/combat_test.go
@@ -131,6 +131,31 @@ func TestPlayerStepTriggersTrap(t *testing.T) {
 	}
 }
 
+func TestZapWandDamagesAndKills(t *testing.T) {
+	g := combatGame()
+	rat := &Creature{Def: &content.MonsterDef{ID: "rat", Name: "rat", HP: 3}, Pos: Pos{3, 1}, HP: 3}
+	g.Level.Creatures = append(g.Level.Creatures, rat)
+	wand := &Item{Def: &content.ItemDef{Name: "wand", Kind: "wand", Damage: "10d1"}, Charges: 2}
+	g.ZapWand(wand, Pos{3, 1})
+	if g.Level.CreatureAt(Pos{3, 1}) != nil {
+		t.Error("wand should have killed the rat (10 dmg vs 3 HP)")
+	}
+	if wand.Charges != 1 {
+		t.Errorf("charges = %d, want 1 (spent one)", wand.Charges)
+	}
+}
+
+func TestZapEmptyWandDoesNothing(t *testing.T) {
+	g := combatGame()
+	rat := &Creature{Def: &content.MonsterDef{ID: "rat", Name: "rat", HP: 3}, Pos: Pos{3, 1}, HP: 3}
+	g.Level.Creatures = append(g.Level.Creatures, rat)
+	wand := &Item{Def: &content.ItemDef{Name: "wand", Kind: "wand", Damage: "10d1"}, Charges: 0}
+	g.ZapWand(wand, Pos{3, 1})
+	if g.Level.CreatureAt(Pos{3, 1}) == nil {
+		t.Error("an empty wand should not damage anything")
+	}
+}
+
 func TestKillCreatureNoCorpse(t *testing.T) {
 	g := combatGame()
 	ghost := &Creature{Def: &content.MonsterDef{ID: "ghost", Name: "ghost"}, Pos: Pos{2, 1}, HP: 1}

--- a/go/internal/game/item.go
+++ b/go/internal/game/item.go
@@ -8,8 +8,9 @@ import (
 
 // Item is an item instance (on the ground while Pos is meaningful, or carried).
 type Item struct {
-	Def *content.ItemDef
-	Pos Pos
+	Def     *content.ItemDef
+	Pos     Pos
+	Charges int // remaining wand charges (0 for non-wands)
 }
 
 // Behavior is an item effect, looked up by name from Game.Behaviors and invoked

--- a/go/internal/game/use.go
+++ b/go/internal/game/use.go
@@ -91,3 +91,14 @@ func (g *Game) EdibleInventory() []*Item {
 	}
 	return food
 }
+
+// WandInventory returns the wand items the player is carrying, in inventory order.
+func (g *Game) WandInventory() []*Item {
+	var wands []*Item
+	for _, it := range g.Inventory {
+		if it.Def != nil && it.Def.Kind == "wand" {
+			wands = append(wands, it)
+		}
+	}
+	return wands
+}

--- a/go/internal/game/use_test.go
+++ b/go/internal/game/use_test.go
@@ -127,3 +127,15 @@ func TestPickupAutoEquipsWhenSlotEmpty(t *testing.T) {
 		t.Error("armor should auto-equip when the slot is empty")
 	}
 }
+
+func TestWandInventoryFilters(t *testing.T) {
+	g := useGame()
+	g.Inventory = append(g.Inventory,
+		&Item{Def: &content.ItemDef{Name: "dagger", Kind: "weapon"}},
+		&Item{Def: &content.ItemDef{Name: "wand", Kind: "wand", Damage: "1d1"}, Charges: 3},
+	)
+	wands := g.WandInventory()
+	if len(wands) != 1 || wands[0].Def.Name != "wand" {
+		t.Errorf("WandInventory = %v, want [wand]", wands)
+	}
+}

--- a/go/internal/gen/gen.go
+++ b/go/internal/gen/gen.go
@@ -143,7 +143,11 @@ func placeItems(r *rng.MT, c *content.Content, lvl *game.Level, rooms []rect, st
 			continue
 		}
 		def := c.Items[ids[r.Intn(len(ids))]]
-		lvl.Items = append(lvl.Items, &game.Item{Def: def, Pos: pos})
+		it := &game.Item{Def: def, Pos: pos}
+		if def.Kind == "wand" {
+			it.Charges = def.Power // seed wand charges from its power
+		}
+		lvl.Items = append(lvl.Items, it)
 	}
 }
 

--- a/go/internal/gen/gen_test.go
+++ b/go/internal/gen/gen_test.go
@@ -123,6 +123,28 @@ func TestPlaceItemsSkipsNoSpawn(t *testing.T) {
 	}
 }
 
+func TestPlaceItemsSeedsWandCharges(t *testing.T) {
+	c := testContent()
+	c.Items = map[string]*content.ItemDef{
+		"wand": {ID: "wand", Name: "wand", Glyph: "/", Color: content.ColorBlue, Kind: "wand", Damage: "2d6", Power: 5},
+	}
+	for seed := uint32(1); seed <= 20; seed++ {
+		lvl, err := LevelFromDef(rng.NewWithSeed(seed), c, &content.LevelDef{ID: "x", Name: "X", W: 60, H: 24, Links: []string{"y"}})
+		if err != nil {
+			t.Fatal(err)
+		}
+		for _, it := range lvl.Items {
+			if it.Def.Kind == "wand" {
+				if it.Charges != 5 {
+					t.Fatalf("wand charges = %d, want 5 (from power)", it.Charges)
+				}
+				return // found a placed wand and verified its charges
+			}
+		}
+	}
+	t.Fatal("no wand was placed across 20 seeds")
+}
+
 func TestPlaceMonstersRespectsMinDepth(t *testing.T) {
 	c := testContent()
 	c.Monsters = map[string]*content.MonsterDef{

--- a/go/internal/ui/tcell/screen.go
+++ b/go/internal/ui/tcell/screen.go
@@ -14,7 +14,8 @@ import (
 
 // Screen is a tcell-backed ui.Renderer and ui.Prompter.
 type Screen struct {
-	s tc.Screen
+	s    tc.Screen
+	last ui.View // most recently rendered view, reused by Target
 }
 
 // New creates and initializes a real terminal screen.
@@ -48,6 +49,13 @@ var colorMap = map[content.Color]tc.Color{
 
 // Render draws the view (map then message lines) and flushes it.
 func (sc *Screen) Render(v ui.View) {
+	sc.last = v
+	sc.drawView(v)
+	sc.s.Show()
+}
+
+// drawView paints the map, status line, and messages (without flushing).
+func (sc *Screen) drawView(v ui.View) {
 	sc.s.Clear()
 	for y := 0; y < v.H; y++ {
 		for x := 0; x < v.W; x++ {
@@ -63,7 +71,6 @@ func (sc *Screen) Render(v ui.View) {
 	for i, msg := range v.Messages {
 		drawString(sc.s, 0, v.H+1+i, msg)
 	}
-	sc.s.Show()
 }
 
 func drawString(s tc.Screen, x, y int, str string) {
@@ -120,6 +127,8 @@ func keyToAction(ev *tc.EventKey) (ui.Action, bool) {
 		return ui.Action{Kind: ui.ActPickup}, true
 	case 'i':
 		return ui.Action{Kind: ui.ActInventory}, true
+	case 'z':
+		return ui.Action{Kind: ui.ActZap}, true
 	case 'e':
 		return ui.Action{Kind: ui.ActEat}, true
 	case '>':
@@ -160,6 +169,53 @@ func (sc *Screen) Menu(m ui.MenuSpec) (int, bool) {
 			return 0, false
 		case ev.Rune() >= 'a' && int(ev.Rune()-'a') < len(m.Items):
 			return int(ev.Rune() - 'a'), true
+		}
+	}
+}
+
+// Target lets the player move a cursor over the last-rendered map and pick a
+// tile. Arrows/hjkl move the cursor; Enter confirms; Esc/q cancels.
+func (sc *Screen) Target(origin game.Pos) (game.Pos, bool) {
+	v := sc.last
+	clamp := func(p game.Pos) game.Pos {
+		if p.X < 0 {
+			p.X = 0
+		}
+		if p.Y < 0 {
+			p.Y = 0
+		}
+		if v.W > 0 && p.X >= v.W {
+			p.X = v.W - 1
+		}
+		if v.H > 0 && p.Y >= v.H {
+			p.Y = v.H - 1
+		}
+		return p
+	}
+	cur := clamp(origin)
+	cursorStyle := tc.StyleDefault.Foreground(tc.ColorYellow).Reverse(true)
+	for {
+		sc.drawView(v)
+		drawString(sc.s, 0, v.H+1+len(v.Messages), "Aim: move cursor, Enter to fire, Esc to cancel")
+		sc.s.SetContent(cur.X, cur.Y, '*', nil, cursorStyle)
+		sc.s.Show()
+		ev, ok := sc.s.PollEvent().(*tc.EventKey)
+		if !ok {
+			continue
+		}
+		switch {
+		case ev.Key() == tc.KeyEnter:
+			return cur, true
+		case ev.Key() == tc.KeyEscape || ev.Rune() == 'q':
+			return game.Pos{}, false
+		case ev.Key() == tc.KeyUp || ev.Rune() == 'k':
+			cur = clamp(game.Pos{X: cur.X, Y: cur.Y - 1})
+		case ev.Key() == tc.KeyDown || ev.Rune() == 'j':
+			cur = clamp(game.Pos{X: cur.X, Y: cur.Y + 1})
+		case ev.Key() == tc.KeyLeft || ev.Rune() == 'h':
+			cur = clamp(game.Pos{X: cur.X - 1, Y: cur.Y})
+		case ev.Key() == tc.KeyRight || ev.Rune() == 'l':
+			cur = clamp(game.Pos{X: cur.X + 1, Y: cur.Y})
 		}
 	}
 }

--- a/go/internal/ui/tcell/screen_test.go
+++ b/go/internal/ui/tcell/screen_test.go
@@ -46,7 +46,8 @@ func TestKeyToAction(t *testing.T) {
 		{tc.NewEventKey(tc.KeyLeft, 0, tc.ModNone), ui.Action{Kind: ui.ActMove, Dir: game.DirW}, true},
 		{tc.NewEventKey(tc.KeyRune, 'q', tc.ModNone), ui.Action{Kind: ui.ActQuit}, true},
 		{tc.NewEventKey(tc.KeyRune, 'e', tc.ModNone), ui.Action{Kind: ui.ActEat}, true},
-		{tc.NewEventKey(tc.KeyRune, 'z', tc.ModNone), ui.Action{}, false},
+		{tc.NewEventKey(tc.KeyRune, 'z', tc.ModNone), ui.Action{Kind: ui.ActZap}, true},
+		{tc.NewEventKey(tc.KeyRune, 'X', tc.ModNone), ui.Action{}, false},
 	}
 	for _, tt := range cases {
 		got, ok := keyToAction(tt.ev)

--- a/go/internal/ui/ui.go
+++ b/go/internal/ui/ui.go
@@ -40,6 +40,7 @@ const (
 	ActInventory
 	ActTravel
 	ActEat
+	ActZap
 )
 
 // Action is a decoded player intent. Dir is meaningful only when Kind==ActMove.
@@ -54,10 +55,11 @@ type MenuSpec struct {
 	Items []string
 }
 
-// Prompter supplies player actions and menu selections.
+// Prompter supplies player actions, menu selections, and targeting.
 type Prompter interface {
 	NextAction() (Action, error)
 	Menu(MenuSpec) (index int, ok bool)
+	Target(origin game.Pos) (game.Pos, bool)
 }
 
 // Renderer draws a View.
@@ -179,6 +181,23 @@ func Run(g *game.Game, p Prompter, r Renderer) error {
 			}
 			if idx, ok := p.Menu(MenuSpec{Title: "Eat what?", Items: names}); ok && idx >= 0 && idx < len(food) {
 				g.PlayerUse(food[idx])
+			}
+		case ActZap:
+			wands := g.WandInventory()
+			if len(wands) == 0 {
+				g.Messages = append(g.Messages, "You have no wand to zap.")
+				break
+			}
+			names := make([]string, len(wands))
+			for i, it := range wands {
+				names[i] = fmt.Sprintf("%s (%d charges)", it.Def.Name, it.Charges)
+			}
+			idx, ok := p.Menu(MenuSpec{Title: "Zap which wand?", Items: names})
+			if !ok || idx < 0 || idx >= len(wands) {
+				break
+			}
+			if target, ok := p.Target(g.Player); ok {
+				g.ZapWand(wands[idx], target)
 			}
 		}
 	}

--- a/go/internal/ui/ui_test.go
+++ b/go/internal/ui/ui_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/c0ze/tsl/internal/content"
 	"github.com/c0ze/tsl/internal/game"
+	"github.com/c0ze/tsl/internal/rng"
 )
 
 func testGame(t *testing.T, rows []string) *game.Game {
@@ -37,6 +38,8 @@ func (s *scriptPrompter) NextAction() (Action, error) {
 }
 
 func (s *scriptPrompter) Menu(MenuSpec) (int, bool) { return 0, false }
+
+func (s *scriptPrompter) Target(game.Pos) (game.Pos, bool) { return game.Pos{}, false }
 
 type nullRenderer struct{ frames int }
 
@@ -172,6 +175,41 @@ func (m *menuPrompter) NextAction() (Action, error) {
 	return a, nil
 }
 func (m *menuPrompter) Menu(MenuSpec) (int, bool) { return m.pick, true }
+
+func (m *menuPrompter) Target(game.Pos) (game.Pos, bool) { return game.Pos{}, false }
+
+// zapPrompter scripts actions, picks the first wand, and targets a fixed tile.
+type zapPrompter struct {
+	actions []Action
+	i       int
+	target  game.Pos
+}
+
+func (z *zapPrompter) NextAction() (Action, error) {
+	if z.i >= len(z.actions) {
+		return Action{Kind: ActQuit}, nil
+	}
+	a := z.actions[z.i]
+	z.i++
+	return a, nil
+}
+func (z *zapPrompter) Menu(MenuSpec) (int, bool)        { return 0, true }
+func (z *zapPrompter) Target(game.Pos) (game.Pos, bool) { return z.target, true }
+
+func TestRunZapWandDamagesCreature(t *testing.T) {
+	g := testGame(t, []string{".....", ".@...", "....."})
+	g.RNG = rng.NewWithSeed(1)
+	g.UpdateFOV()
+	g.Level.Creatures = append(g.Level.Creatures, &game.Creature{Def: &content.MonsterDef{ID: "rat", Name: "rat", HP: 3}, Pos: game.Pos{X: 3, Y: 1}, HP: 3})
+	g.Inventory = append(g.Inventory, &game.Item{Def: &content.ItemDef{Name: "wand", Kind: "wand", Damage: "5d1"}, Charges: 3})
+	p := &zapPrompter{actions: []Action{{Kind: ActZap}, {Kind: ActQuit}}, target: game.Pos{X: 3, Y: 1}}
+	if err := Run(g, p, &nullRenderer{}); err != nil {
+		t.Fatal(err)
+	}
+	if g.Level.CreatureAt(game.Pos{X: 3, Y: 1}) != nil {
+		t.Error("zapping the wand should have killed the rat")
+	}
+}
 
 func TestBuildViewShowsVisibleMonsterAndMessages(t *testing.T) {
 	g := testGame(t, []string{".....", ".@...", "....."})


### PR DESCRIPTION
The biggest remaining mechanic — **interactive targeting** + **wands**.

## What
- **Targeting**: a new `Prompter.Target(origin)` — press `z`, pick a wand, then a `*` cursor appears on the map. Arrows/hjkl move it, Enter fires, Esc cancels. (tcell redraws the last frame + the cursor.)
- **Wands**: `kind = "wand"` items with a `damage` spec and per-instance **charges** (`Item.Charges`, seeded from `power` when generated). `Game.ZapWand` spends a charge, rolls damage on the creature at the target (kills via the shared death path), and passes a turn. A spent wand fizzles for free.
- **Data**: the **wand of force bolt** (`/`, 2d6, 5 charges) scatters as loot.

## Scope
Instant hit on the targeted tile's creature — no beam path / line-of-sight blocking yet, damage wands only. Later: status-effect wands (monster-targeted poison/sleep), beams, charge display, auto-target nearest.

## Tests
content (wand kind + damage validation), game (zap damages/kills, spends a charge, empty wand no-ops; WandInventory), gen (placed wands get charges), ui (Run zaps a creature via a fake `Target`), tcell (`z` → ActZap). `gofmt`/`vet`/`test ./...` green; boots on shipped data.

Part of #15.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Wands introduced as a new usable item type with limited charges that deplete when cast
  * Added wand targeting and casting via the "z" key with a cursor-based aiming mode
  * Force bolt wand added to the item set (2d6 damage, consumes charges)

* **Documentation**
  * Added an implementation plan describing wand and targeting work

* **Tests**
  * Added unit and integration tests covering wand loading, validation, inventory filtering, casting, and UI zap flow
<!-- end of auto-generated comment: release notes by coderabbit.ai -->