### PR TITLE
feat: status-effect wands (wand of venom)

### DIFF
--- a/docs/superpowers/plans/2026-06-08-effect-wands-15d.md
+++ b/docs/superpowers/plans/2026-06-08-effect-wands-15d.md
@@ -1,0 +1,75 @@
+# Status-Effect Wands 15d Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** A wand that applies a timed status effect to its target instead of (or
+as well as) blasting it for damage. Concretely: a *wand of venom* that poisons
+the creature you aim at, so it dies over the next several turns. This generalizes
+the status-effect system from player-only to any creature, unlocking all future
+creature afflictions (slow, sleep, fear) and effect-bearing items.
+
+## Design
+- **Effects on creatures.** Today `Effect{Kind,Turns}` lives only on the player
+  (`Game.Effects`). Extract the add/refresh logic into a free function
+  `addEffect(effects, kind, turns) []Effect`; `Game.AddEffect` and a new
+  `Creature.AddEffect` both delegate to it. Give `Creature` an `Effects []Effect`.
+- **Ticking creature effects.** `tickCreatureEffects(m) bool` applies each
+  effect's per-turn outcome (poison: `HP--`), decrements/expires, and when the
+  creature reaches 0 HP resolves death through the existing `killCreature`
+  (drops a corpse, removes it) and reports `true`. `monstersAct` ticks each
+  living creature once per turn, before it gains energy; a creature that died of
+  poison is skipped.
+- **Effect-bearing items.** Mirror `TileDef`: add `ItemDef.Effect string` +
+  `ItemDef.EffectTurns int` (`effect` / `effect_turns`). A trap tile and a venom
+  wand now describe an affliction the same way.
+- **ZapWand.** Spend a charge; if a creature is on the target, deal the wand's
+  `damage` (only when it has a damage spec) and, if it survives, apply the wand's
+  `effect` for `effect_turns`. A wand may carry damage, an effect, or both.
+
+**Scope:** poison is the one creature effect wired this pass (symmetric with the
+player's poison). The mechanism is general — later effects (slow/sleep) only add
+a `case` to the tick and, for control effects, a check in the monster's action.
+No per-creature status shown in the HUD yet (the zap message announces it).
+
+## Task 1: content — effect-bearing items
+**Files:** `internal/content/content.go`, `internal/content/content_test.go`
+- Add `Effect string` (`effect`) + `EffectTurns int` (`effect_turns`) to `ItemDef`.
+- `validateItem`: any item with `effect != ""` needs `effect_turns > 0`
+  (mirrors `validateTile`). A `wand` now needs a valid `damage` spec **or** an
+  effect; with a damage spec present it must still parse.
+- Tests (first, watch fail): effect-only wand loads; wand with neither damage
+  nor effect rejected; `effect` without `effect_turns` rejected; existing
+  damage-only wand still loads.
+- Commit: `feat(content): effect-bearing items (effect/effect_turns)`
+
+## Task 2: game — creature effects + zap effect path
+**Files:** `internal/game/creature.go` (Effects field + AddEffect),
+`internal/game/effects.go` (addEffect free fn, tickCreatureEffects),
+`internal/game/combat.go` (monstersAct tick, ZapWand effect), tests
+- Extract `addEffect`; `Game.AddEffect`/`Creature.AddEffect` delegate (player
+  effect tests stay green).
+- `tickCreatureEffects(m *Creature) bool`: poison `HP--`, expire, `killCreature`
+  + return `true` on death.
+- `monstersAct`: for each snapshot creature still present, tick its effects;
+  `continue` if it died.
+- `ZapWand`: only roll/apply damage when `it.Def.Damage != ""`; if the target
+  survives and the wand has an `Effect`, `m.AddEffect(effect, turns)` and log it.
+- Tests (first): creature poison damages + kills over ticks; `Creature.AddEffect`
+  refreshes to longer; zapping a venom wand poisons a live target and spends a
+  charge; a poisoned monster dies across `monstersAct` turns.
+- Commit: `feat(game): status effects on creatures + effect wands`
+
+## Task 3: data — wand of venom
+**Files:** `data/items.toml`, `data/data_test.go`
+- `wand_venom` (kind wand, glyph `/`, green, `effect = "poison"`,
+  `effect_turns = 8`, `power = 5` = charges, no damage). Golden test
+  `TestEmbeddedVenomWand`.
+- Commit: `feat(data): wand of venom (poisons its target)`
+
+## Task 4: verify, push, PR, loop
+`gofmt -l . && go vet ./... && go test ./... && go build -o /tmp/tsl ./cmd/tsl`.
+Push `effect-wands`; open PR. CodeRabbit loop → merge when green → pull master.
+
+## Done when
+Aim a wand of venom at a monster: it takes no immediate hit but withers and dies
+over the next handful of turns. Damage wands are unaffected. Suite green.

--- a/go/data/data_test.go
+++ b/go/data/data_test.go
@@ -102,6 +102,22 @@ func TestEmbeddedWand(t *testing.T) {
 	}
 }
 
+// TestEmbeddedVenomWand checks the status-effect (venom) wand loaded: a pure
+// poison wand with charges and no direct damage.
+func TestEmbeddedVenomWand(t *testing.T) {
+	c, err := content.Load(Files)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	w := c.Items["wand_venom"]
+	if w == nil || w.Kind != "wand" || w.Effect != "poison" || w.EffectTurns <= 0 || w.Power <= 0 {
+		t.Errorf("wand_venom def unexpected: %+v", w)
+	}
+	if w != nil && w.Damage != "" {
+		t.Errorf("wand_venom should be a pure status wand (no damage), got %q", w.Damage)
+	}
+}
+
 // TestEmbeddedDungeon validates the shipped level graph loads with exactly one
 // start and the expected starter levels.
 func TestEmbeddedDungeon(t *testing.T) {

--- a/go/data/items.toml
+++ b/go/data/items.toml
@@ -155,11 +155,22 @@ kind = "food"
 use = "eat_mushroom"
 power = 4
 
-# Wand (#15) — zap (z) to blast a targeted creature; power = charges.
+# Wands (#15) — zap (z) to target a creature; power = charges.
 [item.wand_force_bolt]
 name = "wand of force bolt"
 glyph = "/"
 color = "blue"
 kind = "wand"
 damage = "2d6"
+power = 5
+
+# Status-effect wand: no direct hit, but poisons the target so it withers over
+# the next several turns (effect/effect_turns mirror a trap tile).
+[item.wand_venom]
+name = "wand of venom"
+glyph = "/"
+color = "green"
+kind = "wand"
+effect = "poison"
+effect_turns = 8
 power = 5

--- a/go/internal/content/content.go
+++ b/go/internal/content/content.go
@@ -73,17 +73,19 @@ func (m *MonsterDef) Rune() rune {
 
 // ItemDef defines a kind of item.
 type ItemDef struct {
-	ID      string `toml:"-"`
-	Name    string `toml:"name"`
-	Glyph   string `toml:"glyph"`
-	Color   Color  `toml:"color"`
-	Kind    string `toml:"kind"`    // "potion", "weapon", "armor", or "food"
-	Use     string `toml:"use"`     // behavior name (potions/food)
-	Power   int    `toml:"power"`   // potion/food magnitude (heal amount)
-	Attack  int    `toml:"attack"`  // weapon attack bonus
-	Dodge   int    `toml:"dodge"`   // armor dodge bonus
-	Damage  string `toml:"damage"`  // weapon damage spec
-	NoSpawn bool   `toml:"nospawn"` // exclude from random floor loot (e.g. corpses)
+	ID          string `toml:"-"`
+	Name        string `toml:"name"`
+	Glyph       string `toml:"glyph"`
+	Color       Color  `toml:"color"`
+	Kind        string `toml:"kind"`         // "potion", "weapon", "armor", "food", or "wand"
+	Use         string `toml:"use"`          // behavior name (potions/food)
+	Power       int    `toml:"power"`        // potion/food heal magnitude, or wand charges
+	Attack      int    `toml:"attack"`       // weapon attack bonus
+	Dodge       int    `toml:"dodge"`        // armor dodge bonus
+	Damage      string `toml:"damage"`       // weapon/wand damage spec
+	Effect      string `toml:"effect"`       // status effect applied on use ("" = none); e.g. a venom wand
+	EffectTurns int    `toml:"effect_turns"` // duration of Effect
+	NoSpawn     bool   `toml:"nospawn"`      // exclude from random floor loot (e.g. corpses)
 }
 
 // Rune returns the item's glyph as a rune.
@@ -370,7 +372,10 @@ func validateItem(i *ItemDef) error {
 			return fmt.Errorf("weapon damage %q is not a valid dice spec", i.Damage)
 		}
 	case "wand":
-		if !validDamageSpec(i.Damage) {
+		if i.Damage == "" && i.Effect == "" {
+			return fmt.Errorf("wand must have a damage spec or an effect")
+		}
+		if i.Damage != "" && !validDamageSpec(i.Damage) {
 			return fmt.Errorf("wand damage %q is not a valid dice spec", i.Damage)
 		}
 	case "food":
@@ -380,6 +385,9 @@ func validateItem(i *ItemDef) error {
 		if i.Power < 0 {
 			return fmt.Errorf("food power must be >= 0, got %d", i.Power)
 		}
+	}
+	if i.Effect != "" && i.EffectTurns <= 0 {
+		return fmt.Errorf("item effect %q needs effect_turns > 0", i.Effect)
 	}
 	return nil
 }

--- a/go/internal/content/content_test.go
+++ b/go/internal/content/content_test.go
@@ -454,3 +454,32 @@ func TestLoadRejectsWandBadDamage(t *testing.T) {
 		t.Fatal("expected error: wand needs a valid damage spec")
 	}
 }
+
+func TestLoadEffectWand(t *testing.T) {
+	dir := writeItemsFixture(t, "[item.venom]\nname=\"venom wand\"\nglyph=\"/\"\ncolor=\"green\"\nkind=\"wand\"\neffect=\"poison\"\neffect_turns=8\npower=5\n")
+	c, err := Load(os.DirFS(dir))
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	w := c.Items["venom"]
+	if w == nil || w.Kind != "wand" || w.Effect != "poison" || w.EffectTurns != 8 {
+		t.Errorf("effect wand def unexpected: %+v", w)
+	}
+	if w != nil && w.Damage != "" {
+		t.Errorf("effect-only wand should carry no damage spec, got %q", w.Damage)
+	}
+}
+
+func TestLoadRejectsWandWithoutDamageOrEffect(t *testing.T) {
+	dir := writeItemsFixture(t, "[item.dud]\nname=\"dud\"\nglyph=\"/\"\ncolor=\"blue\"\nkind=\"wand\"\npower=5\n")
+	if _, err := Load(os.DirFS(dir)); err == nil {
+		t.Fatal("expected error: a wand needs a damage spec or an effect")
+	}
+}
+
+func TestLoadRejectsItemEffectWithoutTurns(t *testing.T) {
+	dir := writeItemsFixture(t, "[item.venom]\nname=\"venom\"\nglyph=\"/\"\ncolor=\"green\"\nkind=\"wand\"\neffect=\"poison\"\n")
+	if _, err := Load(os.DirFS(dir)); err == nil {
+		t.Fatal("expected error: item effect needs effect_turns > 0")
+	}
+}

--- a/go/internal/game/combat.go
+++ b/go/internal/game/combat.go
@@ -107,9 +107,11 @@ func (g *Game) killCreature(m *Creature) {
 	g.Level.RemoveCreature(m)
 }
 
-// ZapWand fires a wand at target: it spends a charge and damages the creature
-// there (killing it if reduced to 0), then passes a turn. A wand with no charges
-// fizzles without costing a turn.
+// ZapWand fires a wand at target: it spends a charge, then on the creature there
+// deals the wand's damage (if any, killing it at 0 HP) and — if the target
+// survives — applies the wand's status effect (e.g. poison). A wand may carry
+// damage, an effect, or both. It passes a turn; a wand with no charges fizzles
+// without costing a turn.
 func (g *Game) ZapWand(it *Item, target Pos) {
 	if g.Dead || g.Won {
 		return
@@ -120,11 +122,16 @@ func (g *Game) ZapWand(it *Item, target Pos) {
 	}
 	it.Charges--
 	if m := g.Level.CreatureAt(target); m != nil {
-		dmg := g.RNG.RollSpec(it.Def.Damage)
-		m.HP -= dmg
-		g.log("The %s blasts the %s for %d.", it.Def.Name, m.Def.Name, dmg)
+		if it.Def.Damage != "" {
+			dmg := g.RNG.RollSpec(it.Def.Damage)
+			m.HP -= dmg
+			g.log("The %s blasts the %s for %d.", it.Def.Name, m.Def.Name, dmg)
+		}
 		if m.HP <= 0 {
 			g.killCreature(m)
+		} else if it.Def.Effect != "" {
+			m.AddEffect(it.Def.Effect, it.Def.EffectTurns)
+			g.log("The %s %s the %s.", it.Def.Name, effectVerb(it.Def.Effect), m.Def.Name)
 		}
 	} else {
 		g.log("The bolt fizzles against nothing.")
@@ -166,6 +173,9 @@ func (g *Game) monstersAct() {
 		}
 		if g.Level.CreatureAt(m.Pos) != m {
 			continue // already removed this turn
+		}
+		if g.tickCreatureEffects(m) {
+			continue // succumbed to its afflictions before acting
 		}
 		m.Energy += speedOf(m)
 		for m.Energy >= turnCost {

--- a/go/internal/game/combat_test.go
+++ b/go/internal/game/combat_test.go
@@ -156,6 +156,47 @@ func TestZapEmptyWandDoesNothing(t *testing.T) {
 	}
 }
 
+func TestZapWandAppliesEffect(t *testing.T) {
+	g := combatGame()
+	rat := &Creature{Def: &content.MonsterDef{ID: "rat", Name: "rat", HP: 5, Damage: "1d1"}, Pos: Pos{3, 1}, HP: 5}
+	g.Level.Creatures = append(g.Level.Creatures, rat)
+	wand := &Item{Def: &content.ItemDef{Name: "wand of venom", Kind: "wand", Effect: "poison", EffectTurns: 6}, Charges: 2}
+
+	g.ZapWand(wand, Pos{3, 1})
+
+	if wand.Charges != 1 {
+		t.Errorf("charges = %d, want 1 (spent one)", wand.Charges)
+	}
+	if g.Level.CreatureAt(rat.Pos) != rat {
+		t.Fatal("a venom wand should not kill its target instantly")
+	}
+	poisoned := false
+	for _, e := range rat.Effects {
+		if e.Kind == "poison" {
+			poisoned = true
+		}
+	}
+	if !poisoned {
+		t.Error("zapping a venom wand should poison the target")
+	}
+}
+
+func TestPoisonedMonsterDiesOverTurns(t *testing.T) {
+	g := combatGame() // 10x3 floor, player at (1,1)
+	rat := &Creature{Def: &content.MonsterDef{ID: "rat", Name: "rat", HP: 4, Damage: "1d1"}, Pos: Pos{9, 1}, HP: 4}
+	g.Level.Creatures = append(g.Level.Creatures, rat)
+	rat.AddEffect("poison", 8)
+
+	for i := 0; i < 8 && g.Level.CreatureAt(rat.Pos) == rat; i++ {
+		g.monstersAct()
+	}
+	for _, m := range g.Level.Creatures {
+		if m == rat {
+			t.Fatal("poison should have killed the rat within its duration")
+		}
+	}
+}
+
 func TestKillCreatureNoCorpse(t *testing.T) {
 	g := combatGame()
 	ghost := &Creature{Def: &content.MonsterDef{ID: "ghost", Name: "ghost"}, Pos: Pos{2, 1}, HP: 1}

--- a/go/internal/game/creature.go
+++ b/go/internal/game/creature.go
@@ -18,6 +18,13 @@ type Creature struct {
 	HP      int
 	Faction Faction
 	Energy  int
+	Effects []Effect // timed afflictions (e.g. poison from a venom wand)
+}
+
+// AddEffect applies a timed status effect to the creature, refreshing an
+// already-active effect of the same kind to the longer duration.
+func (m *Creature) AddEffect(kind string, turns int) {
+	m.Effects = addEffect(m.Effects, kind, turns)
 }
 
 // CreatureAt returns the creature standing on p, or nil.

--- a/go/internal/game/effects.go
+++ b/go/internal/game/effects.go
@@ -14,21 +14,68 @@ var effectLabels = map[string]string{
 	"regen":  "Regenerating",
 }
 
-// AddEffect applies a status effect for the given number of turns, refreshing an
-// already-active effect of the same kind to the longer duration.
-func (g *Game) AddEffect(kind string, turns int) {
-	if kind == "" || turns <= 0 {
-		return
+// effectVerbs phrases how a source inflicts an effect, for the zap message.
+var effectVerbs = map[string]string{
+	"poison": "poisons",
+}
+
+// effectVerb returns the verb describing inflicting kind, with a generic
+// fallback for effects that have no specific phrasing.
+func effectVerb(kind string) string {
+	if v := effectVerbs[kind]; v != "" {
+		return v
 	}
-	for i := range g.Effects {
-		if g.Effects[i].Kind == kind {
-			if turns > g.Effects[i].Turns {
-				g.Effects[i].Turns = turns
+	return "afflicts"
+}
+
+// addEffect adds or refreshes a timed effect in effects and returns the updated
+// slice. An already-active effect of the same kind is kept at the longer of the
+// two durations. Empty kinds and non-positive durations are ignored. Shared by
+// the player and creatures so both get identical stacking semantics.
+func addEffect(effects []Effect, kind string, turns int) []Effect {
+	if kind == "" || turns <= 0 {
+		return effects
+	}
+	for i := range effects {
+		if effects[i].Kind == kind {
+			if turns > effects[i].Turns {
+				effects[i].Turns = turns
 			}
-			return
+			return effects
 		}
 	}
-	g.Effects = append(g.Effects, Effect{Kind: kind, Turns: turns})
+	return append(effects, Effect{Kind: kind, Turns: turns})
+}
+
+// AddEffect applies a status effect to the player for the given number of turns,
+// refreshing an already-active effect of the same kind to the longer duration.
+func (g *Game) AddEffect(kind string, turns int) {
+	g.Effects = addEffect(g.Effects, kind, turns)
+}
+
+// tickCreatureEffects applies each of a creature's active effects (poison costs
+// it 1 HP), decrements and expires them, and resolves death through killCreature
+// when its HP reaches 0. It reports whether the creature died this tick.
+func (g *Game) tickCreatureEffects(m *Creature) bool {
+	if len(m.Effects) == 0 {
+		return false
+	}
+	kept := m.Effects[:0]
+	for _, e := range m.Effects {
+		if e.Kind == "poison" {
+			m.HP--
+		}
+		e.Turns--
+		if e.Turns > 0 {
+			kept = append(kept, e)
+		}
+	}
+	m.Effects = kept
+	if m.HP <= 0 {
+		g.killCreature(m)
+		return true
+	}
+	return false
 }
 
 // tickEffects applies each active effect's per-turn outcome, then decrements and

--- a/go/internal/game/effects_test.go
+++ b/go/internal/game/effects_test.go
@@ -1,6 +1,10 @@
 package game
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/c0ze/tsl/internal/content"
+)
 
 func TestPoisonDamagesAndKills(t *testing.T) {
 	g := &Game{PlayerHP: 3, PlayerMax: 20}
@@ -72,5 +76,44 @@ func TestAddEffectRejectsBadInput(t *testing.T) {
 	g.AddEffect("poison", -3) // negative duration
 	if len(g.Effects) != 0 {
 		t.Errorf("bad inputs should add no effects, got %v", g.Effects)
+	}
+}
+
+// Creatures carry the same timed effects as the player; poison whittles their
+// HP and resolves death through killCreature (corpse drop + removal).
+func TestCreaturePoisonDamagesAndKills(t *testing.T) {
+	g := combatGame()
+	m := &Creature{Def: &content.MonsterDef{ID: "rat", Name: "rat", HP: 3, Damage: "1d1"}, Pos: Pos{3, 1}, HP: 3}
+	g.Level.Creatures = append(g.Level.Creatures, m)
+	m.AddEffect("poison", 5)
+
+	if g.tickCreatureEffects(m) { // 3 -> 2
+		t.Fatal("one tick should not kill a 3-HP creature")
+	}
+	if m.HP != 2 {
+		t.Errorf("HP = %d, want 2 after one poison tick", m.HP)
+	}
+	died := false
+	for i := 0; i < 5 && !died; i++ {
+		died = g.tickCreatureEffects(m)
+	}
+	if !died {
+		t.Fatal("poison should eventually kill the creature")
+	}
+	if g.Level.CreatureAt(Pos{3, 1}) != nil {
+		t.Error("a creature poisoned to death should be removed from the level")
+	}
+}
+
+func TestCreatureAddEffectRefreshesToLonger(t *testing.T) {
+	m := &Creature{Def: &content.MonsterDef{ID: "rat"}, HP: 5}
+	m.AddEffect("poison", 3)
+	m.AddEffect("poison", 6) // refresh to the longer duration
+	if len(m.Effects) != 1 || m.Effects[0].Turns != 6 {
+		t.Errorf("expected one poison effect with 6 turns, got %v", m.Effects)
+	}
+	m.AddEffect("poison", 2) // shorter — no change
+	if m.Effects[0].Turns != 6 {
+		t.Errorf("shorter refresh should not shorten, got %d", m.Effects[0].Turns)
 	}
 }


### PR DESCRIPTION
## Status-effect wands (#15)

Generalizes the status-effect system from **player-only** to **any creature**, and ships the first effect-applying wand: a **wand of venom** that poisons whatever you aim at, so it withers and dies over the next several turns.

### What's new
- **Effects on creatures.** The add/refresh logic is extracted into a shared `addEffect` helper; `Game.AddEffect` and a new `Creature.AddEffect` both delegate to it, so the player and monsters stack timed effects identically. `Creature` gains an `Effects []Effect`.
- **Ticking.** `tickCreatureEffects` applies each effect per turn (poison = −1 HP), expires them, and resolves death through the existing `killCreature` (corpse drop + removal). `monstersAct` ticks each living creature once per turn, before it acts; one that succumbs is skipped.
- **Effect-bearing items.** `ItemDef` gains `effect` / `effect_turns`, mirroring trap `TileDef`. A wand now validates with a **damage spec OR an effect** (effect requires `effect_turns > 0`).
- **ZapWand.** Spends a charge, deals damage only when the wand has a damage spec, and — if the target survives — applies the wand's effect. A wand may carry damage, an effect, or both.
- **Data.** `wand_venom` (green `/`, `effect = "poison"`, 8 turns, 5 charges, no damage).

### Scope
Poison is the one creature effect wired this pass (symmetric with the player's). The mechanism is general: future control effects (slow/sleep) add a `case` to the tick and, for turn-skipping, a check in the monster's action. No per-creature status in the HUD yet — the zap message announces the affliction.

### Tests (TDD)
- content: effect-only wand loads; wand with neither damage nor effect rejected; `effect` without `effect_turns` rejected.
- game: creature poison damages + kills via `killCreature`; `Creature.AddEffect` refreshes to longer; zapping venom poisons a live target + spends a charge; a poisoned monster dies across `monstersAct` turns.
- data: `TestEmbeddedVenomWand` golden check.

`gofmt`/`go vet`/`go test ./...`/`go build` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced venom wand that applies a persistent poison effect to targets
  * Poison damage occurs over multiple turns, gradually weakening creatures
  * Creatures now support status effects that persist and tick down each turn

* **Documentation**
  * Added implementation plan for status-effect wands development

<!-- end of auto-generated comment: release notes by coderabbit.ai -->