### PR TITLE
feat: wand of slowing (control affliction)

### DIFF
--- a/docs/superpowers/plans/2026-06-08-slow-wand-15e.md
+++ b/docs/superpowers/plans/2026-06-08-slow-wand-15e.md
@@ -1,0 +1,49 @@
+# Wand of Slowing 15e Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** The control counterpart to the venom wand. A *wand of slowing* afflicts
+its target with a timed **slow**: the creature gains energy at half rate, so it
+moves and attacks half as often — letting you kite it. This exercises the new
+creature-effect system in the turn scheduler (a different path than poison's
+per-tick HP loss).
+
+## Design
+- **slow** is a creature effect with no per-tick HP cost; instead it halves the
+  energy a creature banks each turn. In `monstersAct`, capture whether the
+  creature is slowed **before** ticking its effects (so a 1-turn slow still
+  applies this turn, symmetric with how poison deals its last tick), then add
+  `speedOf(m)/2` instead of `speedOf(m)`.
+- `Creature.HasEffect(kind) bool` answers the slowed check (and is generally
+  useful for future control effects).
+- Register `slow` in `effectLabels` ("Slowed") and `effectVerbs` ("slows") so
+  messages read naturally and a future player-facing slow would have a HUD label.
+- The wand reuses the existing `ItemDef.Effect`/`EffectTurns` path — `ZapWand`
+  already applies any wand effect to a surviving target, so no zap changes.
+
+**Scope:** slow applies to creatures only (the player has no slow source). No new
+content fields. Future control effects (sleep/fear) follow the same shape.
+
+## Task 1: game — slow in the scheduler (TDD)
+**Files:** `internal/game/creature.go` (HasEffect), `internal/game/combat.go`
+(monstersAct energy), `internal/game/effects.go` (labels/verbs), tests
+- Tests first: a slowed default-speed monster moves once over two `monstersAct`
+  turns (vs twice unslowed); zapping a slowing wand leaves the target slowed.
+- Implement `HasEffect`; halve slowed energy gain; add label/verb entries.
+- Commit: `feat(game): slow affliction (half energy) for creatures`
+
+## Task 2: data — wand of slowing (TDD)
+**Files:** `data/items.toml`, `data/data_test.go`
+- Golden test first: `wand_slowing` is a wand with `effect = "slow"`,
+  `effect_turns > 0`, `power > 0`, no damage.
+- Add `wand_slowing` (cyan `/`, `effect = "slow"`, `effect_turns = 10`,
+  `power = 5`).
+- Commit: `feat(data): wand of slowing`
+
+## Task 3: verify, push, PR, loop
+`gofmt -l . && go vet ./... && go test ./... && go build -o /tmp/tsl ./cmd/tsl`.
+Push `slow-wand`; open PR. CodeRabbit loop → merge when green → pull master.
+
+## Done when
+Zap a wand of slowing at a monster: it crawls at half pace for the duration, so
+you can outmaneuver it. Suite green.

--- a/go/data/data_test.go
+++ b/go/data/data_test.go
@@ -118,6 +118,21 @@ func TestEmbeddedVenomWand(t *testing.T) {
 	}
 }
 
+// TestEmbeddedSlowingWand checks the control (slowing) wand loaded.
+func TestEmbeddedSlowingWand(t *testing.T) {
+	c, err := content.Load(Files)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	w := c.Items["wand_slowing"]
+	if w == nil || w.Kind != "wand" || w.Effect != "slow" || w.EffectTurns <= 0 || w.Power <= 0 {
+		t.Errorf("wand_slowing def unexpected: %+v", w)
+	}
+	if w != nil && w.Damage != "" {
+		t.Errorf("wand_slowing should be a pure status wand (no damage), got %q", w.Damage)
+	}
+}
+
 // TestEmbeddedDungeon validates the shipped level graph loads with exactly one
 // start and the expected starter levels.
 func TestEmbeddedDungeon(t *testing.T) {

--- a/go/data/items.toml
+++ b/go/data/items.toml
@@ -174,3 +174,13 @@ kind = "wand"
 effect = "poison"
 effect_turns = 8
 power = 5
+
+# Control wand: slows the target so it moves and attacks at half pace — kite it.
+[item.wand_slowing]
+name = "wand of slowing"
+glyph = "/"
+color = "cyan"
+kind = "wand"
+effect = "slow"
+effect_turns = 10
+power = 5

--- a/go/internal/game/combat.go
+++ b/go/internal/game/combat.go
@@ -174,10 +174,17 @@ func (g *Game) monstersAct() {
 		if g.Level.CreatureAt(m.Pos) != m {
 			continue // already removed this turn
 		}
+		// Capture slow before ticking, so a 1-turn slow still applies this turn
+		// (symmetric with poison dealing its final tick before expiring).
+		slowed := m.HasEffect("slow")
 		if g.tickCreatureEffects(m) {
 			continue // succumbed to its afflictions before acting
 		}
-		m.Energy += speedOf(m)
+		gain := speedOf(m)
+		if slowed {
+			gain /= 2 // slowed creatures bank energy at half rate
+		}
+		m.Energy += gain
 		for m.Energy >= turnCost {
 			m.Energy -= turnCost
 			g.monsterAct(m)

--- a/go/internal/game/combat_test.go
+++ b/go/internal/game/combat_test.go
@@ -181,6 +181,35 @@ func TestZapWandAppliesEffect(t *testing.T) {
 	}
 }
 
+func TestSlowedMonsterActsLessOften(t *testing.T) {
+	g := combatGame() // 10x3 floor, player at (1,1)
+	rat := &Creature{Def: &content.MonsterDef{ID: "rat", Name: "rat", HP: 9, Damage: "1d1"}, Pos: Pos{9, 1}, HP: 9}
+	g.Level.Creatures = append(g.Level.Creatures, rat)
+	rat.AddEffect("slow", 10)
+	start := rat.Pos.X
+	g.monstersAct() // gains 50 energy: not enough to act
+	g.monstersAct() // 50+50=100: acts once
+	if moved := start - rat.Pos.X; moved != 1 {
+		t.Errorf("slowed default-speed monster moved %d tiles in two turns, want 1", moved)
+	}
+}
+
+func TestZapWandSlows(t *testing.T) {
+	g := combatGame()
+	rat := &Creature{Def: &content.MonsterDef{ID: "rat", Name: "rat", HP: 5, Damage: "1d1"}, Pos: Pos{3, 1}, HP: 5}
+	g.Level.Creatures = append(g.Level.Creatures, rat)
+	wand := &Item{Def: &content.ItemDef{Name: "wand of slowing", Kind: "wand", Effect: "slow", EffectTurns: 10}, Charges: 1}
+
+	g.ZapWand(wand, Pos{3, 1})
+
+	if g.Level.CreatureAt(rat.Pos) != rat {
+		t.Fatal("a slowing wand should not kill its target")
+	}
+	if !rat.HasEffect("slow") {
+		t.Error("zapping a slowing wand should slow the target")
+	}
+}
+
 func TestPoisonedMonsterDiesOverTurns(t *testing.T) {
 	g := combatGame() // 10x3 floor, player at (1,1)
 	rat := &Creature{Def: &content.MonsterDef{ID: "rat", Name: "rat", HP: 4, Damage: "1d1"}, Pos: Pos{9, 1}, HP: 4}

--- a/go/internal/game/creature.go
+++ b/go/internal/game/creature.go
@@ -27,6 +27,17 @@ func (m *Creature) AddEffect(kind string, turns int) {
 	m.Effects = addEffect(m.Effects, kind, turns)
 }
 
+// HasEffect reports whether a timed effect of the given kind is currently active
+// on the creature.
+func (m *Creature) HasEffect(kind string) bool {
+	for _, e := range m.Effects {
+		if e.Kind == kind {
+			return true
+		}
+	}
+	return false
+}
+
 // CreatureAt returns the creature standing on p, or nil.
 func (l *Level) CreatureAt(p Pos) *Creature {
 	for _, cr := range l.Creatures {

--- a/go/internal/game/effects.go
+++ b/go/internal/game/effects.go
@@ -12,11 +12,13 @@ type Effect struct {
 var effectLabels = map[string]string{
 	"poison": "Poisoned",
 	"regen":  "Regenerating",
+	"slow":   "Slowed",
 }
 
 // effectVerbs phrases how a source inflicts an effect, for the zap message.
 var effectVerbs = map[string]string{
 	"poison": "poisons",
+	"slow":   "slows",
 }
 
 // effectVerb returns the verb describing inflicting kind, with a generic


### PR DESCRIPTION
## Wand of slowing (#15)

The control counterpart to the venom wand, completing the status-effect wand pair: **poison** (damage over time) + **slow** (control). Builds directly on the creature-effect system from #30 — exercising it in the **turn scheduler** rather than the HP tick.

### What's new
- **`slow`** is a creature affliction with no per-tick HP cost. Instead, a slowed creature banks **half** its energy each turn, so it moves and attacks half as often — you can kite it.
- `monstersAct` captures `slowed` **before** ticking effects (so a 1-turn slow still applies that turn, symmetric with poison dealing its final tick) then gains `speedOf(m)/2`.
- `Creature.HasEffect(kind)` helper; `slow` registered in the effect label ("Slowed") and verb ("slows") maps.
- `ZapWand` already routes any wand effect to a surviving target, so **no zap changes** — the data does the rest.
- **Data:** `wand_slowing` (cyan `/`, `effect = "slow"`, 10 turns, 5 charges, no damage).

### Scope
Slow applies to creatures only (the player has no slow source). No new content fields. Future control effects (sleep/fear) follow the same shape: a `HasEffect` check in the relevant system + label/verb entries + data.

### Tests (TDD)
- game: a slowed default-speed monster moves once over two `monstersAct` turns (vs twice unslowed); zapping a slowing wand leaves the target slowed and alive.
- data: `TestEmbeddedSlowingWand` golden check.

`gofmt`/`go vet`/`go test ./...`/`go build` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the Wand of Slowing, a new wand item that applies the slow status effect to enemies.
  * Introduced the slow effect mechanic, which halves enemy per-turn energy gain and reduces how frequently affected enemies act in combat.
  * Slow status effects are now properly tracked and displayed in the UI during gameplay.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->