### PR TITLE
feat: scrolls + read verb (closes #15)

### DIFF
--- a/docs/superpowers/plans/2026-06-08-scrolls-15f.md
+++ b/docs/superpowers/plans/2026-06-08-scrolls-15f.md
@@ -2,7 +2,7 @@
 
 > **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
 
-**Goal:** The last missing piece of #15 (consumables & magic): **scrolls** and a
+**Goal:** The scroll slice of #15 (consumables & magic): **scrolls** and a
 `read` (`r`) verb. Ship two to make the verb worthwhile — a **scroll of
 teleportation** (blink to a random spot — an escape hatch) and a **scroll of
 magic mapping** (reveal the whole level).
@@ -67,7 +67,8 @@ unidentified yet) or enchant (no enchant stat yet).
   (`use = "reveal"`), glyph `?`. Golden test.
 - Commit: `feat(data): scrolls of teleport + magic mapping`
 - Then: `gofmt -l . && go vet ./... && go test ./... && go build`. Push, PR,
-  CodeRabbit loop → merge → pull master. **Closes #15.**
+  CodeRabbit loop → merge → pull master. **Addresses the scroll slice of #15**
+  (the epic also covers more potions/scrolls, spellbooks, and identify).
 
 ## Done when
 Carry a scroll, press `r`, pick it: teleport whisks you across the level, or the

--- a/docs/superpowers/plans/2026-06-08-scrolls-15f.md
+++ b/docs/superpowers/plans/2026-06-08-scrolls-15f.md
@@ -1,0 +1,74 @@
+# Scrolls 15f Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** The last missing piece of #15 (consumables & magic): **scrolls** and a
+`read` (`r`) verb. Ship two to make the verb worthwhile — a **scroll of
+teleportation** (blink to a random spot — an escape hatch) and a **scroll of
+magic mapping** (reveal the whole level).
+
+## Design
+- **scroll** is a new consumable item kind that, like a potion, names a `use`
+  behavior and is consumed on use. Reuses the existing behavior registry and
+  `PlayerUse` consume-and-pass-a-turn path.
+- **Read verb.** A new `ActRead` (`r`): filter inventory to scrolls → `Menu` →
+  `PlayerUse`. Mirrors the eat (`e`) flow.
+- **World mutation lives in the engine**, not the behaviors package (which only
+  has exported API): add two `Game` methods the behaviors call —
+  - `Teleport() bool`: relocate the player to a uniformly random passable,
+    unoccupied tile (not a portal/altar, not the current tile); report success.
+  - `RevealMap()`: mark every tile `Seen` (remembered/dimmed) without making it
+    currently `Visible`.
+
+**Scope:** two scrolls; instant effects. No scroll-of-identify (nothing is
+unidentified yet) or enchant (no enchant stat yet).
+
+## Task 1: content — scroll kind (TDD)
+**Files:** `internal/content/content.go`, `internal/content/content_test.go`
+- Add `"scroll"` to `validItemKinds`; `validateItem` scroll case needs a
+  non-empty `use` (like potion/food).
+- Tests first: a scroll loads; a use-less scroll is rejected.
+- Commit: `feat(content): scroll item kind`
+
+## Task 2: game — teleport, reveal, read plumbing (TDD)
+**Files:** `internal/game/use.go` (ReadableInventory, PlayerUse scroll case),
+`internal/game/teleport.go` (Teleport, RevealMap), `internal/game/item.go`
+(ValidateItemUses covers scroll), tests
+- `Teleport()` picks uniformly from all passable, unoccupied, non-portal tiles
+  (excluding the player's current tile) via `g.RNG`; sets `g.Player`. No
+  candidates → returns false, no move.
+- `RevealMap()` sets `Seen` on every tile.
+- `ReadableInventory()` filters scrolls; `PlayerUse` adds `"scroll"` to the
+  consumable case; `ValidateItemUses` validates scroll `use`.
+- Tests first: teleport lands on a passable tile different from the start and not
+  on a wall/creature; reveal marks all tiles seen; reading a scroll consumes it
+  and runs its behavior.
+- Commit: `feat(game): teleport + reveal + readable scrolls`
+
+## Task 3: behaviors — teleport + reveal (TDD)
+**Files:** `internal/behaviors/behaviors.go`, `internal/behaviors/behaviors_test.go`
+- `teleport` calls `g.Teleport()` (message depends on success); `reveal` calls
+  `g.RevealMap()`. Register both.
+- Tests first: teleport behavior moves the player; reveal behavior marks tiles
+  seen.
+- Commit: `feat(behaviors): scroll of teleport + magic mapping`
+
+## Task 4: ui — read verb (TDD)
+**Files:** `internal/ui/ui.go`, `internal/ui/ui_test.go`,
+`internal/ui/tcell/screen.go`, `internal/ui/tcell/screen_test.go`
+- `ActRead` in the enum; `Run` ActRead case (scrolls → `Menu` → `PlayerUse`, with
+  a "nothing to read" message when empty). tcell `r` → `ActRead`.
+- Tests first: Run reads a scroll from inventory; tcell `r` maps to `ActRead`.
+- Commit: `feat(ui): read (r) scrolls`
+
+## Task 5: data — two scrolls + golden + ship
+**Files:** `data/items.toml`, `data/data_test.go`
+- `scroll_teleport` (`use = "teleport"`) and `scroll_magic_mapping`
+  (`use = "reveal"`), glyph `?`. Golden test.
+- Commit: `feat(data): scrolls of teleport + magic mapping`
+- Then: `gofmt -l . && go vet ./... && go test ./... && go build`. Push, PR,
+  CodeRabbit loop → merge → pull master. **Closes #15.**
+
+## Done when
+Carry a scroll, press `r`, pick it: teleport whisks you across the level, or the
+map fills in. Suite green.

--- a/go/data/data_test.go
+++ b/go/data/data_test.go
@@ -118,6 +118,20 @@ func TestEmbeddedVenomWand(t *testing.T) {
 	}
 }
 
+// TestEmbeddedScrolls checks the read-verb scrolls loaded.
+func TestEmbeddedScrolls(t *testing.T) {
+	c, err := content.Load(Files)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if s := c.Items["scroll_teleport"]; s == nil || s.Kind != "scroll" || s.Use != "teleport" {
+		t.Errorf("scroll_teleport def unexpected: %+v", s)
+	}
+	if s := c.Items["scroll_magic_mapping"]; s == nil || s.Kind != "scroll" || s.Use != "reveal" {
+		t.Errorf("scroll_magic_mapping def unexpected: %+v", s)
+	}
+}
+
 // TestEmbeddedSlowingWand checks the control (slowing) wand loaded.
 func TestEmbeddedSlowingWand(t *testing.T) {
 	c, err := content.Load(Files)

--- a/go/data/items.toml
+++ b/go/data/items.toml
@@ -184,3 +184,18 @@ kind = "wand"
 effect = "slow"
 effect_turns = 10
 power = 5
+
+# Scrolls (#15) — read (r) to invoke. Glyph ?.
+[item.scroll_teleport]
+name = "scroll of teleportation"
+glyph = "?"
+color = "magenta"
+kind = "scroll"
+use = "teleport"
+
+[item.scroll_magic_mapping]
+name = "scroll of magic mapping"
+glyph = "?"
+color = "blue"
+kind = "scroll"
+use = "reveal"

--- a/go/internal/behaviors/behaviors.go
+++ b/go/internal/behaviors/behaviors.go
@@ -16,6 +16,8 @@ func Registry() map[string]game.Behavior {
 		"eat":          eat,
 		"regenerate":   regenerate,
 		"eat_mushroom": eatMushroom,
+		"teleport":     teleport,
+		"reveal":       reveal,
 	}
 }
 
@@ -54,4 +56,18 @@ func eatMushroom(g *game.Game, it *game.Item) []string {
 	recovered := restoreHP(g, it.Def.Power)
 	g.AddEffect("poison", 6)
 	return []string{fmt.Sprintf("You eat the %s and recover %d HP, but you feel ill.", it.Def.Name, recovered)}
+}
+
+// teleport blinks the player to a random spot on the level (an escape hatch).
+func teleport(g *game.Game, it *game.Item) []string {
+	if g.Teleport() {
+		return []string{fmt.Sprintf("You read the %s and blink across the dungeon.", it.Def.Name)}
+	}
+	return []string{fmt.Sprintf("You read the %s, but nothing happens.", it.Def.Name)}
+}
+
+// reveal maps the whole level (a scroll of magic mapping).
+func reveal(g *game.Game, it *game.Item) []string {
+	g.RevealMap()
+	return []string{fmt.Sprintf("You read the %s; the layout floods into your mind.", it.Def.Name)}
 }

--- a/go/internal/behaviors/behaviors_test.go
+++ b/go/internal/behaviors/behaviors_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/c0ze/tsl/internal/content"
 	"github.com/c0ze/tsl/internal/game"
+	"github.com/c0ze/tsl/internal/rng"
 )
 
 func TestHealCapsAtMax(t *testing.T) {
@@ -50,6 +51,37 @@ func TestRegenerateAddsEffect(t *testing.T) {
 	regen(g, &game.Item{Def: &content.ItemDef{Name: "potion of regeneration", Power: 8}})
 	if len(g.Effects) != 1 || g.Effects[0].Kind != "regen" || g.Effects[0].Turns != 8 {
 		t.Errorf("expected a regen effect for 8 turns, got %v", g.Effects)
+	}
+}
+
+func TestTeleportBehaviorMovesPlayer(t *testing.T) {
+	tele, ok := Registry()["teleport"]
+	if !ok {
+		t.Fatal("teleport behavior not registered")
+	}
+	floor := &content.TileDef{ID: "floor", Glyph: ".", Color: content.ColorNormal, Passable: true, Transparent: true}
+	g := &game.Game{Level: game.NewLevel(8, 3, floor), Player: game.Pos{X: 1, Y: 1}, RNG: rng.NewWithSeed(1)}
+	start := g.Player
+	msgs := tele(g, &game.Item{Def: &content.ItemDef{Name: "scroll of teleportation"}})
+	if g.Player == start {
+		t.Error("teleport scroll should move the player")
+	}
+	if len(msgs) == 0 {
+		t.Error("teleport should return a message")
+	}
+}
+
+func TestRevealBehaviorMarksSeen(t *testing.T) {
+	reveal, ok := Registry()["reveal"]
+	if !ok {
+		t.Fatal("reveal behavior not registered")
+	}
+	floor := &content.TileDef{ID: "floor", Glyph: ".", Color: content.ColorNormal, Passable: true, Transparent: true}
+	lvl := game.NewLevel(6, 3, floor)
+	g := &game.Game{Level: lvl, Player: game.Pos{X: 1, Y: 1}}
+	reveal(g, &game.Item{Def: &content.ItemDef{Name: "scroll of magic mapping"}})
+	if !lvl.At(game.Pos{X: 4, Y: 2}).Seen {
+		t.Error("magic mapping should mark distant tiles seen")
 	}
 }
 

--- a/go/internal/content/content.go
+++ b/go/internal/content/content.go
@@ -94,7 +94,7 @@ func (i *ItemDef) Rune() rune {
 	return r
 }
 
-var validItemKinds = map[string]bool{"potion": true, "weapon": true, "armor": true, "food": true, "wand": true}
+var validItemKinds = map[string]bool{"potion": true, "weapon": true, "armor": true, "food": true, "wand": true, "scroll": true}
 
 // SpawnEntry is one weighted entry in a level's monster spawn table.
 type SpawnEntry struct {
@@ -366,6 +366,10 @@ func validateItem(i *ItemDef) error {
 	case "potion":
 		if strings.TrimSpace(i.Use) == "" {
 			return fmt.Errorf("potion must have a non-empty use")
+		}
+	case "scroll":
+		if strings.TrimSpace(i.Use) == "" {
+			return fmt.Errorf("scroll must have a non-empty use")
 		}
 	case "weapon":
 		if !validDamageSpec(i.Damage) {

--- a/go/internal/content/content_test.go
+++ b/go/internal/content/content_test.go
@@ -483,3 +483,21 @@ func TestLoadRejectsItemEffectWithoutTurns(t *testing.T) {
 		t.Fatal("expected error: item effect needs effect_turns > 0")
 	}
 }
+
+func TestLoadScrollItem(t *testing.T) {
+	dir := writeItemsFixture(t, "[item.tele]\nname=\"scroll of teleportation\"\nglyph=\"?\"\ncolor=\"normal\"\nkind=\"scroll\"\nuse=\"teleport\"\n")
+	c, err := Load(os.DirFS(dir))
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if s := c.Items["tele"]; s == nil || s.Kind != "scroll" || s.Use != "teleport" {
+		t.Errorf("scroll def unexpected: %+v", s)
+	}
+}
+
+func TestLoadRejectsScrollWithoutUse(t *testing.T) {
+	dir := writeItemsFixture(t, "[item.blank]\nname=\"blank scroll\"\nglyph=\"?\"\ncolor=\"normal\"\nkind=\"scroll\"\n")
+	if _, err := Load(os.DirFS(dir)); err == nil {
+		t.Fatal("expected error: scroll needs a non-empty use")
+	}
+}

--- a/go/internal/game/item.go
+++ b/go/internal/game/item.go
@@ -43,7 +43,7 @@ func (l *Level) RemoveItem(it *Item) {
 // doing nothing at runtime.
 func ValidateItemUses(c *content.Content, reg map[string]Behavior) error {
 	for id, it := range c.Items {
-		if it.Kind == "potion" || it.Kind == "food" {
+		if it.Kind == "potion" || it.Kind == "food" || it.Kind == "scroll" {
 			if _, ok := reg[it.Use]; !ok {
 				return fmt.Errorf("item %q references unknown behavior %q", id, it.Use)
 			}

--- a/go/internal/game/teleport.go
+++ b/go/internal/game/teleport.go
@@ -1,0 +1,30 @@
+package game
+
+// Teleport relocates the player to a uniformly random passable, unoccupied tile
+// (never the current tile, a portal, or a creature's tile). It reports whether
+// the player moved; with no valid destination it stays put and returns false.
+func (g *Game) Teleport() bool {
+	var candidates []Pos
+	for y := 0; y < g.Level.H; y++ {
+		for x := 0; x < g.Level.W; x++ {
+			p := Pos{X: x, Y: y}
+			if p == g.Player || !g.Level.Passable(p) || g.Level.CreatureAt(p) != nil || g.Level.PortalAt(p) != nil {
+				continue
+			}
+			candidates = append(candidates, p)
+		}
+	}
+	if len(candidates) == 0 {
+		return false
+	}
+	g.Player = candidates[g.RNG.Intn(len(candidates))]
+	return true
+}
+
+// RevealMap marks every tile on the current level as Seen (remembered/dimmed)
+// without making it currently Visible — the effect of a scroll of magic mapping.
+func (g *Game) RevealMap() {
+	for i := range g.Level.tiles {
+		g.Level.tiles[i].Seen = true
+	}
+}

--- a/go/internal/game/teleport_test.go
+++ b/go/internal/game/teleport_test.go
@@ -1,0 +1,90 @@
+package game
+
+import (
+	"testing"
+
+	"github.com/c0ze/tsl/internal/content"
+	"github.com/c0ze/tsl/internal/rng"
+)
+
+func TestTeleportMovesToPassableTile(t *testing.T) {
+	g := combatGame() // 10x3 all floor, player at (1,1)
+	start := g.Player
+	if !g.Teleport() {
+		t.Fatal("teleport should succeed on an open level")
+	}
+	if g.Player == start {
+		t.Error("teleport should move the player off the starting tile")
+	}
+	if !g.Level.Passable(g.Player) {
+		t.Errorf("teleport landed on an impassable tile %v", g.Player)
+	}
+	if g.Level.CreatureAt(g.Player) != nil {
+		t.Error("teleport should not land on a creature")
+	}
+}
+
+func TestTeleportLandsOnFloorAmongWalls(t *testing.T) {
+	c := testContent()
+	rows := []string{
+		"#####",
+		"#@.##",
+		"##..#",
+		"#####",
+	}
+	lvl, start, err := ParseLevel(c, rows, map[rune]string{'#': "wall", '@': "floor", '.': "floor"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	g := &Game{Content: c, Level: lvl, Player: start, RNG: rng.NewWithSeed(1)}
+	for i := 0; i < 30; i++ {
+		g.Teleport()
+		if !g.Level.Passable(g.Player) {
+			t.Fatalf("teleport landed on a wall at %v", g.Player)
+		}
+	}
+}
+
+func TestRevealMapMarksAllSeen(t *testing.T) {
+	g := combatGame()
+	g.RevealMap()
+	for y := 0; y < g.Level.H; y++ {
+		for x := 0; x < g.Level.W; x++ {
+			if !g.Level.At(Pos{X: x, Y: y}).Seen {
+				t.Fatalf("tile %d,%d not marked seen after RevealMap", x, y)
+			}
+		}
+	}
+}
+
+func TestReadableInventoryFiltersScrolls(t *testing.T) {
+	g := combatGame()
+	g.Inventory = []*Item{
+		{Def: &content.ItemDef{Name: "potion", Kind: "potion", Use: "heal"}},
+		{Def: &content.ItemDef{Name: "scroll", Kind: "scroll", Use: "teleport"}},
+	}
+	r := g.ReadableInventory()
+	if len(r) != 1 || r[0].Def.Kind != "scroll" {
+		t.Errorf("ReadableInventory = %v, want exactly one scroll", r)
+	}
+}
+
+func TestPlayerUseScrollConsumesAndRuns(t *testing.T) {
+	g := combatGame()
+	ran := false
+	g.Behaviors = map[string]Behavior{"teleport": func(gg *Game, it *Item) []string {
+		ran = true
+		return []string{"zap"}
+	}}
+	sc := &Item{Def: &content.ItemDef{Name: "scroll", Kind: "scroll", Use: "teleport"}}
+	g.Inventory = append(g.Inventory, sc)
+
+	g.PlayerUse(sc)
+
+	if !ran {
+		t.Error("reading a scroll should invoke its behavior")
+	}
+	if g.hasInventoryItem(sc) {
+		t.Error("a read scroll should be consumed")
+	}
+}

--- a/go/internal/game/use.go
+++ b/go/internal/game/use.go
@@ -51,7 +51,7 @@ func (g *Game) PlayerUse(it *Item) {
 	case "armor":
 		g.Armor = it
 		g.log("You wear the %s.", it.Def.Name)
-	case "potion", "food":
+	case "potion", "food", "scroll":
 		if b, ok := g.Behaviors[it.Def.Use]; ok {
 			g.Messages = append(g.Messages, b(g, it)...)
 		} else {
@@ -101,4 +101,16 @@ func (g *Game) WandInventory() []*Item {
 		}
 	}
 	return wands
+}
+
+// ReadableInventory returns the scroll items the player is carrying, in inventory
+// order. The UI uses it to build the "read what?" menu.
+func (g *Game) ReadableInventory() []*Item {
+	var scrolls []*Item
+	for _, it := range g.Inventory {
+		if it.Def != nil && it.Def.Kind == "scroll" {
+			scrolls = append(scrolls, it)
+		}
+	}
+	return scrolls
 }

--- a/go/internal/ui/tcell/screen.go
+++ b/go/internal/ui/tcell/screen.go
@@ -131,6 +131,8 @@ func keyToAction(ev *tc.EventKey) (ui.Action, bool) {
 		return ui.Action{Kind: ui.ActZap}, true
 	case 'e':
 		return ui.Action{Kind: ui.ActEat}, true
+	case 'r':
+		return ui.Action{Kind: ui.ActRead}, true
 	case '>':
 		return ui.Action{Kind: ui.ActTravel}, true
 	}

--- a/go/internal/ui/tcell/screen_test.go
+++ b/go/internal/ui/tcell/screen_test.go
@@ -47,6 +47,7 @@ func TestKeyToAction(t *testing.T) {
 		{tc.NewEventKey(tc.KeyRune, 'q', tc.ModNone), ui.Action{Kind: ui.ActQuit}, true},
 		{tc.NewEventKey(tc.KeyRune, 'e', tc.ModNone), ui.Action{Kind: ui.ActEat}, true},
 		{tc.NewEventKey(tc.KeyRune, 'z', tc.ModNone), ui.Action{Kind: ui.ActZap}, true},
+		{tc.NewEventKey(tc.KeyRune, 'r', tc.ModNone), ui.Action{Kind: ui.ActRead}, true},
 		{tc.NewEventKey(tc.KeyRune, 'X', tc.ModNone), ui.Action{}, false},
 	}
 	for _, tt := range cases {

--- a/go/internal/ui/ui.go
+++ b/go/internal/ui/ui.go
@@ -41,6 +41,7 @@ const (
 	ActTravel
 	ActEat
 	ActZap
+	ActRead
 )
 
 // Action is a decoded player intent. Dir is meaningful only when Kind==ActMove.
@@ -181,6 +182,19 @@ func Run(g *game.Game, p Prompter, r Renderer) error {
 			}
 			if idx, ok := p.Menu(MenuSpec{Title: "Eat what?", Items: names}); ok && idx >= 0 && idx < len(food) {
 				g.PlayerUse(food[idx])
+			}
+		case ActRead:
+			scrolls := g.ReadableInventory()
+			if len(scrolls) == 0 {
+				g.Messages = append(g.Messages, "You have nothing to read.")
+				break
+			}
+			names := make([]string, len(scrolls))
+			for i, it := range scrolls {
+				names[i] = it.Def.Name
+			}
+			if idx, ok := p.Menu(MenuSpec{Title: "Read what?", Items: names}); ok && idx >= 0 && idx < len(scrolls) {
+				g.PlayerUse(scrolls[idx])
 			}
 		case ActZap:
 			wands := g.WandInventory()

--- a/go/internal/ui/ui_test.go
+++ b/go/internal/ui/ui_test.go
@@ -278,6 +278,37 @@ func TestRunEatHealsFromInventory(t *testing.T) {
 	}
 }
 
+func TestRunReadScrollFromInventory(t *testing.T) {
+	g := testGame(t, []string{".....", ".@...", "....."})
+	read := false
+	g.Behaviors = map[string]game.Behavior{"teleport": func(gg *game.Game, it *game.Item) []string {
+		read = true
+		return []string{"blink"}
+	}}
+	g.Inventory = append(g.Inventory, &game.Item{Def: &content.ItemDef{Name: "scroll of teleportation", Kind: "scroll", Use: "teleport"}})
+	p := &menuPrompter{actions: []Action{{Kind: ActRead}, {Kind: ActQuit}}, pick: 0}
+	if err := Run(g, p, &nullRenderer{}); err != nil {
+		t.Fatal(err)
+	}
+	if !read {
+		t.Error("reading a scroll should invoke its behavior")
+	}
+	if len(g.Inventory) != 0 {
+		t.Errorf("the scroll should be consumed, inventory = %v", g.Inventory)
+	}
+}
+
+func TestRunReadWithNoScrollReports(t *testing.T) {
+	g := testGame(t, []string{".@."})
+	p := &scriptPrompter{actions: []Action{{Kind: ActRead}, {Kind: ActQuit}}}
+	if err := Run(g, p, &nullRenderer{}); err != nil {
+		t.Fatal(err)
+	}
+	if len(g.Messages) == 0 || !strings.Contains(g.Messages[len(g.Messages)-1], "nothing to read") {
+		t.Errorf("expected a 'nothing to read' message, got %v", g.Messages)
+	}
+}
+
 func TestRunEatWithNoFoodReports(t *testing.T) {
 	g := testGame(t, []string{".@."})
 	p := &scriptPrompter{actions: []Action{{Kind: ActEat}, {Kind: ActQuit}}}


### PR DESCRIPTION
## Scrolls + the read (`r`) verb — scroll slice of #15

Ships the **scrolls** slice of #15 (Consumables & magic), read with a new `r` verb. Two scrolls, to make the verb worthwhile. The epic stays open — it also covers more potions/scrolls, spellbooks, and identify.

### What's new
- **`scroll`** item kind — a consumable that names a `use` behavior and is consumed on read, reusing the existing behavior registry + `PlayerUse` path.
- **Read verb** — `ActRead` (`r`): filter inventory to scrolls → `Menu` → `PlayerUse` (mirrors eat/`e`). "Nothing to read" when empty.
- **Engine world-mutation methods** (kept in `game`, not the behaviors package which only has exported API):
  - `Teleport()` — relocate the player to a uniformly random passable, unoccupied, non-portal tile; reports success.
  - `RevealMap()` — mark every tile `Seen` (remembered/dimmed) without making it currently visible.
- **Behaviors** `teleport` + `reveal` call those methods.
- **Data:** `scroll_teleport` (blink — an escape hatch) and `scroll_magic_mapping` (reveal the layout), glyph `?`.

### Tests (TDD)
- content: scroll loads; use-less scroll rejected.
- game: teleport lands on a passable, creature-free tile off the start (incl. a walls fixture); reveal marks all tiles seen; reading a scroll consumes it + runs its behavior; `ReadableInventory` filters scrolls.
- behaviors: teleport moves the player; reveal marks tiles seen.
- ui: Run reads a scroll from inventory (+ empty-handed message); tcell `r` → `ActRead`.
- data: golden check for both scrolls. The shipped-data boot test validates the scroll `use` behaviors are registered.

`gofmt`/`go vet`/`go test ./...`/`go build` all green.

Part of #15 (scroll slice).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Two consumable scrolls: Teleportation and Magic Mapping.
  * Added a "read" action (press 'r') to open readable items from inventory.
  * Teleport scroll relocates player to a valid passable tile; Magic Mapping reveals the level.

* **Documentation**
  * Added an implementation plan describing scope, tasks, and completion criteria.

* **Tests**
  * New content, behavior, gameplay, and UI tests covering scrolls and related actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->