### PR TITLE
feat: doors (open on bump, block sight) — #18

### DIFF
--- a/docs/superpowers/plans/2026-06-08-doors-18b.md
+++ b/docs/superpowers/plans/2026-06-08-doors-18b.md
@@ -1,0 +1,69 @@
+# Doors 18b Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** The doors slice of #18 (hazards & systems). Closed doors block both
+movement **and** sight (they hide the room beyond), and open when something bumps
+them. Because FOV occludes on tile transparency, a closed door darkens what's
+behind it for free; opening it reveals the room.
+
+## Design
+- **Doors are tiles.** `door_closed` is impassable + opaque; `door_open` is
+  passable + transparent. A closed door names what it becomes via a new
+  `TileDef.OpensTo` (`opens_to = "door_open"`).
+- **Open on bump.** `Game.openDoor(p)` replaces a closed-door tile with its
+  `OpensTo` tile and reports success (false for plain walls). The player's
+  blocked step into a closed door opens it and spends the turn (you walk through
+  next step — the faithful "opening takes an action" feel). Monsters open doors
+  in their path the same way, so a closed door is a brief delay, never an exploit.
+- **Placement.** The generator converts doorway tiles — floor on a room's
+  boundary ring, where a corridor punched through the wall — into closed doors,
+  gated by a per-level `LevelDef.Doors` flag.
+
+**Scope:** open-only (no close/lock/search verbs, no secret doors yet). Monsters
+open doors but don't close them. Doors never overwrite stairs, the altar, traps,
+or the start tile.
+
+## Task 1: content — door tiles (TDD)
+**Files:** `internal/content/content.go`, `internal/content/content_test.go`
+- Add `OpensTo string` (`opens_to`) to `TileDef`. Validate: when set, it must
+  reference a defined tile.
+- Tests first: a door tile with `opens_to` loads; an `opens_to` to an unknown
+  tile is rejected.
+- Commit: `feat(content): tile opens_to (doors)`
+
+## Task 2: game — open on bump (TDD)
+**Files:** `internal/game/combat.go` (PlayerStep, stepToward), `internal/game/door.go`
+(openDoor), tests
+- `openDoor(p) bool`: closed door → `Level.Set(p, OpensTo tile)`, true; else false.
+- `PlayerStep`: when the move is blocked and `openDoor(dst)` succeeds, log "You
+  open the door." and pass the turn (no move this step).
+- `stepToward`: when a monster's step is blocked by a door (not a creature/the
+  player), open it (consumes its action).
+- Tests first: bumping a closed door opens it (tile becomes passable) and passes
+  a turn; a monster opens a door between it and the player; bumping a plain wall
+  still does nothing.
+- Commit: `feat(game): open doors on bump (player + monsters)`
+
+## Task 3: gen — doorway placement (TDD)
+**Files:** `internal/content/content.go` (LevelDef.Doors), `internal/gen/gen.go`
+(placeDoors), `internal/gen/gen_test.go`
+- `LevelDef.Doors bool`. `placeDoors` walks each room's boundary ring and turns
+  floor doorways into `door_closed` (never the start, a portal, or a non-floor
+  special tile). Called from `LevelFromDef` when `def.Doors`.
+- Test first: a def with `Doors=true` (+ door tiles in content) yields at least
+  one `door_closed` tile, all on otherwise-passable doorways.
+- Commit: `feat(gen): place doors in room doorways`
+
+## Task 4: data — door tiles + golden + ship
+**Files:** `data/tiles.toml`, `data/levels.toml`, `data/data_test.go`
+- `door_closed` (glyph `+`, impassable, opaque, `opens_to = "door_open"`) and
+  `door_open` (glyph `'`, passable, transparent). Enable `doors = true` on a few
+  levels. Golden test: door tiles present; ≥1 level has doors.
+- Commit: `feat(data): doors on some levels`
+- Then: `gofmt -l . && go vet ./... && go test ./... && go build`. Push, PR,
+  CodeRabbit loop → merge → pull master. Advances #18 (doors slice).
+
+## Done when
+A `+` blocks your path and hides the room behind it; bump it, it swings open
+(`'`) and the room lights up. Monsters open doors to chase you. Suite green.

--- a/go/data/data_test.go
+++ b/go/data/data_test.go
@@ -118,6 +118,30 @@ func TestEmbeddedVenomWand(t *testing.T) {
 	}
 }
 
+// TestEmbeddedDoors checks the door tiles loaded and that some levels use them.
+func TestEmbeddedDoors(t *testing.T) {
+	c, err := content.Load(Files)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	dc := c.Tiles["door_closed"]
+	if dc == nil || dc.Passable || dc.Transparent || dc.OpensTo != "door_open" {
+		t.Errorf("door_closed tile unexpected: %+v", dc)
+	}
+	if do := c.Tiles["door_open"]; do == nil || !do.Passable || !do.Transparent {
+		t.Errorf("door_open tile unexpected: %+v", do)
+	}
+	doored := false
+	for _, l := range c.Levels {
+		if l.Doors {
+			doored = true
+		}
+	}
+	if !doored {
+		t.Error("expected at least one level with doors enabled")
+	}
+}
+
 // TestEmbeddedScrolls checks the read-verb scrolls loaded.
 func TestEmbeddedScrolls(t *testing.T) {
 	c, err := content.Load(Files)

--- a/go/data/levels.toml
+++ b/go/data/levels.toml
@@ -71,6 +71,7 @@ height = 24
 links = ["catacombs", "drowned_city"]
 monsters = 10
 traps = 4
+doors = true
 [[level.laboratory.spawn]]
 monster = "gnoblin"
 weight = 2
@@ -90,6 +91,7 @@ width = 60
 height = 24
 links = ["ominous_cave", "frozen_vault"]
 monsters = 10
+doors = true
 [[level.comm_hub.spawn]]
 monster = "gnoblin"
 weight = 3
@@ -141,6 +143,7 @@ width = 60
 height = 24
 links = ["comm_hub", "dragons_lair"]
 monsters = 10
+doors = true
 [[level.frozen_vault.spawn]]
 monster = "scarecrow"
 weight = 3
@@ -177,6 +180,7 @@ links = ["dragons_lair"]
 monsters = 12
 altar = true
 boss = "elder_mummylich"
+doors = true
 [[level.chapel.spawn]]
 monster = "ghoul"
 weight = 3

--- a/go/data/tiles.toml
+++ b/go/data/tiles.toml
@@ -34,3 +34,18 @@ passable = true
 transparent = true
 effect = "poison"
 effect_turns = 5
+
+# Doors (#18). A closed door blocks movement and sight; bumping it opens it into
+# door_open (passable + transparent). Placed in room doorways on doored levels.
+[tile.door_closed]
+glyph = "+"
+color = "brown"
+passable = false
+transparent = false
+opens_to = "door_open"
+
+[tile.door_open]
+glyph = "'"
+color = "brown"
+passable = true
+transparent = true

--- a/go/internal/content/content.go
+++ b/go/internal/content/content.go
@@ -116,6 +116,7 @@ type LevelDef struct {
 	Altar    bool         `toml:"altar"` // place an ascension altar (a win tile)
 	Boss     string       `toml:"boss"`  // a guaranteed monster placed once on the level
 	Traps    int          `toml:"traps"` // number of dart_trap tiles to scatter
+	Doors    bool         `toml:"doors"` // place closed doors in room doorways
 }
 
 // Content is the fully-loaded, validated game content.

--- a/go/internal/content/content.go
+++ b/go/internal/content/content.go
@@ -41,6 +41,7 @@ type TileDef struct {
 	Win         bool   `toml:"win"`          // stepping onto this tile wins (the ascension altar)
 	Effect      string `toml:"effect"`       // status effect applied when stepped on ("" = none)
 	EffectTurns int    `toml:"effect_turns"` // duration of Effect
+	OpensTo     string `toml:"opens_to"`     // tile id this becomes when opened ("" = not a door)
 }
 
 // Rune returns the tile's glyph as a rune. Glyph is guaranteed by validateTile
@@ -165,6 +166,9 @@ func Load(fsys fs.FS) (*Content, error) {
 	if len(c.Tiles) == 0 {
 		return nil, fmt.Errorf("tiles.toml: no tiles defined")
 	}
+	if err := validateTileRefs(c); err != nil {
+		return nil, err
+	}
 
 	var mf monstersFile
 	if ok, err := decodeOptionalTOML(fsys, "monsters.toml", &mf); err != nil {
@@ -209,6 +213,20 @@ func Load(fsys fs.FS) (*Content, error) {
 		return nil, err
 	}
 	return c, nil
+}
+
+// validateTileRefs checks that every tile's opens_to (when set) names a defined
+// tile, so a door always has an open state to become.
+func validateTileRefs(c *Content) error {
+	for id, t := range c.Tiles {
+		if t.OpensTo == "" {
+			continue
+		}
+		if _, ok := c.Tiles[t.OpensTo]; !ok {
+			return fmt.Errorf("tile %q: opens_to %q is not a defined tile", id, t.OpensTo)
+		}
+	}
+	return nil
 }
 
 // validateCorpseRefs checks that every monster's corpse (when set) names a

--- a/go/internal/content/content_test.go
+++ b/go/internal/content/content_test.go
@@ -484,6 +484,28 @@ func TestLoadRejectsItemEffectWithoutTurns(t *testing.T) {
 	}
 }
 
+func TestLoadDoorTile(t *testing.T) {
+	dir := writeTiles(t, "[tile.floor]\nglyph=\".\"\ncolor=\"normal\"\npassable=true\ntransparent=true\n"+
+		"[tile.door_open]\nglyph=\"'\"\ncolor=\"brown\"\npassable=true\ntransparent=true\n"+
+		"[tile.door_closed]\nglyph=\"+\"\ncolor=\"brown\"\nopens_to=\"door_open\"\n")
+	c, err := Load(os.DirFS(dir))
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	d := c.Tiles["door_closed"]
+	if d == nil || d.OpensTo != "door_open" || d.Passable || d.Transparent {
+		t.Errorf("door_closed def unexpected: %+v", d)
+	}
+}
+
+func TestLoadRejectsBadOpensTo(t *testing.T) {
+	dir := writeTiles(t, "[tile.floor]\nglyph=\".\"\ncolor=\"normal\"\npassable=true\ntransparent=true\n"+
+		"[tile.door_closed]\nglyph=\"+\"\ncolor=\"brown\"\nopens_to=\"nope\"\n")
+	if _, err := Load(os.DirFS(dir)); err == nil {
+		t.Fatal("expected error: opens_to references an unknown tile")
+	}
+}
+
 func TestLoadScrollItem(t *testing.T) {
 	dir := writeItemsFixture(t, "[item.tele]\nname=\"scroll of teleportation\"\nglyph=\"?\"\ncolor=\"normal\"\nkind=\"scroll\"\nuse=\"teleport\"\n")
 	c, err := Load(os.DirFS(dir))

--- a/go/internal/game/combat.go
+++ b/go/internal/game/combat.go
@@ -54,6 +54,9 @@ func (g *Game) PlayerStep(d Direction) {
 			g.AddEffect(tile.Effect, tile.EffectTurns)
 			g.log("You trigger a trap!")
 		}
+	} else if g.openDoor(dst) { // blocked by a closed door: open it (costs the turn)
+		g.log("You open the door.")
+		acted = true
 	}
 	if acted { // a blocked move into a wall doesn't pass the turn
 		g.monstersAct()
@@ -222,7 +225,11 @@ func (g *Game) stepToward(m *Creature, target Pos) {
 		}
 	}
 	dst := Pos{m.Pos.X + step(m.Pos.X, target.X), m.Pos.Y + step(m.Pos.Y, target.Y)}
-	if dst == g.Player || !g.Level.Passable(dst) || g.Level.CreatureAt(dst) != nil {
+	if dst == g.Player || g.Level.CreatureAt(dst) != nil {
+		return
+	}
+	if !g.Level.Passable(dst) {
+		g.openDoor(dst) // open a door in the way (spends this move); a plain wall is a no-op
 		return
 	}
 	m.Pos = dst

--- a/go/internal/game/door.go
+++ b/go/internal/game/door.go
@@ -1,0 +1,21 @@
+package game
+
+// openDoor opens a closed door at p — a tile whose def names an OpensTo state —
+// by replacing it with that open-state tile. It reports whether a door was
+// actually opened, returning false for any non-door tile (e.g. a plain wall),
+// so callers can use it as the "is this a door?" branch of a blocked step.
+func (g *Game) openDoor(p Pos) bool {
+	if !g.Level.InBounds(p) {
+		return false
+	}
+	t := g.Level.At(p)
+	if t.Def.OpensTo == "" {
+		return false
+	}
+	open, ok := g.Content.Tiles[t.Def.OpensTo]
+	if !ok {
+		return false
+	}
+	g.Level.Set(p, open)
+	return true
+}

--- a/go/internal/game/door_test.go
+++ b/go/internal/game/door_test.go
@@ -1,0 +1,67 @@
+package game
+
+import (
+	"testing"
+
+	"github.com/c0ze/tsl/internal/content"
+	"github.com/c0ze/tsl/internal/rng"
+)
+
+func doorContent() *content.Content {
+	return &content.Content{Tiles: map[string]*content.TileDef{
+		"floor":       {ID: "floor", Glyph: ".", Color: content.ColorNormal, Passable: true, Transparent: true},
+		"wall":        {ID: "wall", Glyph: "#", Color: content.ColorNormal},
+		"door_open":   {ID: "door_open", Glyph: "'", Color: content.ColorBrown, Passable: true, Transparent: true},
+		"door_closed": {ID: "door_closed", Glyph: "+", Color: content.ColorBrown, OpensTo: "door_open"},
+	}}
+}
+
+func doorGame() *Game {
+	c := doorContent()
+	l := NewLevel(5, 3, c.Tiles["floor"])
+	return &Game{Content: c, Level: l, Player: Pos{1, 1}, RNG: rng.NewWithSeed(1), PlayerHP: 10, PlayerMax: 10}
+}
+
+func TestBumpOpensDoor(t *testing.T) {
+	g := doorGame()
+	g.Level.Set(Pos{2, 1}, g.Content.Tiles["door_closed"])
+
+	g.PlayerStep(DirE) // bump the door east of the player
+
+	if g.Player != (Pos{1, 1}) {
+		t.Errorf("player should not step onto a just-opened door, at %v", g.Player)
+	}
+	if g.Level.At(Pos{2, 1}).Def.ID != "door_open" {
+		t.Errorf("bumping a closed door should open it, got %q", g.Level.At(Pos{2, 1}).Def.ID)
+	}
+	if !g.Level.Passable(Pos{2, 1}) {
+		t.Error("an opened door should be passable")
+	}
+}
+
+func TestMonsterOpensDoor(t *testing.T) {
+	g := doorGame()
+	g.Level.Set(Pos{2, 1}, g.Content.Tiles["door_closed"])
+	rat := &Creature{Def: &content.MonsterDef{ID: "rat", Name: "rat", HP: 3, Damage: "1d1"}, Pos: Pos{3, 1}, HP: 3}
+	g.Level.Creatures = append(g.Level.Creatures, rat)
+
+	g.monstersAct() // rat steps toward the player, blocked by the closed door
+
+	if g.Level.At(Pos{2, 1}).Def.ID != "door_open" {
+		t.Errorf("a monster should open a door in its path, got %q", g.Level.At(Pos{2, 1}).Def.ID)
+	}
+}
+
+func TestBumpWallDoesNotOpen(t *testing.T) {
+	g := doorGame()
+	g.Level.Set(Pos{2, 1}, g.Content.Tiles["wall"])
+
+	g.PlayerStep(DirE)
+
+	if g.Level.At(Pos{2, 1}).Def.ID != "wall" {
+		t.Error("bumping a plain wall should not open anything")
+	}
+	if g.Player != (Pos{1, 1}) {
+		t.Errorf("player should not move into a wall, at %v", g.Player)
+	}
+}

--- a/go/internal/gen/gen.go
+++ b/go/internal/gen/gen.go
@@ -216,12 +216,69 @@ func LevelFromDef(r *rng.MT, c *content.Content, def *content.LevelDef) (*game.L
 			lvl.Creatures = append(lvl.Creatures, &game.Creature{Def: bdef, Pos: pos, HP: bdef.HP})
 		}
 	}
+	if def.Doors {
+		placeDoors(c, lvl, rooms)
+	}
 	placeSpawnMonsters(r, c, lvl, rooms, def)
 	placeItems(r, c, lvl, rooms, lvl.Start)
 	if def.Traps > 0 {
 		placeTraps(r, c, lvl, rooms, def.Traps)
 	}
 	return lvl, nil
+}
+
+// placeDoors converts each room's doorways — single-tile passages where a
+// corridor punched through the room's wall ring — into closed doors. Doorways
+// are detected on the original (door-free) layout so placement order can't
+// affect the result; stairs, the altar, traps, portals, and the start tile are
+// never overwritten.
+func placeDoors(c *content.Content, lvl *game.Level, rooms []rect) {
+	closed := c.Tiles["door_closed"]
+	if closed == nil {
+		return
+	}
+	doorways := map[game.Pos]bool{}
+	for _, room := range rooms {
+		for _, p := range boundaryRing(room) {
+			if !lvl.InBounds(p) || lvl.At(p).Def.ID != "floor" {
+				continue // only plain corridor floor becomes a door
+			}
+			if p == lvl.Start || lvl.PortalAt(p) != nil {
+				continue
+			}
+			if isDoorway(lvl, p) {
+				doorways[p] = true
+			}
+		}
+	}
+	for p := range doorways {
+		lvl.Set(p, closed)
+	}
+}
+
+// boundaryRing returns the tiles one step outside a room's interior (the wall
+// ring), where corridors break through to form doorways.
+func boundaryRing(r rect) []game.Pos {
+	ps := make([]game.Pos, 0, 2*(r.w+r.h)+4)
+	for x := r.x - 1; x <= r.x+r.w; x++ {
+		ps = append(ps, game.Pos{X: x, Y: r.y - 1}, game.Pos{X: x, Y: r.y + r.h})
+	}
+	for y := r.y; y < r.y+r.h; y++ {
+		ps = append(ps, game.Pos{X: r.x - 1, Y: y}, game.Pos{X: r.x + r.w, Y: y})
+	}
+	return ps
+}
+
+// isDoorway reports whether p is a clean single-tile passage: passable on
+// exactly one axis (the corridor through the wall) with walls flanking it.
+func isDoorway(lvl *game.Level, p game.Pos) bool {
+	up := lvl.Passable(game.Pos{X: p.X, Y: p.Y - 1})
+	down := lvl.Passable(game.Pos{X: p.X, Y: p.Y + 1})
+	left := lvl.Passable(game.Pos{X: p.X - 1, Y: p.Y})
+	right := lvl.Passable(game.Pos{X: p.X + 1, Y: p.Y})
+	horizontal := left && right && !up && !down
+	vertical := up && down && !left && !right
+	return horizontal || vertical
 }
 
 // placeTraps scatters up to n dart_trap tiles onto plain floor tiles, avoiding

--- a/go/internal/gen/gen_test.go
+++ b/go/internal/gen/gen_test.go
@@ -263,6 +263,38 @@ func TestLevelFromDefScattersTraps(t *testing.T) {
 	}
 }
 
+func TestLevelFromDefPlacesDoors(t *testing.T) {
+	c := levelDefContent()
+	c.Tiles["door_open"] = &content.TileDef{ID: "door_open", Glyph: "'", Color: content.ColorBrown, Passable: true, Transparent: true}
+	c.Tiles["door_closed"] = &content.TileDef{ID: "door_closed", Glyph: "+", Color: content.ColorBrown, OpensTo: "door_open"}
+	def := &content.LevelDef{ID: "x", Name: "X", W: 60, H: 24, Links: []string{"y"}, Doors: true}
+	lvl, err := LevelFromDef(rng.NewWithSeed(1), c, def)
+	if err != nil {
+		t.Fatal(err)
+	}
+	doors := 0
+	for y := 0; y < lvl.H; y++ {
+		for x := 0; x < lvl.W; x++ {
+			p := game.Pos{X: x, Y: y}
+			if lvl.At(p).Def.ID != "door_closed" {
+				continue
+			}
+			doors++
+			// A door sits on a 1-wide passage: exactly one opposite axis open.
+			up := lvl.Passable(game.Pos{X: x, Y: y - 1})
+			down := lvl.Passable(game.Pos{X: x, Y: y + 1})
+			left := lvl.Passable(game.Pos{X: x - 1, Y: y})
+			right := lvl.Passable(game.Pos{X: x + 1, Y: y})
+			if !((up && down && !left && !right) || (left && right && !up && !down)) {
+				t.Errorf("door at %v is not on a clean doorway (u%v d%v l%v r%v)", p, up, down, left, right)
+			}
+		}
+	}
+	if doors == 0 {
+		t.Error("expected at least one door placed at a doorway")
+	}
+}
+
 func TestLevelFromDefDeterministic(t *testing.T) {
 	c := levelDefContent()
 	def := &content.LevelDef{ID: "x", Name: "X", W: 60, H: 24, Links: []string{"y"}, Monsters: 5, Spawn: []content.SpawnEntry{{Monster: "ratman", Weight: 1}}}


### PR DESCRIPTION
## Doors — doors slice of #18 (hazards & systems)

Closed doors block both **movement and sight**, and open when something bumps them. Because FOV occludes on tile transparency, a closed door hides the room behind it for free; opening it reveals the room.

### What's new
- **Doors are tiles.** `door_closed` (`+`) is impassable + opaque; `door_open` (`'`) is passable + transparent. A closed door names what it becomes via the new `TileDef.OpensTo` (`opens_to = "door_open"`), validated at load.
- **Open on bump.** `Game.openDoor(p)` swaps a closed door for its open state (false for any non-door, so it doubles as the "is this a door?" branch). A player's blocked step into a closed door opens it and passes the turn; **monsters open doors in their path too**, so a door is a brief delay, not an exploit. Plain walls stay a no-op.
- **Placement.** `LevelDef.Doors` gates `placeDoors`, which turns single-tile *doorways* — floor where a corridor breaks a room's wall ring, detected via a pinch test — into closed doors. Doorways are computed on the door-free layout then set together (order-independent, deterministic). Never overwrites stairs, the altar, traps, portals, or the start tile.
- **Data:** door tiles + `doors = true` on the Laboratory, Comm Hub, Frozen Vault, and Chapel.

### FOV
No FOV changes needed — `fovGrid.Opaque` already keys off `!Transparent`, so a closed door darkens what's behind it and an open one lets sight through.

### Tests (TDD)
- content: door tile with `opens_to` loads; unknown `opens_to` rejected.
- game: bumping a closed door opens it + passes a turn; a monster opens a door between it and the player; bumping a plain wall is a no-op.
- gen: a doored level yields ≥1 closed door, each on a clean 1-wide doorway.
- data: golden — door tiles correct; ≥1 level has doors. Shipped-data boot test exercises generation of doored levels.

`gofmt`/`go vet`/`go test ./...`/`go build` all green.

Part of #18 (doors slice; light & swimming still to come).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced door tiles that block movement and visibility when closed
  * Doors automatically transition to an open state when bumped into
  * Four levels now feature doors placed in room doorways
  * Both players and monsters can open doors during movement

<!-- end of auto-generated comment: release notes by coderabbit.ai -->