### PR TITLE
feat: monster roster batch 2 (bat/kobold/zombie/skeleton/wraith/ogre) — #13

### DIFF
--- a/go/data/data_test.go
+++ b/go/data/data_test.go
@@ -29,6 +29,41 @@ func TestEmbeddedRoster(t *testing.T) {
 	}
 }
 
+// TestEmbeddedRosterBatch2 checks the second monster batch loaded with the
+// expected glyphs and edible corpses, broadening the bestiary beyond rats/ghouls.
+func TestEmbeddedRosterBatch2(t *testing.T) {
+	c, err := content.Load(Files)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	want := map[string]rune{
+		"bat": 'b', "kobold": 'k', "zombie": 'z',
+		"skeleton": 's', "wraith": 'W', "ogre": 'O',
+	}
+	for id, glyph := range want {
+		m := c.Monsters[id]
+		if m == nil {
+			t.Errorf("missing monster %q", id)
+			continue
+		}
+		if m.Rune() != glyph {
+			t.Errorf("%s glyph = %q, want %q", id, m.Rune(), glyph)
+		}
+	}
+	// At least one new monster appears in a spawn table, so it can actually show up.
+	spawned := false
+	for _, l := range c.Levels {
+		for _, s := range l.Spawn {
+			if _, ok := want[s.Monster]; ok {
+				spawned = true
+			}
+		}
+	}
+	if !spawned {
+		t.Error("expected at least one batch-2 monster placed in a spawn table")
+	}
+}
+
 // TestDepthGatedTanks checks the tougher monsters only appear on deeper floors.
 func TestDepthGatedTanks(t *testing.T) {
 	c, err := content.Load(Files)

--- a/go/data/levels.toml
+++ b/go/data/levels.toml
@@ -24,6 +24,12 @@ weight = 2
 [[level.dungeon.spawn]]
 monster = "crypt_vermin"
 weight = 1
+[[level.dungeon.spawn]]
+monster = "bat"
+weight = 2
+[[level.dungeon.spawn]]
+monster = "kobold"
+weight = 2
 
 [level.catacombs]
 name = "the Catacombs"
@@ -44,6 +50,12 @@ weight = 2
 [[level.catacombs.spawn]]
 monster = "scarecrow"
 weight = 1
+[[level.catacombs.spawn]]
+monster = "kobold"
+weight = 2
+[[level.catacombs.spawn]]
+monster = "zombie"
+weight = 1
 
 [level.ominous_cave]
 name = "the Ominous Cave"
@@ -63,6 +75,9 @@ weight = 2
 [[level.ominous_cave.spawn]]
 monster = "merman"
 weight = 1
+[[level.ominous_cave.spawn]]
+monster = "bat"
+weight = 2
 
 [level.laboratory]
 name = "the Laboratory"
@@ -84,6 +99,9 @@ weight = 2
 [[level.laboratory.spawn]]
 monster = "slime"
 weight = 1
+[[level.laboratory.spawn]]
+monster = "skeleton"
+weight = 2
 
 [level.comm_hub]
 name = "the Communications Hub"
@@ -100,6 +118,9 @@ monster = "scarecrow"
 weight = 2
 [[level.comm_hub.spawn]]
 monster = "crypt_vermin"
+weight = 2
+[[level.comm_hub.spawn]]
+monster = "skeleton"
 weight = 2
 
 [level.underpass]
@@ -120,6 +141,9 @@ weight = 3
 [[level.underpass.spawn]]
 monster = "merman"
 weight = 1
+[[level.underpass.spawn]]
+monster = "zombie"
+weight = 2
 
 [level.drowned_city]
 name = "the Drowned City"
@@ -136,6 +160,9 @@ weight = 2
 [[level.drowned_city.spawn]]
 monster = "crypt_vermin"
 weight = 2
+[[level.drowned_city.spawn]]
+monster = "wraith"
+weight = 1
 
 [level.frozen_vault]
 name = "the Vault of the Frozen Saint"
@@ -152,6 +179,9 @@ monster = "ghoul"
 weight = 2
 [[level.frozen_vault.spawn]]
 monster = "slime"
+weight = 2
+[[level.frozen_vault.spawn]]
+monster = "ogre"
 weight = 2
 
 [level.dragons_lair]
@@ -171,6 +201,9 @@ weight = 3
 [[level.dragons_lair.spawn]]
 monster = "slime"
 weight = 3
+[[level.dragons_lair.spawn]]
+monster = "ogre"
+weight = 2
 
 [level.chapel]
 name = "the Chapel of Fallen Stars"
@@ -193,3 +226,6 @@ weight = 3
 [[level.chapel.spawn]]
 monster = "merman"
 weight = 1
+[[level.chapel.spawn]]
+monster = "wraith"
+weight = 2

--- a/go/data/monsters.toml
+++ b/go/data/monsters.toml
@@ -92,6 +92,77 @@ damage = "1d4"
 speed = 80
 min_depth = 3
 
+# Roster batch 2 (#13) — more standard foes across the tiers. Corpses reuse the
+# generic carcass/corpse food; the undead leave none. Depth is enforced by which
+# spawn tables list them (min_depth stays as canon documentation).
+[monster.bat]
+name = "giant bat"
+glyph = "b"
+color = "cyan"
+hp = 2
+attack = 3
+dodge = 3
+damage = "1d2"
+speed = 150
+corpse = "carcass"
+
+[monster.kobold]
+name = "kobold"
+glyph = "k"
+color = "green"
+hp = 4
+attack = 3
+dodge = 2
+damage = "1d3"
+speed = 100
+corpse = "corpse"
+
+[monster.zombie]
+name = "zombie"
+glyph = "z"
+color = "normal"
+hp = 12
+attack = 4
+dodge = 0
+damage = "1d5"
+speed = 55
+corpse = "corpse"
+min_depth = 2
+
+[monster.skeleton]
+name = "skeleton"
+glyph = "s"
+color = "normal"
+hp = 9
+attack = 5
+dodge = 2
+damage = "1d6"
+speed = 95
+min_depth = 2
+
+[monster.wraith]
+name = "wraith"
+glyph = "W"
+color = "magenta"
+hp = 14
+attack = 6
+dodge = 3
+damage = "1d6"
+speed = 110
+min_depth = 3
+
+[monster.ogre]
+name = "ogre"
+glyph = "O"
+color = "brown"
+hp = 22
+attack = 6
+dodge = 1
+damage = "2d4"
+speed = 90
+corpse = "carcass"
+min_depth = 3
+
 # Bosses (#16 2c). Deadly guardians — but you win by reaching the altar, so you
 # needn't kill them. Stats are tunable; gear breadth (#14) will make this fairer.
 [monster.elder_mummylich]


### PR DESCRIPTION
## Monster roster batch 2 — #13

Broadens the bestiary well beyond the early rats/ghouls (the original "I didn't run into anything else" gap). Pure data — no engine changes.

### New foes (across the tiers)
| Monster | Glyph | Tier | Notes |
|---|---|---|---|
| giant bat | `b` | early | very fast (speed 150), fragile |
| kobold | `k` | early | weak humanoid |
| zombie | `z` | mid | slow (55), tanky, hits hard |
| skeleton | `s` | mid | accurate undead warrior (no corpse) |
| wraith | `W` | deep | fast, evasive undead (no corpse) |
| ogre | `O` | deep | bruiser, 2d4 damage |

- Corpses reuse the generic `carcass`/`corpse` food; the undead leave none.
- Each is placed in 1–2 level **spawn tables** by depth, so they actually appear (giant bat/kobold early; zombie/skeleton mid; wraith/ogre deep). `min_depth` stays as canon documentation.

### Tests
- `TestEmbeddedRosterBatch2` golden: all six load with the expected glyphs, and at least one appears in a spawn table. The shipped-data boot test validates corpse refs + spawn refs end-to-end.

`gofmt`/`go vet`/`go test ./...`/`go build` all green.

Part of #13 (~16 monsters now; the ~25 target continues).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added six new monsters: bat, kobold, zombie, skeleton, wraith, and ogre with unique attributes and abilities
  * Integrated new monsters into spawn tables across multiple dungeon levels

* **Tests**
  * Added validation test to ensure new monsters appear in level spawns

<!-- end of auto-generated comment: release notes by coderabbit.ai -->