### PR TITLE
feat: ranged-attacker monsters + line of sight (imp) — #13

### DIFF
--- a/docs/superpowers/plans/2026-06-08-ranged-monsters-13c.md
+++ b/docs/superpowers/plans/2026-06-08-ranged-monsters-13c.md
@@ -1,0 +1,54 @@
+# Ranged Monsters 13c Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** The first AI variety beyond melee-chase: a monster that **blasts you
+from a distance**. When it has a clear line of sight and you're within range
+(but not adjacent), it fires a bolt instead of closing in — so you can be hurt
+across a room and want to break line of sight or rush it. Ships an **imp**, a
+fast ranged caster.
+
+## Design
+- **`MonsterDef.Ranged int`** — the attack range in tiles (0 = melee only). A
+  ranged monster reuses its `Damage` spec for the bolt and `Attack` vs the
+  player's dodge for the to-hit roll.
+- **Line of sight** — `Game.lineOfSight(a, b)` walks a Bresenham line from a to
+  b and returns false if any *intermediate* tile is opaque (`!Transparent`), so
+  walls and closed doors block bolts (and an open door lets them through).
+- **`monsterAct`** gains a branch: when not adjacent, if `Ranged > 0`, the target
+  is within `Ranged`, and there's line of sight, fire (`rangedAttack`) and don't
+  move; otherwise fall back to stepping toward the player.
+- **Refactor:** extract `hurtPlayer(dmg, cause)` (the HP-drop + death block) so
+  melee and ranged share one death path.
+
+**Scope:** straight-line bolts at the player only; no friendly fire, no beam
+that hits everything in the path, no separate ranged-damage stat. Faithful enough
+for a caster; richer spell effects can layer on the status system later.
+
+## Task 1: content — Ranged stat (TDD)
+**Files:** `internal/content/content.go`, `internal/content/content_test.go`
+- Add `Ranged int` (`ranged`) to `MonsterDef`; validate `>= 0`.
+- Tests first: a ranged monster loads; a negative `ranged` is rejected.
+- Commit: `feat(content): monster ranged attack stat`
+
+## Task 2: game — line of sight + ranged AI (TDD)
+**Files:** `internal/game/combat.go` (monsterAct, rangedAttack, hurtPlayer),
+`internal/game/los.go` (lineOfSight), tests
+- `lineOfSight` Bresenham, intermediate opacity check. `rangedAttack` mirrors
+  melee mechanics with a bolt message via `hurtPlayer`. `monsterAct` ranged
+  branch.
+- Tests first: clear LOS true, wall-blocked LOS false; a ranged monster in range
+  with LOS damages the player without moving adjacent; a wall between blocks the
+  shot (it approaches instead); out-of-range it approaches.
+- Commit: `feat(game): line-of-sight ranged monster AI`
+
+## Task 3: data — the imp + golden + ship
+**Files:** `data/monsters.toml`, `data/data_test.go`, level spawn tables
+- `imp` (`i`, red, fast, `ranged = 5`, mid/deep tiers, no corpse). Add to a few
+  spawn tables. Golden test: imp loads with `ranged > 0`.
+- Commit: `feat(data): imp (ranged caster)`
+- Then full gate; push, PR, CodeRabbit loop → merge → pull master. Advances #13.
+
+## Done when
+An imp pelts you with bolts across a lit room; duck behind a wall or a closed
+door and the bolts stop. Suite green.

--- a/go/data/data_test.go
+++ b/go/data/data_test.go
@@ -64,6 +64,29 @@ func TestEmbeddedRosterBatch2(t *testing.T) {
 	}
 }
 
+// TestEmbeddedImp checks the ranged caster loaded and appears in a spawn table.
+func TestEmbeddedImp(t *testing.T) {
+	c, err := content.Load(Files)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	imp := c.Monsters["imp"]
+	if imp == nil || imp.Rune() != 'i' || imp.Ranged <= 0 {
+		t.Errorf("imp def unexpected: %+v", imp)
+	}
+	spawned := false
+	for _, l := range c.Levels {
+		for _, s := range l.Spawn {
+			if s.Monster == "imp" {
+				spawned = true
+			}
+		}
+	}
+	if !spawned {
+		t.Error("expected the imp placed in a spawn table")
+	}
+}
+
 // TestDepthGatedTanks checks the tougher monsters only appear on deeper floors.
 func TestDepthGatedTanks(t *testing.T) {
 	c, err := content.Load(Files)

--- a/go/data/levels.toml
+++ b/go/data/levels.toml
@@ -102,6 +102,9 @@ weight = 1
 [[level.laboratory.spawn]]
 monster = "skeleton"
 weight = 2
+[[level.laboratory.spawn]]
+monster = "imp"
+weight = 1
 
 [level.comm_hub]
 name = "the Communications Hub"
@@ -163,6 +166,9 @@ weight = 2
 [[level.drowned_city.spawn]]
 monster = "wraith"
 weight = 1
+[[level.drowned_city.spawn]]
+monster = "imp"
+weight = 2
 
 [level.frozen_vault]
 name = "the Vault of the Frozen Saint"
@@ -203,6 +209,9 @@ monster = "slime"
 weight = 3
 [[level.dragons_lair.spawn]]
 monster = "ogre"
+weight = 2
+[[level.dragons_lair.spawn]]
+monster = "imp"
 weight = 2
 
 [level.chapel]

--- a/go/data/monsters.toml
+++ b/go/data/monsters.toml
@@ -163,6 +163,20 @@ speed = 90
 corpse = "carcass"
 min_depth = 3
 
+# Ranged caster (#13c) — pelts you with bolts across a lit room (ranged = 5);
+# break line of sight (a wall or closed door) to make it close in.
+[monster.imp]
+name = "imp"
+glyph = "i"
+color = "red"
+hp = 6
+attack = 4
+dodge = 3
+damage = "1d4"
+speed = 110
+ranged = 5
+min_depth = 2
+
 # Bosses (#16 2c). Deadly guardians — but you win by reaching the altar, so you
 # needn't kill them. Stats are tunable; gear breadth (#14) will make this fairer.
 [monster.elder_mummylich]

--- a/go/internal/content/content.go
+++ b/go/internal/content/content.go
@@ -64,6 +64,7 @@ type MonsterDef struct {
 	Speed    int    `toml:"speed"`     // energy gained per turn; <= 0 defaults to 100
 	Corpse   string `toml:"corpse"`    // item id dropped on death ("" = none); must be a food item
 	MinDepth int    `toml:"min_depth"` // earliest depth this monster spawns (0/1 = from depth 1)
+	Ranged   int    `toml:"ranged"`    // ranged attack distance in tiles (0 = melee only)
 }
 
 // Rune returns the monster's glyph as a rune.
@@ -367,6 +368,9 @@ func validateMonster(m *MonsterDef) error {
 	}
 	if m.MinDepth < 0 {
 		return fmt.Errorf("min_depth must be >= 0, got %d", m.MinDepth)
+	}
+	if m.Ranged < 0 {
+		return fmt.Errorf("ranged must be >= 0, got %d", m.Ranged)
 	}
 	return nil
 }

--- a/go/internal/content/content_test.go
+++ b/go/internal/content/content_test.go
@@ -196,6 +196,36 @@ func TestLoadRejectsBadMonsterDamage(t *testing.T) {
 	}
 }
 
+func TestLoadRangedMonster(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "tiles.toml"), []byte("[tile.floor]\nglyph=\".\"\ncolor=\"normal\"\npassable=true\ntransparent=true\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "monsters.toml"), []byte("[monster.imp]\nname=\"imp\"\nglyph=\"i\"\ncolor=\"red\"\nhp=6\nattack=4\ndodge=3\ndamage=\"1d4\"\nranged=5\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	c, err := Load(os.DirFS(dir))
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if m := c.Monsters["imp"]; m == nil || m.Ranged != 5 {
+		t.Errorf("imp def unexpected: %+v", m)
+	}
+}
+
+func TestLoadRejectsNegativeRanged(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "tiles.toml"), []byte("[tile.floor]\nglyph=\".\"\ncolor=\"normal\"\npassable=true\ntransparent=true\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "monsters.toml"), []byte("[monster.bad]\nname=\"bad\"\nglyph=\"b\"\ncolor=\"normal\"\nhp=3\nattack=1\ndodge=1\ndamage=\"1d2\"\nranged=-1\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := Load(os.DirFS(dir)); err == nil {
+		t.Fatal("expected error for negative ranged")
+	}
+}
+
 func TestLoadFoodItem(t *testing.T) {
 	dir := t.TempDir()
 	must := func(name, body string) {

--- a/go/internal/game/combat.go
+++ b/go/internal/game/combat.go
@@ -148,12 +148,30 @@ func (g *Game) monsterAttacks(m *Creature) {
 		return
 	}
 	dmg := g.RNG.RollSpec(m.Def.Damage)
-	g.PlayerHP -= dmg
 	g.log("The %s hits you for %d.", m.Def.Name, dmg)
+	g.hurtPlayer(dmg, m.Def.Name)
+}
+
+// rangedAttack fires a bolt at the player from a distance, using the same
+// to-hit (attack vs dodge) and damage model as a melee swing.
+func (g *Game) rangedAttack(m *Creature) {
+	if !g.RNG.Chance(m.Def.Attack, g.playerDodgeStat()) {
+		g.log("The %s's bolt misses you.", m.Def.Name)
+		return
+	}
+	dmg := g.RNG.RollSpec(m.Def.Damage)
+	g.log("The %s blasts you for %d.", m.Def.Name, dmg)
+	g.hurtPlayer(dmg, m.Def.Name)
+}
+
+// hurtPlayer applies dmg to the player and resolves death once (clamped HP +
+// recorded cause), so melee and ranged attacks share one death path.
+func (g *Game) hurtPlayer(dmg int, cause string) {
+	g.PlayerHP -= dmg
 	if g.PlayerHP <= 0 {
 		g.PlayerHP = 0
 		g.Dead = true
-		g.DeathCause = m.Def.Name
+		g.DeathCause = cause
 		g.log("You die.")
 	}
 }
@@ -204,11 +222,16 @@ func (g *Game) monstersAct() {
 // monsterAct is a single monster action: attack the player if adjacent, else
 // step toward the player if within sense range.
 func (g *Game) monsterAct(m *Creature) {
-	if chebyshev(m.Pos, g.Player) == 1 {
+	dist := chebyshev(m.Pos, g.Player)
+	if dist == 1 {
 		g.monsterAttacks(m)
 		return
 	}
-	if chebyshev(m.Pos, g.Player) <= senseRange {
+	if m.Def.Ranged > 0 && dist <= m.Def.Ranged && g.lineOfSight(m.Pos, g.Player) {
+		g.rangedAttack(m)
+		return
+	}
+	if dist <= senseRange {
 		g.stepToward(m, g.Player)
 	}
 }

--- a/go/internal/game/los.go
+++ b/go/internal/game/los.go
@@ -1,0 +1,45 @@
+package game
+
+// lineOfSight reports whether b is visible from a along a straight line: it
+// returns false if any tile strictly between a and b is opaque (a wall or a
+// closed door). The endpoints themselves are never treated as blockers. Uses a
+// Bresenham walk, matching the FOV's transparency model.
+func (g *Game) lineOfSight(a, b Pos) bool {
+	dx := b.X - a.X
+	if dx < 0 {
+		dx = -dx
+	}
+	dy := b.Y - a.Y
+	if dy < 0 {
+		dy = -dy
+	}
+	sx, sy := 1, 1
+	if a.X > b.X {
+		sx = -1
+	}
+	if a.Y > b.Y {
+		sy = -1
+	}
+	err := dx - dy
+	x, y := a.X, a.Y
+	for {
+		if x == b.X && y == b.Y {
+			return true
+		}
+		e2 := 2 * err
+		if e2 > -dy {
+			err -= dy
+			x += sx
+		}
+		if e2 < dx {
+			err += dx
+			y += sy
+		}
+		if x == b.X && y == b.Y {
+			return true // reached the target; its own tile isn't a blocker
+		}
+		if !g.Level.InBounds(Pos{X: x, Y: y}) || !g.Level.At(Pos{X: x, Y: y}).Def.Transparent {
+			return false
+		}
+	}
+}

--- a/go/internal/game/ranged_test.go
+++ b/go/internal/game/ranged_test.go
@@ -1,0 +1,70 @@
+package game
+
+import (
+	"testing"
+
+	"github.com/c0ze/tsl/internal/content"
+)
+
+func TestLineOfSightClear(t *testing.T) {
+	g := combatGame() // 10x3, all floor
+	if !g.lineOfSight(Pos{1, 1}, Pos{8, 1}) {
+		t.Error("clear floor should have line of sight")
+	}
+}
+
+func TestLineOfSightBlockedByWall(t *testing.T) {
+	g := combatGame()
+	g.Level.Set(Pos{5, 1}, g.Content.Tiles["wall"])
+	if g.lineOfSight(Pos{1, 1}, Pos{8, 1}) {
+		t.Error("a wall between the endpoints should block line of sight")
+	}
+}
+
+func TestRangedMonsterShootsAcrossRoom(t *testing.T) {
+	g := combatGame() // player at (1,1)
+	g.PlayerHP = 20
+	imp := &Creature{Def: &content.MonsterDef{ID: "imp", Name: "imp", HP: 6, Attack: 100, Dodge: 3, Damage: "1d4", Ranged: 6}, Pos: Pos{5, 1}, HP: 6}
+	g.Level.Creatures = append(g.Level.Creatures, imp)
+	before := imp.Pos
+
+	g.monstersAct()
+
+	if g.PlayerHP >= 20 {
+		t.Errorf("a ranged monster with line of sight should hit the player, HP=%d", g.PlayerHP)
+	}
+	if imp.Pos != before {
+		t.Errorf("a shooting monster should hold position, moved to %v", imp.Pos)
+	}
+}
+
+func TestRangedMonsterBlockedApproaches(t *testing.T) {
+	g := combatGame()
+	g.PlayerHP = 20
+	g.Level.Set(Pos{3, 1}, g.Content.Tiles["wall"]) // wall on the sightline
+	imp := &Creature{Def: &content.MonsterDef{ID: "imp", Name: "imp", HP: 6, Attack: 100, Dodge: 3, Damage: "1d4", Ranged: 6}, Pos: Pos{5, 1}, HP: 6}
+	g.Level.Creatures = append(g.Level.Creatures, imp)
+
+	g.monstersAct()
+
+	if g.PlayerHP != 20 {
+		t.Errorf("a monster with no line of sight should not shoot, HP=%d", g.PlayerHP)
+	}
+}
+
+func TestRangedMonsterOutOfRangeApproaches(t *testing.T) {
+	g := combatGame() // 10 wide; player at (1,1)
+	g.PlayerHP = 20
+	imp := &Creature{Def: &content.MonsterDef{ID: "imp", Name: "imp", HP: 6, Attack: 100, Dodge: 3, Damage: "1d4", Ranged: 3}, Pos: Pos{8, 1}, HP: 6}
+	g.Level.Creatures = append(g.Level.Creatures, imp)
+	beforeX := imp.Pos.X
+
+	g.monstersAct()
+
+	if g.PlayerHP != 20 {
+		t.Errorf("an out-of-range ranged monster should not shoot, HP=%d", g.PlayerHP)
+	}
+	if imp.Pos.X >= beforeX {
+		t.Error("an out-of-range ranged monster should approach the player")
+	}
+}

--- a/go/internal/game/ranged_test.go
+++ b/go/internal/game/ranged_test.go
@@ -44,11 +44,15 @@ func TestRangedMonsterBlockedApproaches(t *testing.T) {
 	g.Level.Set(Pos{3, 1}, g.Content.Tiles["wall"]) // wall on the sightline
 	imp := &Creature{Def: &content.MonsterDef{ID: "imp", Name: "imp", HP: 6, Attack: 100, Dodge: 3, Damage: "1d4", Ranged: 6}, Pos: Pos{5, 1}, HP: 6}
 	g.Level.Creatures = append(g.Level.Creatures, imp)
+	beforeX := imp.Pos.X
 
 	g.monstersAct()
 
 	if g.PlayerHP != 20 {
 		t.Errorf("a monster with no line of sight should not shoot, HP=%d", g.PlayerHP)
+	}
+	if imp.Pos.X >= beforeX {
+		t.Error("a monster with no line of sight should approach instead of idling")
 	}
 }
 


### PR DESCRIPTION
## Ranged-attacker monsters — first AI variety (#13)

Until now every monster used the same melee-chase AI. This adds a foe that **blasts you from a distance**, so positioning and cover start to matter. Ships an **imp**.

### What's new
- **`MonsterDef.Ranged`** — attack range in tiles (0 = melee only), validated `>= 0`. A ranged monster reuses its `Damage`/`Attack` for the bolt.
- **Line of sight** — `Game.lineOfSight(a, b)` walks a Bresenham line and returns false if any tile *between* the endpoints is opaque (`!Transparent`). So **walls and closed doors block bolts**, and an open door lets them through — reusing the same transparency model as FOV.
- **`monsterAct`** branch: when not adjacent, if `Ranged > 0`, the player is in range, and there's LOS → fire and hold position; otherwise approach. Extracted `hurtPlayer` so melee and ranged share one death path.
- **Data:** `imp` (`i`, red, fast, `ranged = 5`) in the Laboratory, Drowned City, and Dragons Lair spawn tables.

### Play feel
An imp pelts you with bolts across a lit room. Duck behind a wall or pull a closed door between you and it, and the bolts stop — it has to come to you.

### Tests (TDD)
- content: ranged monster loads; negative `ranged` rejected.
- game: clear LOS true / wall-blocked LOS false; an in-range imp with LOS damages the player without moving adjacent; a wall on the sightline stops the shot (it approaches); out of range it approaches.
- data: `TestEmbeddedImp` golden — loads with `ranged > 0` and appears in a spawn table.

`gofmt`/`go vet`/`go test ./...`/`go build` all green.

Part of #13 (ranged/special AI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Ranged monsters can attack from distance when the player is visible and within range.
  * A new imp enemy has been added to multiple dungeon levels.

* **Line of Sight**
  * Visibility checks now prevent ranged attacks through opaque obstacles.

* **Data**
  * Spawn tables updated to include the imp on several levels.

* **Tests**
  * New unit and content tests validate ranged behavior and data loading.

* **Documentation**
  * Added an implementation plan describing ranged monster behavior and test steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->