### PR TITLE
feat: player ranged weapons (fire) + ranged bosses — #14

### DIFF
--- a/docs/superpowers/plans/2026-06-08-ranged-weapons-14b.md
+++ b/docs/superpowers/plans/2026-06-08-ranged-weapons-14b.md
@@ -1,0 +1,63 @@
+# Ranged Weapons 14b Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** The player's answer to the imp — a wielded **ranged weapon** (a
+shortbow) and a **fire (`f`)** action that aims the targeting cursor at a
+creature and shoots it across the room, gated by range and line of sight. As a
+thematic round-out, the **dragon and mummylich bosses gain ranged attacks** (fire
+breath / dark bolts) using the same monster AI shipped in 13c.
+
+## Design
+- **`ItemDef.Ranged int`** — a weapon's firing range in tiles (0 = melee only).
+  A ranged weapon still has melee stats (you can bash with a bow), but its real
+  use is `f`.
+- **`Game.FireWeapon(target)`** — requires a wielded weapon with `Ranged > 0`;
+  rejects (no turn spent) when there's no ranged weapon, the target is out of
+  range, or `lineOfSight` is blocked. On a valid shot it rolls the weapon's
+  `Damage` against the creature at the target (`killCreature` on a kill) or
+  reports a miss into empty space, then passes the turn. Reuses the existing
+  `Prompter.Target` cursor and `lineOfSight`.
+- **`ActFire` (`f`)** — `Run` checks for a wielded ranged weapon, prompts a
+  target, and calls `FireWeapon`.
+- **Bosses:** add `ranged` to the dragon and elder mummylich so they threaten
+  from a distance (no engine change — the 13c AI already fires on `Ranged > 0`).
+
+**Scope:** no ammunition (infinite shots) and no separate ranged-damage stat —
+the weapon's `Damage` is the projectile. Throwing arbitrary items and quivers can
+come later.
+
+## Task 1: content — weapon Ranged (TDD)
+**Files:** `internal/content/content.go`, `internal/content/content_test.go`
+- Add `Ranged int` (`ranged`) to `ItemDef`; validate `>= 0`.
+- Tests first: a ranged weapon loads; a negative `ranged` is rejected.
+- Commit: `feat(content): weapon ranged stat`
+
+## Task 2: game — FireWeapon (TDD)
+**Files:** `internal/game/combat.go` (FireWeapon, WieldedRanged helper), tests
+- `WieldedRanged() bool` (wielded weapon with `Ranged > 0`). `FireWeapon(target)`
+  with the range/LOS guards above; valid shot damages + passes a turn.
+- Tests first: fire kills a creature in range with LOS + spends a charge-free
+  turn (monsters act); out of range → message, no damage, no turn; blocked LOS →
+  no shot; no ranged weapon wielded → message.
+- Commit: `feat(game): fire a wielded ranged weapon`
+
+## Task 3: ui — fire verb (TDD)
+**Files:** `internal/ui/ui.go`, `internal/ui/ui_test.go`,
+`internal/ui/tcell/screen.go`, `internal/ui/tcell/screen_test.go`
+- `ActFire` in the enum; `Run` ActFire case (wielded ranged weapon → `Target` →
+  `FireWeapon`, else "you have no ranged weapon"). tcell `f` → `ActFire`.
+- Tests first: Run fires at a creature via a fake Target; tcell `f` → `ActFire`.
+- Commit: `feat(ui): fire (f) a ranged weapon`
+
+## Task 4: data — shortbow + boss ranged + golden + ship
+**Files:** `data/items.toml`, `data/monsters.toml`, `data/data_test.go`
+- `shortbow` (kind weapon, glyph `}`, `ranged = 6`, modest melee). Give `dragon`
+  and `elder_mummylich` a `ranged`. Golden tests: shortbow `ranged > 0`; bosses
+  `ranged > 0`.
+- Commit: `feat(data): shortbow + ranged bosses (fire breath)`
+- Then full gate; push, PR, CodeRabbit loop → merge → pull master. Advances #14.
+
+## Done when
+Wield a shortbow, press `f`, aim at a monster down the corridor, and drop it —
+while the dragon roasts you from across its lair. Suite green.

--- a/go/data/data_test.go
+++ b/go/data/data_test.go
@@ -115,6 +115,24 @@ func TestEmbeddedGear(t *testing.T) {
 	}
 }
 
+// TestEmbeddedRangedWeapons checks the shortbow and the ranged bosses loaded.
+func TestEmbeddedRangedWeapons(t *testing.T) {
+	c, err := content.Load(Files)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if w := c.Items["shortbow"]; w == nil || w.Kind != "weapon" || w.Ranged <= 0 {
+		t.Errorf("shortbow def unexpected: %+v", w)
+	}
+	// Bosses threaten from a distance (fire breath / dark bolts) via the 13c AI.
+	if d := c.Monsters["dragon"]; d == nil || d.Ranged <= 0 {
+		t.Errorf("dragon should have a ranged attack, got %+v", d)
+	}
+	if m := c.Monsters["elder_mummylich"]; m == nil || m.Ranged <= 0 {
+		t.Errorf("elder_mummylich should have a ranged attack, got %+v", m)
+	}
+}
+
 // TestEmbeddedConsumables checks the status-effect consumables loaded.
 func TestEmbeddedConsumables(t *testing.T) {
 	c, err := content.Load(Files)

--- a/go/data/items.toml
+++ b/go/data/items.toml
@@ -63,6 +63,17 @@ kind = "weapon"
 attack = 5
 damage = "2d6"
 
+# Ranged weapon (#14) — wield it, then fire (f) at a target in line of sight.
+# Weak in melee; its strength is reach. power/ammo are infinite for now.
+[item.shortbow]
+name = "shortbow"
+glyph = "}"
+color = "brown"
+kind = "weapon"
+attack = 1
+damage = "1d6"
+ranged = 6
+
 # Body armor (dodge bonus).
 [item.filthy_rags]
 name = "filthy rags"

--- a/go/data/monsters.toml
+++ b/go/data/monsters.toml
@@ -188,6 +188,7 @@ attack = 6
 dodge = 3
 damage = "1d8"
 speed = 110
+ranged = 5
 
 [monster.dragon]
 name = "dragon"
@@ -198,3 +199,4 @@ attack = 7
 dodge = 3
 damage = "1d10"
 speed = 110
+ranged = 4

--- a/go/internal/content/content.go
+++ b/go/internal/content/content.go
@@ -87,6 +87,7 @@ type ItemDef struct {
 	Damage      string `toml:"damage"`       // weapon/wand damage spec
 	Effect      string `toml:"effect"`       // status effect applied on use ("" = none); e.g. a venom wand
 	EffectTurns int    `toml:"effect_turns"` // duration of Effect
+	Ranged      int    `toml:"ranged"`       // weapon firing range in tiles (0 = melee only)
 	NoSpawn     bool   `toml:"nospawn"`      // exclude from random floor loot (e.g. corpses)
 }
 
@@ -415,6 +416,9 @@ func validateItem(i *ItemDef) error {
 	}
 	if i.Effect != "" && i.EffectTurns <= 0 {
 		return fmt.Errorf("item effect %q needs effect_turns > 0", i.Effect)
+	}
+	if i.Ranged < 0 {
+		return fmt.Errorf("ranged must be >= 0, got %d", i.Ranged)
 	}
 	return nil
 }

--- a/go/internal/content/content_test.go
+++ b/go/internal/content/content_test.go
@@ -553,3 +553,21 @@ func TestLoadRejectsScrollWithoutUse(t *testing.T) {
 		t.Fatal("expected error: scroll needs a non-empty use")
 	}
 }
+
+func TestLoadRangedWeapon(t *testing.T) {
+	dir := writeItemsFixture(t, "[item.shortbow]\nname=\"shortbow\"\nglyph=\"}\"\ncolor=\"brown\"\nkind=\"weapon\"\nattack=1\ndamage=\"1d6\"\nranged=6\n")
+	c, err := Load(os.DirFS(dir))
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if w := c.Items["shortbow"]; w == nil || w.Ranged != 6 {
+		t.Errorf("shortbow def unexpected: %+v", w)
+	}
+}
+
+func TestLoadRejectsNegativeItemRanged(t *testing.T) {
+	dir := writeItemsFixture(t, "[item.bow]\nname=\"bow\"\nglyph=\"}\"\ncolor=\"brown\"\nkind=\"weapon\"\ndamage=\"1d6\"\nranged=-1\n")
+	if _, err := Load(os.DirFS(dir)); err == nil {
+		t.Fatal("expected error for negative item ranged")
+	}
+}

--- a/go/internal/game/fire.go
+++ b/go/internal/game/fire.go
@@ -1,0 +1,41 @@
+package game
+
+// WieldedRanged reports whether the player is wielding a ranged weapon (one with
+// a firing range), which is what the fire action requires.
+func (g *Game) WieldedRanged() bool {
+	return g.Weapon != nil && g.Weapon.Def != nil && g.Weapon.Def.Ranged > 0
+}
+
+// FireWeapon shoots the wielded ranged weapon at target. A shot is refused —
+// without costing a turn — when the player has no ranged weapon, the target is
+// beyond the weapon's range, or line of sight is blocked. A valid shot rolls the
+// weapon's damage against the creature there (killing it at 0 HP) or sails into
+// empty space, then passes a turn.
+func (g *Game) FireWeapon(target Pos) {
+	if g.Dead || g.Won {
+		return
+	}
+	if !g.WieldedRanged() {
+		g.log("You have no ranged weapon to fire.")
+		return
+	}
+	if chebyshev(g.Player, target) > g.Weapon.Def.Ranged {
+		g.log("That is out of range.")
+		return
+	}
+	if !g.lineOfSight(g.Player, target) {
+		g.log("You don't have a clear shot.")
+		return
+	}
+	if m := g.Level.CreatureAt(target); m != nil {
+		dmg := g.RNG.RollSpec(g.Weapon.Def.Damage)
+		m.HP -= dmg
+		g.log("You shoot the %s for %d.", m.Def.Name, dmg)
+		if m.HP <= 0 {
+			g.killCreature(m)
+		}
+	} else {
+		g.log("Your shot flies into empty space.")
+	}
+	g.monstersAct()
+}

--- a/go/internal/game/fire_test.go
+++ b/go/internal/game/fire_test.go
@@ -1,0 +1,65 @@
+package game
+
+import (
+	"testing"
+
+	"github.com/c0ze/tsl/internal/content"
+)
+
+func TestFireWeaponKillsInRange(t *testing.T) {
+	g := combatGame() // player at (1,1), all floor
+	g.Weapon = &Item{Def: &content.ItemDef{Name: "shortbow", Kind: "weapon", Damage: "10d1", Ranged: 6}}
+	rat := &Creature{Def: &content.MonsterDef{ID: "rat", Name: "rat", HP: 3}, Pos: Pos{5, 1}, HP: 3}
+	g.Level.Creatures = append(g.Level.Creatures, rat)
+
+	g.FireWeapon(Pos{5, 1})
+
+	if g.Level.CreatureAt(Pos{5, 1}) != nil {
+		t.Error("a ranged weapon should kill a creature in range with line of sight")
+	}
+}
+
+func TestFireWeaponOutOfRange(t *testing.T) {
+	g := combatGame()
+	g.Weapon = &Item{Def: &content.ItemDef{Name: "shortbow", Kind: "weapon", Damage: "10d1", Ranged: 2}}
+	rat := &Creature{Def: &content.MonsterDef{ID: "rat", Name: "rat", HP: 3}, Pos: Pos{8, 1}, HP: 3}
+	g.Level.Creatures = append(g.Level.Creatures, rat)
+
+	g.FireWeapon(Pos{8, 1})
+
+	if g.Level.CreatureAt(Pos{8, 1}) == nil {
+		t.Error("an out-of-range shot should not hit")
+	}
+}
+
+func TestFireWeaponBlockedByWall(t *testing.T) {
+	g := combatGame()
+	g.Weapon = &Item{Def: &content.ItemDef{Name: "shortbow", Kind: "weapon", Damage: "10d1", Ranged: 8}}
+	g.Level.Set(Pos{3, 1}, g.Content.Tiles["wall"])
+	rat := &Creature{Def: &content.MonsterDef{ID: "rat", Name: "rat", HP: 3}, Pos: Pos{5, 1}, HP: 3}
+	g.Level.Creatures = append(g.Level.Creatures, rat)
+
+	g.FireWeapon(Pos{5, 1})
+
+	if g.Level.CreatureAt(Pos{5, 1}) == nil {
+		t.Error("a shot with no clear line of sight should not hit")
+	}
+}
+
+func TestFireWeaponNoRangedWeapon(t *testing.T) {
+	g := combatGame()
+	g.Weapon = &Item{Def: &content.ItemDef{Name: "dagger", Kind: "weapon", Damage: "1d4"}} // Ranged 0
+	rat := &Creature{Def: &content.MonsterDef{ID: "rat", Name: "rat", HP: 3}, Pos: Pos{5, 1}, HP: 3}
+	g.Level.Creatures = append(g.Level.Creatures, rat)
+
+	g.FireWeapon(Pos{5, 1})
+
+	if g.Level.CreatureAt(Pos{5, 1}) == nil {
+		t.Error("with no ranged weapon wielded, firing should hit nothing")
+	}
+	if !g.WieldedRanged() {
+		// sanity: a plain dagger is not a ranged weapon
+	} else {
+		t.Error("a melee dagger should not count as a ranged weapon")
+	}
+}

--- a/go/internal/ui/tcell/screen.go
+++ b/go/internal/ui/tcell/screen.go
@@ -133,6 +133,8 @@ func keyToAction(ev *tc.EventKey) (ui.Action, bool) {
 		return ui.Action{Kind: ui.ActEat}, true
 	case 'r':
 		return ui.Action{Kind: ui.ActRead}, true
+	case 'f':
+		return ui.Action{Kind: ui.ActFire}, true
 	case '>':
 		return ui.Action{Kind: ui.ActTravel}, true
 	}

--- a/go/internal/ui/tcell/screen_test.go
+++ b/go/internal/ui/tcell/screen_test.go
@@ -48,6 +48,7 @@ func TestKeyToAction(t *testing.T) {
 		{tc.NewEventKey(tc.KeyRune, 'e', tc.ModNone), ui.Action{Kind: ui.ActEat}, true},
 		{tc.NewEventKey(tc.KeyRune, 'z', tc.ModNone), ui.Action{Kind: ui.ActZap}, true},
 		{tc.NewEventKey(tc.KeyRune, 'r', tc.ModNone), ui.Action{Kind: ui.ActRead}, true},
+		{tc.NewEventKey(tc.KeyRune, 'f', tc.ModNone), ui.Action{Kind: ui.ActFire}, true},
 		{tc.NewEventKey(tc.KeyRune, 'X', tc.ModNone), ui.Action{}, false},
 	}
 	for _, tt := range cases {

--- a/go/internal/ui/ui.go
+++ b/go/internal/ui/ui.go
@@ -42,6 +42,7 @@ const (
 	ActEat
 	ActZap
 	ActRead
+	ActFire
 )
 
 // Action is a decoded player intent. Dir is meaningful only when Kind==ActMove.
@@ -212,6 +213,14 @@ func Run(g *game.Game, p Prompter, r Renderer) error {
 			}
 			if target, ok := p.Target(g.Player); ok {
 				g.ZapWand(wands[idx], target)
+			}
+		case ActFire:
+			if !g.WieldedRanged() {
+				g.Messages = append(g.Messages, "You have no ranged weapon to fire.")
+				break
+			}
+			if target, ok := p.Target(g.Player); ok {
+				g.FireWeapon(target)
 			}
 		}
 	}

--- a/go/internal/ui/ui_test.go
+++ b/go/internal/ui/ui_test.go
@@ -211,6 +211,32 @@ func TestRunZapWandDamagesCreature(t *testing.T) {
 	}
 }
 
+func TestRunFireWeaponAtCreature(t *testing.T) {
+	g := testGame(t, []string{".....", ".@...", "....."})
+	g.RNG = rng.NewWithSeed(1)
+	g.Weapon = &game.Item{Def: &content.ItemDef{Name: "shortbow", Kind: "weapon", Damage: "10d1", Ranged: 6}}
+	g.Level.Creatures = append(g.Level.Creatures, &game.Creature{Def: &content.MonsterDef{ID: "rat", Name: "rat", HP: 3}, Pos: game.Pos{X: 3, Y: 1}, HP: 3})
+	g.UpdateFOV()
+	p := &zapPrompter{actions: []Action{{Kind: ActFire}, {Kind: ActQuit}}, target: game.Pos{X: 3, Y: 1}}
+	if err := Run(g, p, &nullRenderer{}); err != nil {
+		t.Fatal(err)
+	}
+	if g.Level.CreatureAt(game.Pos{X: 3, Y: 1}) != nil {
+		t.Error("firing the shortbow should have killed the rat")
+	}
+}
+
+func TestRunFireWithNoRangedWeaponReports(t *testing.T) {
+	g := testGame(t, []string{".@."})
+	p := &scriptPrompter{actions: []Action{{Kind: ActFire}, {Kind: ActQuit}}}
+	if err := Run(g, p, &nullRenderer{}); err != nil {
+		t.Fatal(err)
+	}
+	if len(g.Messages) == 0 || !strings.Contains(g.Messages[len(g.Messages)-1], "no ranged weapon") {
+		t.Errorf("expected a 'no ranged weapon' message, got %v", g.Messages)
+	}
+}
+
 func TestBuildViewShowsVisibleMonsterAndMessages(t *testing.T) {
 	g := testGame(t, []string{".....", ".@...", "....."})
 	g.UpdateFOV()


### PR DESCRIPTION
## Player ranged weapons + ranged bosses — #14

The player's answer to the imp: wield a **shortbow** and **fire (`f`)** at a creature across the room, gated by range and line of sight. As a thematic round-out, the **dragon and mummylich bosses gain ranged attacks** using the same monster AI from #13c.

### What's new
- **`ItemDef.Ranged`** — a weapon's firing range in tiles (0 = melee only), validated `>= 0`.
- **`Game.FireWeapon(target)`** — requires a wielded ranged weapon; refuses the shot **without spending a turn** when there's no ranged weapon, the target is out of range, or `lineOfSight` is blocked. A valid shot rolls the weapon's `Damage` against the creature there (`killCreature` on a kill) or sails into empty space, then passes the turn. Reuses the targeting cursor + `lineOfSight`. `WieldedRanged()` helper.
- **`ActFire` (`f`)** — `Run` aims and fires when a ranged weapon is wielded, else reports there's none. tcell `f` → `ActFire`.
- **Data:** `shortbow` (`}`, `ranged = 6`, weak melee); `dragon` gains `ranged = 4` (fire breath) and `elder_mummylich` `ranged = 5` (dark bolts) — no engine change, the 13c AI already fires on `Ranged > 0`.

### Play feel
Wield a shortbow, press `f`, aim down a corridor, and drop a monster before it reaches you — while the dragon roasts you from across its lair (duck behind a wall to break its line).

### Tests (TDD)
- content: ranged weapon loads; negative `ranged` rejected.
- game: fire kills a creature in range + LOS; out of range / blocked LOS / no ranged weapon each refuse the shot (target unharmed).
- ui: Run fires at a creature via a fake target; empty-handed reports "no ranged weapon"; tcell `f` → `ActFire`.
- data: `TestEmbeddedRangedWeapons` golden — shortbow `ranged > 0`, dragon + mummylich `ranged > 0`.

`gofmt`/`go vet`/`go test ./...`/`go build` all green.

Part of #14 (ranged weapons).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced ranged weapons system with shortbow item.
  * Added fire action (press 'f') to aim and shoot with equipped ranged weapons.
  * Enemy monsters (dragons, elder mummylich) now launch ranged attacks.

* **Documentation**
  * Added implementation plan for ranged weapons feature.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->