### PR TITLE
feat: dark levels (reduced vision) — #18

### DIFF
--- a/docs/superpowers/plans/2026-06-08-darkness-18c.md
+++ b/docs/superpowers/plans/2026-06-08-darkness-18c.md
@@ -1,0 +1,48 @@
+# Darkness 18c Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** The light slice of #18: **dark levels**. On an unlit level the player
+sees only a few tiles around them, so deep places feel claustrophobic and
+dangerous — an imp's bolt now comes out of the dark. Reuses the FOV; only the
+radius changes.
+
+## Design
+- **`Level.Dark bool`** marks an unlit level. `Game.visionRadius()` returns the
+  reduced `DarkVisionRadius` (3) on a dark level and the normal `VisionRadius`
+  (8) otherwise; `UpdateFOV` uses it instead of the constant.
+- **`LevelDef.Dark`** (`dark`) drives it through the data; `gen.LevelFromDef`
+  copies `def.Dark` onto the generated `Level`.
+
+**Scope:** a binary lit/dark per level (no light-source items or radius gradients
+yet — a torch/lantern that extends the radius can follow). Memory still works:
+tiles you've seen stay dimly remembered even in the dark.
+
+## Task 1: game — vision radius + FOV (TDD)
+**Files:** `internal/game/game.go` (Level.Dark), `internal/game/fov.go`
+(DarkVisionRadius, visionRadius, UpdateFOV), tests
+- `Level.Dark bool`; `const DarkVisionRadius = 3`; `func (g *Game) visionRadius() int`
+  returns the dark radius when `g.Level.Dark`. `UpdateFOV` calls `fov.Compute`
+  with `g.visionRadius()`.
+- Tests first: on a normal level a tile 6 away is visible; on a dark level the
+  same tile is not (but a near tile still is). `visionRadius` returns 3 dark / 8
+  lit.
+- Commit: `feat(game): reduced vision on dark levels`
+
+## Task 2: content + gen — wire the flag (TDD)
+**Files:** `internal/content/content.go` (LevelDef.Dark),
+`internal/gen/gen.go` (LevelFromDef), `internal/gen/gen_test.go`
+- Add `Dark bool` (`dark`) to `LevelDef`; `LevelFromDef` sets `lvl.Dark = def.Dark`.
+- Test first: a def with `Dark=true` yields a `Level` with `Dark` true.
+- Commit: `feat(gen): carry the dark flag onto generated levels`
+
+## Task 3: data — dark levels + golden + ship
+**Files:** `data/levels.toml`, `data/data_test.go`
+- Mark a few atmospheric levels `dark = true` (e.g. the Ominous Cave, the
+  Underpass, the Vault of the Frozen Saint). Golden test: ≥1 dark level.
+- Commit: `feat(data): unlit levels`
+- Then full gate; push, PR, CodeRabbit loop → merge → pull master. Advances #18.
+
+## Done when
+On a dark level your view shrinks to a small bubble of light around you; step
+carefully. Suite green.

--- a/go/data/data_test.go
+++ b/go/data/data_test.go
@@ -218,6 +218,23 @@ func TestEmbeddedDoors(t *testing.T) {
 	}
 }
 
+// TestEmbeddedDarkLevels checks that some levels are unlit.
+func TestEmbeddedDarkLevels(t *testing.T) {
+	c, err := content.Load(Files)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	dark := 0
+	for _, l := range c.Levels {
+		if l.Dark {
+			dark++
+		}
+	}
+	if dark == 0 {
+		t.Error("expected at least one dark level")
+	}
+}
+
 // TestEmbeddedScrolls checks the read-verb scrolls loaded.
 func TestEmbeddedScrolls(t *testing.T) {
 	c, err := content.Load(Files)

--- a/go/data/levels.toml
+++ b/go/data/levels.toml
@@ -63,6 +63,7 @@ width = 60
 height = 24
 links = ["dungeon", "comm_hub", "underpass"]
 monsters = 9
+dark = true
 [[level.ominous_cave.spawn]]
 monster = "graveling"
 weight = 3
@@ -132,6 +133,7 @@ width = 60
 height = 24
 links = ["ominous_cave", "drowned_city"]
 monsters = 10
+dark = true
 [[level.underpass.spawn]]
 monster = "ratman"
 weight = 2
@@ -177,6 +179,7 @@ height = 24
 links = ["comm_hub", "dragons_lair"]
 monsters = 10
 doors = true
+dark = true
 [[level.frozen_vault.spawn]]
 monster = "scarecrow"
 weight = 3

--- a/go/internal/content/content.go
+++ b/go/internal/content/content.go
@@ -119,6 +119,7 @@ type LevelDef struct {
 	Boss     string       `toml:"boss"`  // a guaranteed monster placed once on the level
 	Traps    int          `toml:"traps"` // number of dart_trap tiles to scatter
 	Doors    bool         `toml:"doors"` // place closed doors in room doorways
+	Dark     bool         `toml:"dark"`  // unlit level: the player sees only a small radius
 }
 
 // Content is the fully-loaded, validated game content.

--- a/go/internal/game/darkness_test.go
+++ b/go/internal/game/darkness_test.go
@@ -1,0 +1,32 @@
+package game
+
+import "testing"
+
+func TestDarkLevelShrinksVision(t *testing.T) {
+	g := combatGame() // 10x3 all floor, player at (1,1)
+	g.UpdateFOV()
+	if !g.Level.At(Pos{7, 1}).Visible {
+		t.Fatal("on a lit level a tile 6 away should be visible")
+	}
+
+	g.Level.Dark = true
+	g.UpdateFOV()
+
+	if g.Level.At(Pos{7, 1}).Visible {
+		t.Error("on a dark level a tile 6 away should be out of sight")
+	}
+	if !g.Level.At(Pos{3, 1}).Visible {
+		t.Error("on a dark level a near tile (2 away) should still be visible")
+	}
+}
+
+func TestVisionRadiusDarkVsLit(t *testing.T) {
+	g := combatGame()
+	if r := g.visionRadius(); r != VisionRadius {
+		t.Errorf("lit visionRadius = %d, want %d", r, VisionRadius)
+	}
+	g.Level.Dark = true
+	if r := g.visionRadius(); r != DarkVisionRadius {
+		t.Errorf("dark visionRadius = %d, want %d", r, DarkVisionRadius)
+	}
+}

--- a/go/internal/game/fov.go
+++ b/go/internal/game/fov.go
@@ -2,9 +2,20 @@ package game
 
 import "github.com/c0ze/tsl/internal/fov"
 
-// VisionRadius is how far the player can see, in tiles. It becomes
-// attribute-driven once creatures land in a later plan.
-const VisionRadius = 8
+// VisionRadius is how far the player can see on a normally-lit level, in tiles.
+// DarkVisionRadius is the reduced reach on an unlit (dark) level.
+const (
+	VisionRadius     = 8
+	DarkVisionRadius = 3
+)
+
+// visionRadius is the player's current sight radius: reduced on a dark level.
+func (g *Game) visionRadius() int {
+	if g.Level != nil && g.Level.Dark {
+		return DarkVisionRadius
+	}
+	return VisionRadius
+}
 
 // fovGrid adapts a Level to fov.Grid.
 type fovGrid struct{ l *Level }
@@ -23,7 +34,7 @@ func (g *Game) UpdateFOV() {
 	for i := range g.Level.tiles {
 		g.Level.tiles[i].Visible = false
 	}
-	fov.Compute(fovGrid{g.Level}, g.Player.X, g.Player.Y, VisionRadius, func(x, y int) {
+	fov.Compute(fovGrid{g.Level}, g.Player.X, g.Player.Y, g.visionRadius(), func(x, y int) {
 		t := g.Level.At(Pos{X: x, Y: y})
 		t.Visible = true
 		t.Seen = true

--- a/go/internal/game/game.go
+++ b/go/internal/game/game.go
@@ -69,6 +69,7 @@ type Level struct {
 	Return  Pos      // saved player position for re-entry (set on leaving)
 	entered bool     // whether the player has arrived here at least once
 	Portals []Portal // stairs leading to other levels
+	Dark    bool     // unlit: the player sees only a small radius
 }
 
 // InBounds reports whether p lies inside the level.

--- a/go/internal/gen/gen.go
+++ b/go/internal/gen/gen.go
@@ -190,6 +190,7 @@ func LevelFromDef(r *rng.MT, c *content.Content, def *content.LevelDef) (*game.L
 		return nil, fmt.Errorf("gen: tiles floor/wall/stairs_down must all be defined")
 	}
 	lvl := game.NewLevel(def.W, def.H, wall)
+	lvl.Dark = def.Dark
 	rooms := carveRooms(r, lvl, floor)
 	if len(rooms) == 0 {
 		return nil, fmt.Errorf("gen: level %q too small for any rooms", def.ID)

--- a/go/internal/gen/gen_test.go
+++ b/go/internal/gen/gen_test.go
@@ -295,6 +295,18 @@ func TestLevelFromDefPlacesDoors(t *testing.T) {
 	}
 }
 
+func TestLevelFromDefCarriesDarkFlag(t *testing.T) {
+	c := levelDefContent()
+	def := &content.LevelDef{ID: "x", Name: "X", W: 60, H: 24, Links: []string{"y"}, Dark: true}
+	lvl, err := LevelFromDef(rng.NewWithSeed(1), c, def)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !lvl.Dark {
+		t.Error("a dark level def should produce a dark level")
+	}
+}
+
 func TestLevelFromDefDeterministic(t *testing.T) {
 	c := levelDefContent()
 	def := &content.LevelDef{ID: "x", Name: "X", W: 60, H: 24, Links: []string{"y"}, Monsters: 5, Spawn: []content.SpawnEntry{{Monster: "ratman", Weight: 1}}}


### PR DESCRIPTION
## Dark levels — light slice of #18

On an **unlit level** the player sees only a small bubble around them, so deep places feel claustrophobic and dangerous — an imp's bolt now lances out of the dark. Reuses the FOV; only the radius changes.

### What's new
- **`Level.Dark`** marks an unlit level. **`Game.visionRadius()`** returns `DarkVisionRadius` (3) on a dark level and `VisionRadius` (8) otherwise; `UpdateFOV` uses it. Memory is unaffected — tiles you've already seen stay dimly remembered.
- **`LevelDef.Dark`** (`dark`) drives it through the data; `gen.LevelFromDef` copies it onto the generated `Level`.
- **Data:** the Ominous Cave, the Underpass, and the Vault of the Frozen Saint are `dark = true`.

### Scope
A binary lit/dark per level — no light-source items or radius gradients yet (a torch/lantern that extends the radius is a natural follow-up).

### Tests (TDD)
- game: on a lit level a tile 6 away is visible; on a dark level it isn't, but a near tile still is. `visionRadius` returns 3 dark / 8 lit.
- gen: a `Dark` def yields a dark `Level`.
- data: `TestEmbeddedDarkLevels` golden — at least one level is dark.

`gofmt`/`go vet`/`go test ./...`/`go build` all green.

Part of #18 (light/darkness).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a darkness system where players experience reduced vision radius in unlit levels, creating a more challenging exploration experience
  * Three levels now feature darkness: Ominous Cave, Underpass, and Frozen Vault

* **Tests**
  * Added validation tests for darkness mechanics and vision radius behavior

* **Documentation**
  * Added implementation plan documenting the darkness feature rollout

<!-- end of auto-generated comment: release notes by coderabbit.ai -->