### PR TITLE
feat: torches (carry light into the dark) — #18

### DIFF
--- a/docs/superpowers/plans/2026-06-08-torches-18d.md
+++ b/docs/superpowers/plans/2026-06-08-torches-18d.md
@@ -1,0 +1,45 @@
+# Torches 18d Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Counterplay for the dark levels from 18c — a **torch** you carry that
+pushes back the dark. Carrying a light source raises your sight radius on an
+unlit level (no effect where it's already bright). Finishes the light arc of #18.
+
+## Design
+- **`ItemDef.Light int`** — the vision radius an item provides while carried
+  (0 = none).
+- **`Game.carriedLight()`** returns the best `Light` among inventory items.
+  `visionRadius()` on a dark level becomes `max(DarkVisionRadius, carriedLight())`;
+  lit levels are unchanged (always `VisionRadius`). Equipped weapon/armor live in
+  the inventory slice too, so a glowing weapon would count automatically.
+
+**Scope:** a passive light (no fuel/burn-out, no lit/unlit toggle). A torch just
+works while you hold it. Burn-out can come later if we want the tension.
+
+## Task 1: content — Light stat (TDD)
+**Files:** `internal/content/content.go`, `internal/content/content_test.go`
+- Add `Light int` (`light`) to `ItemDef`; validate `>= 0`.
+- Tests first: a torch item loads with `Light`; negative `light` rejected.
+- Commit: `feat(content): item light radius`
+
+## Task 2: game — carried light raises dark vision (TDD)
+**Files:** `internal/game/fov.go` (carriedLight, visionRadius), tests
+- `carriedLight()` scans inventory for the max `Light`. `visionRadius()` uses
+  `max(DarkVisionRadius, carriedLight())` on dark levels.
+- Tests first: on a dark level, carrying a `Light 6` torch yields radius 6 (a
+  tile 5 away becomes visible that wasn't); on a lit level the torch changes
+  nothing; no torch keeps the dark radius.
+- Commit: `feat(game): carried light extends vision in the dark`
+
+## Task 3: data — torch + golden + ship
+**Files:** `data/items.toml`, `data/data_test.go`
+- `torch` (glyph `~`, `light = 6`), ordinary floor loot. Golden test: torch
+  `light > 0`.
+- Commit: `feat(data): a torch to carry into the dark`
+- Then full gate; push, PR, CodeRabbit loop → merge → pull master. Completes the
+  light arc of #18.
+
+## Done when
+Pick up a torch and the dark levels open up around you; drop into the dark
+without one and you're nearly blind. Suite green.

--- a/go/data/data_test.go
+++ b/go/data/data_test.go
@@ -218,6 +218,17 @@ func TestEmbeddedDoors(t *testing.T) {
 	}
 }
 
+// TestEmbeddedTorch checks the torch light source loaded.
+func TestEmbeddedTorch(t *testing.T) {
+	c, err := content.Load(Files)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if w := c.Items["torch"]; w == nil || w.Kind != "light" || w.Light <= 0 {
+		t.Errorf("torch def unexpected: %+v", w)
+	}
+}
+
 // TestEmbeddedDarkLevels checks that some levels are unlit.
 func TestEmbeddedDarkLevels(t *testing.T) {
 	c, err := content.Load(Files)

--- a/go/data/items.toml
+++ b/go/data/items.toml
@@ -210,3 +210,11 @@ glyph = "?"
 color = "blue"
 kind = "scroll"
 use = "reveal"
+
+# Light source (#18) — carry it to see in the dark (light = sight radius there).
+[item.torch]
+name = "torch"
+glyph = "~"
+color = "red"
+kind = "light"
+light = 6

--- a/go/internal/content/content.go
+++ b/go/internal/content/content.go
@@ -88,6 +88,7 @@ type ItemDef struct {
 	Effect      string `toml:"effect"`       // status effect applied on use ("" = none); e.g. a venom wand
 	EffectTurns int    `toml:"effect_turns"` // duration of Effect
 	Ranged      int    `toml:"ranged"`       // weapon firing range in tiles (0 = melee only)
+	Light       int    `toml:"light"`        // vision radius provided while carried (0 = none)
 	NoSpawn     bool   `toml:"nospawn"`      // exclude from random floor loot (e.g. corpses)
 }
 
@@ -97,7 +98,7 @@ func (i *ItemDef) Rune() rune {
 	return r
 }
 
-var validItemKinds = map[string]bool{"potion": true, "weapon": true, "armor": true, "food": true, "wand": true, "scroll": true}
+var validItemKinds = map[string]bool{"potion": true, "weapon": true, "armor": true, "food": true, "wand": true, "scroll": true, "light": true}
 
 // SpawnEntry is one weighted entry in a level's monster spawn table.
 type SpawnEntry struct {
@@ -396,6 +397,10 @@ func validateItem(i *ItemDef) error {
 		if strings.TrimSpace(i.Use) == "" {
 			return fmt.Errorf("scroll must have a non-empty use")
 		}
+	case "light":
+		if i.Light <= 0 {
+			return fmt.Errorf("light item must provide light > 0")
+		}
 	case "weapon":
 		if !validDamageSpec(i.Damage) {
 			return fmt.Errorf("weapon damage %q is not a valid dice spec", i.Damage)
@@ -420,6 +425,9 @@ func validateItem(i *ItemDef) error {
 	}
 	if i.Ranged < 0 {
 		return fmt.Errorf("ranged must be >= 0, got %d", i.Ranged)
+	}
+	if i.Light < 0 {
+		return fmt.Errorf("light must be >= 0, got %d", i.Light)
 	}
 	return nil
 }

--- a/go/internal/content/content_test.go
+++ b/go/internal/content/content_test.go
@@ -554,6 +554,31 @@ func TestLoadRejectsScrollWithoutUse(t *testing.T) {
 	}
 }
 
+func TestLoadTorchItem(t *testing.T) {
+	dir := writeItemsFixture(t, "[item.torch]\nname=\"torch\"\nglyph=\"~\"\ncolor=\"red\"\nkind=\"light\"\nlight=6\n")
+	c, err := Load(os.DirFS(dir))
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if w := c.Items["torch"]; w == nil || w.Kind != "light" || w.Light != 6 {
+		t.Errorf("torch def unexpected: %+v", w)
+	}
+}
+
+func TestLoadRejectsNegativeLight(t *testing.T) {
+	dir := writeItemsFixture(t, "[item.bad]\nname=\"bad\"\nglyph=\"~\"\ncolor=\"red\"\nkind=\"weapon\"\ndamage=\"1d4\"\nlight=-1\n")
+	if _, err := Load(os.DirFS(dir)); err == nil {
+		t.Fatal("expected error for negative light")
+	}
+}
+
+func TestLoadRejectsLightlessLight(t *testing.T) {
+	dir := writeItemsFixture(t, "[item.dud]\nname=\"dud\"\nglyph=\"~\"\ncolor=\"red\"\nkind=\"light\"\n")
+	if _, err := Load(os.DirFS(dir)); err == nil {
+		t.Fatal("expected error: a light item needs light > 0")
+	}
+}
+
 func TestLoadRangedWeapon(t *testing.T) {
 	dir := writeItemsFixture(t, "[item.shortbow]\nname=\"shortbow\"\nglyph=\"}\"\ncolor=\"brown\"\nkind=\"weapon\"\nattack=1\ndamage=\"1d6\"\nranged=6\n")
 	c, err := Load(os.DirFS(dir))

--- a/go/internal/game/darkness_test.go
+++ b/go/internal/game/darkness_test.go
@@ -1,6 +1,10 @@
 package game
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/c0ze/tsl/internal/content"
+)
 
 func TestDarkLevelShrinksVision(t *testing.T) {
 	g := combatGame() // 10x3 all floor, player at (1,1)
@@ -28,5 +32,29 @@ func TestVisionRadiusDarkVsLit(t *testing.T) {
 	g.Level.Dark = true
 	if r := g.visionRadius(); r != DarkVisionRadius {
 		t.Errorf("dark visionRadius = %d, want %d", r, DarkVisionRadius)
+	}
+}
+
+func TestCarriedTorchLightsTheDark(t *testing.T) {
+	g := combatGame() // 10x3 all floor, player at (1,1)
+	g.Level.Dark = true
+	g.UpdateFOV()
+	if g.Level.At(Pos{6, 1}).Visible {
+		t.Fatal("on a dark level a tile 5 away should be out of sight without a torch")
+	}
+
+	g.Inventory = append(g.Inventory, &Item{Def: &content.ItemDef{Name: "torch", Kind: "light", Light: 6}})
+	g.UpdateFOV()
+
+	if !g.Level.At(Pos{6, 1}).Visible {
+		t.Error("carrying a torch (light 6) should reveal a tile 5 away in the dark")
+	}
+}
+
+func TestTorchNoEffectWhenLit(t *testing.T) {
+	g := combatGame() // lit
+	g.Inventory = append(g.Inventory, &Item{Def: &content.ItemDef{Name: "torch", Kind: "light", Light: 99}})
+	if r := g.visionRadius(); r != VisionRadius {
+		t.Errorf("a torch should not extend sight on a lit level: got %d, want %d", r, VisionRadius)
 	}
 }

--- a/go/internal/game/fov.go
+++ b/go/internal/game/fov.go
@@ -9,12 +9,29 @@ const (
 	DarkVisionRadius = 3
 )
 
-// visionRadius is the player's current sight radius: reduced on a dark level.
+// visionRadius is the player's current sight radius. On a dark level it shrinks
+// to DarkVisionRadius, but a carried light source (a torch) pushes it back out.
 func (g *Game) visionRadius() int {
-	if g.Level != nil && g.Level.Dark {
-		return DarkVisionRadius
+	if g.Level == nil || !g.Level.Dark {
+		return VisionRadius
 	}
-	return VisionRadius
+	r := DarkVisionRadius
+	if light := g.carriedLight(); light > r {
+		r = light
+	}
+	return r
+}
+
+// carriedLight returns the largest light radius among the items the player is
+// carrying — a torch glows passively while held.
+func (g *Game) carriedLight() int {
+	best := 0
+	for _, it := range g.Inventory {
+		if it.Def != nil && it.Def.Light > best {
+			best = it.Def.Light
+		}
+	}
+	return best
 }
 
 // fovGrid adapts a Level to fov.Grid.


### PR DESCRIPTION
## Torches — light sources for the dark (completes the #18 light arc)

Counterplay for the dark levels from 18c: carry a **torch** and it pushes back the dark; drop into an unlit level without one and you're nearly blind.

### What's new
- **`ItemDef.Light`** — the vision radius an item provides while carried (0 = none) — and a new **`light` item kind** (a torch is a carryable that isn't weapon/armor/consumable).
- **`Game.carriedLight()`** returns the best `Light` among carried items; **`visionRadius()`** on a dark level becomes `max(DarkVisionRadius, carriedLight())`. Lit levels are unchanged. (Equipped gear lives in the inventory slice too, so a future glowing weapon would count automatically.)
- **Data:** `torch` (`~`, `light = 6`), ordinary floor loot.

### Scope
Passive light — no fuel/burn-out, no lit/unlit toggle. The torch just works while you hold it; burn-out tension can come later.

### Tests (TDD)
- content: torch loads (`light` kind, `Light` set); negative `light` rejected; a `light`-kind item with no light rejected.
- game: on a dark level a torch (light 6) reveals a tile 5 away that was invisible; on a lit level a torch changes nothing.
- data: `TestEmbeddedTorch` golden — torch `light > 0`.

`gofmt`/`go vet`/`go test ./...`/`go build` all green.

Completes the light/darkness arc of #18 (doors 18b + dark levels 18c + torches 18d). Swimming/water is the remaining #18 slice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
- Torches can now be carried to increase sight radius on dark levels, enabling safer exploration in previously unlit areas.

## Documentation
- Added implementation plan documentation for the torch system.

## Tests
- Added comprehensive tests to verify torch functionality and vision mechanics on dark levels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->