### PR TITLE
feat: instant-healing/pain potions + identify/recharge scrolls — #15

### DIFF
--- a/docs/superpowers/plans/2026-06-08-consumables-15h.md
+++ b/docs/superpowers/plans/2026-06-08-consumables-15h.md
@@ -1,0 +1,63 @@
+# Consumable Breadth 15h Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Widen the consumable lists (#15) with four items that build on existing
+mechanics and make the new identify system *matter*: a **potion of instant
+healing** (good) and a **potion of pain** (bad — now an unknown potion can hurt
+you), a **scroll of identify** (closes the identify loop), and a **scroll of
+recharge** (refills a wand).
+
+## Faithful reference (`common/potions.c`)
+- `treasure_p_instant_healing`: `heal(creature, 10 + rnd() % 15)` → restore 10–24.
+- `treasure_p_pain`: damages the creature.
+- scrolls of identify / recharge: identify an item / restore wand charges.
+
+(`treasure_p_energy`, polymorph, levitation, sleep, speed, slowing, blindness and
+the spell-y scrolls want a player status/EP model and come in later increments.)
+
+## Design
+- **Engine helpers** (so behaviors, which act only through exported API, can do
+  this): export `HurtPlayer(dmg, cause)` (today's unexported `hurtPlayer`); add
+  `IdentifyItem(it)` (mark a type known, no message), `IsIdentified(it)`, and
+  `UnidentifiedInventory()` (carried items still hidden).
+- **Behaviors** (`internal/behaviors`):
+  - `instant_healing`: `restoreHP(10 + RNG.Intn(15))`.
+  - `pain`: `HurtPlayer(Power, "a potion of pain")` — can kill at low HP.
+  - `identify`: reveal one random still-unidentified carried item (the scroll has
+    already use-identified itself), reporting "Your <appearance> is a <name>.";
+    "nothing new" when the pack is fully known.
+  - `recharge`: add 3–5 charges to a random carried wand.
+- Also commit the **morgue identify test** left out of #39 (test-only coverage
+  for the already-merged morgue `DisplayName` change).
+
+**Scope:** identify/recharge pick a random eligible item rather than prompting
+(behaviors can't drive the Prompter); a chosen-target version is a later
+refinement.
+
+## Task 1: game — helpers (TDD)
+**Files:** `internal/game/combat.go` (export HurtPlayer + callers),
+`internal/game/identify.go` (IdentifyItem/IsIdentified/UnidentifiedInventory),
+tests (+ restore morgue test)
+- Tests first: HurtPlayer damages + resolves death; UnidentifiedInventory lists
+  only hidden carried items and drops them once identified.
+- Commit: `feat(game): export HurtPlayer + identify-item helpers`
+
+## Task 2: behaviors — four effects (TDD)
+**Files:** `internal/behaviors/behaviors.go`, `internal/behaviors/behaviors_test.go`
+- Implement + register `instant_healing`, `pain`, `identify`, `recharge`.
+- Tests first: instant healing restores HP; pain costs HP (and can kill); identify
+  reveals an unidentified carried item; recharge adds wand charges.
+- Commit: `feat(behaviors): instant healing, pain, identify, recharge`
+
+## Task 3: data — four consumables + golden + ship
+**Files:** `data/items.toml`, `data/data_test.go`
+- `potion_instant_healing`, `potion_pain` (power = damage), `scroll_identify`,
+  `scroll_recharge`. Golden test for all four.
+- Commit: `feat(data): instant-healing/pain potions + identify/recharge scrolls`
+- Full gate; push, PR, CodeRabbit loop → merge → pull master. Advances #15.
+
+## Done when
+Quaffing an unidentified potion might heal you to the brim or wrack you with pain;
+a scroll of identify names a mystery item, and a scroll of recharge tops up a
+wand. Suite green.

--- a/go/data/data_test.go
+++ b/go/data/data_test.go
@@ -133,6 +133,30 @@ func TestEmbeddedRangedWeapons(t *testing.T) {
 	}
 }
 
+// TestEmbeddedConsumableBreadth checks the 15h consumables loaded with the right
+// use behaviors (instant healing / pain potions, identify / recharge scrolls).
+func TestEmbeddedConsumableBreadth(t *testing.T) {
+	c, err := content.Load(Files)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	want := map[string]string{
+		"potion_instant_healing": "instant_healing",
+		"potion_pain":            "pain",
+		"scroll_identify":        "identify",
+		"scroll_recharge":        "recharge",
+	}
+	for id, use := range want {
+		it := c.Items[id]
+		if it == nil || it.Use != use {
+			t.Errorf("%s def unexpected: %+v (want use %q)", id, it, use)
+		}
+	}
+	if p := c.Items["potion_pain"]; p != nil && p.Power <= 0 {
+		t.Errorf("potion_pain needs Power for its damage, got %+v", p)
+	}
+}
+
 // TestEmbeddedConsumables checks the status-effect consumables loaded.
 func TestEmbeddedConsumables(t *testing.T) {
 	c, err := content.Load(Files)

--- a/go/data/items.toml
+++ b/go/data/items.toml
@@ -149,6 +149,37 @@ use = "eat"
 power = 1
 nospawn = true
 
+# Consumable breadth (#15h). Potions/scrolls hide behind a random appearance
+# until used or identified; a potion of pain gives quaffing-the-unknown real risk.
+[item.potion_instant_healing]
+name = "potion of instant healing"
+glyph = "!"
+color = "red"
+kind = "potion"
+use = "instant_healing"
+
+[item.potion_pain]
+name = "potion of pain"
+glyph = "!"
+color = "red"
+kind = "potion"
+use = "pain"
+power = 8
+
+[item.scroll_identify]
+name = "scroll of identify"
+glyph = "?"
+color = "normal"
+kind = "scroll"
+use = "identify"
+
+[item.scroll_recharge]
+name = "scroll of recharge"
+glyph = "?"
+color = "cyan"
+kind = "scroll"
+use = "recharge"
+
 # Status-effect consumables (#15).
 [item.potion_regeneration]
 name = "potion of regeneration"

--- a/go/internal/behaviors/behaviors.go
+++ b/go/internal/behaviors/behaviors.go
@@ -18,6 +18,10 @@ func Registry() map[string]game.Behavior {
 		"eat_mushroom": eatMushroom,
 		"teleport":     teleport,
 		"reveal":       reveal,
+		"instant_healing": instantHealing,
+		"pain":            pain,
+		"identify":        identifyScroll,
+		"recharge":        recharge,
 	}
 }
 
@@ -70,4 +74,40 @@ func teleport(g *game.Game, it *game.Item) []string {
 func reveal(g *game.Game, it *game.Item) []string {
 	g.RevealMap()
 	return []string{fmt.Sprintf("You read the %s; the layout floods into your mind.", it.Def.Name)}
+}
+
+// instantHealing restores a big chunk of HP at once (the faithful 10 + rnd%15).
+func instantHealing(g *game.Game, it *game.Item) []string {
+	recovered := restoreHP(g, 10+g.RNG.Intn(15))
+	return []string{fmt.Sprintf("You quaff the %s and surge with vitality (+%d HP).", it.Def.Name, recovered)}
+}
+
+// pain damages the drinker — the reason you don't quaff unknown potions blindly.
+func pain(g *game.Game, it *game.Item) []string {
+	g.HurtPlayer(it.Def.Power, "a potion of pain")
+	return []string{fmt.Sprintf("The %s wracks you with agony!", it.Def.Name)}
+}
+
+// identifyScroll reveals one still-unidentified item in the pack.
+func identifyScroll(g *game.Game, it *game.Item) []string {
+	unknown := g.UnidentifiedInventory()
+	if len(unknown) == 0 {
+		return []string{"You sense nothing new about your possessions."}
+	}
+	pick := unknown[g.RNG.Intn(len(unknown))]
+	was := g.DisplayName(pick)
+	g.IdentifyItem(pick)
+	return []string{fmt.Sprintf("Your %s is revealed to be a %s.", was, pick.Def.Name)}
+}
+
+// recharge tops up a random carried wand with a few fresh charges.
+func recharge(g *game.Game, it *game.Item) []string {
+	wands := g.WandInventory()
+	if len(wands) == 0 {
+		return []string{"You feel a surge of magic with nowhere to go."}
+	}
+	w := wands[g.RNG.Intn(len(wands))]
+	add := 3 + g.RNG.Intn(3)
+	w.Charges += add
+	return []string{fmt.Sprintf("Your %s crackles with %d fresh charges.", g.DisplayName(w), add)}
 }

--- a/go/internal/behaviors/behaviors.go
+++ b/go/internal/behaviors/behaviors.go
@@ -12,12 +12,12 @@ import (
 // Registry returns the name→behavior map referenced by item `use` fields.
 func Registry() map[string]game.Behavior {
 	return map[string]game.Behavior{
-		"heal":         heal,
-		"eat":          eat,
-		"regenerate":   regenerate,
-		"eat_mushroom": eatMushroom,
-		"teleport":     teleport,
-		"reveal":       reveal,
+		"heal":            heal,
+		"eat":             eat,
+		"regenerate":      regenerate,
+		"eat_mushroom":    eatMushroom,
+		"teleport":        teleport,
+		"reveal":          reveal,
 		"instant_healing": instantHealing,
 		"pain":            pain,
 		"identify":        identifyScroll,

--- a/go/internal/behaviors/behaviors_test.go
+++ b/go/internal/behaviors/behaviors_test.go
@@ -85,6 +85,63 @@ func TestRevealBehaviorMarksSeen(t *testing.T) {
 	}
 }
 
+func TestInstantHealingRestores(t *testing.T) {
+	heal, ok := Registry()["instant_healing"]
+	if !ok {
+		t.Fatal("instant_healing not registered")
+	}
+	g := &game.Game{PlayerHP: 5, PlayerMax: 40, RNG: rng.NewWithSeed(1)}
+	heal(g, &game.Item{Def: &content.ItemDef{Name: "potion of instant healing"}})
+	if g.PlayerHP <= 5 {
+		t.Errorf("instant healing should restore HP, got %d", g.PlayerHP)
+	}
+}
+
+func TestPainDamages(t *testing.T) {
+	pain, ok := Registry()["pain"]
+	if !ok {
+		t.Fatal("pain not registered")
+	}
+	g := &game.Game{PlayerHP: 20, PlayerMax: 20}
+	pain(g, &game.Item{Def: &content.ItemDef{Name: "potion of pain", Power: 6}})
+	if g.PlayerHP != 14 {
+		t.Errorf("pain should cost Power HP, got %d", g.PlayerHP)
+	}
+}
+
+func TestIdentifyScrollReveals(t *testing.T) {
+	idScroll, ok := Registry()["identify"]
+	if !ok {
+		t.Fatal("identify not registered")
+	}
+	c := &content.Content{Items: map[string]*content.ItemDef{
+		"healing":  {ID: "healing", Name: "potion of healing", Kind: "potion", Use: "heal"},
+		"idscroll": {ID: "idscroll", Name: "scroll of identify", Kind: "scroll", Use: "identify"},
+	}}
+	g := &game.Game{Content: c, RNG: rng.NewWithSeed(1)}
+	g.AssignAppearances()
+	pot := &game.Item{Def: c.Items["healing"]}
+	g.Inventory = append(g.Inventory, pot)
+	idScroll(g, &game.Item{Def: c.Items["idscroll"]})
+	if !g.IsIdentified(pot) {
+		t.Error("scroll of identify should reveal an unidentified carried item")
+	}
+}
+
+func TestRechargeAddsCharges(t *testing.T) {
+	recharge, ok := Registry()["recharge"]
+	if !ok {
+		t.Fatal("recharge not registered")
+	}
+	g := &game.Game{RNG: rng.NewWithSeed(1)}
+	wand := &game.Item{Def: &content.ItemDef{Name: "wand", Kind: "wand", Damage: "1d4"}, Charges: 1}
+	g.Inventory = append(g.Inventory, wand)
+	recharge(g, &game.Item{Def: &content.ItemDef{Name: "scroll of recharge"}})
+	if wand.Charges <= 1 {
+		t.Errorf("recharge should add charges, got %d", wand.Charges)
+	}
+}
+
 func TestEatMushroomHealsAndPoisons(t *testing.T) {
 	eat, ok := Registry()["eat_mushroom"]
 	if !ok {

--- a/go/internal/game/combat.go
+++ b/go/internal/game/combat.go
@@ -150,7 +150,7 @@ func (g *Game) monsterAttacks(m *Creature) {
 	}
 	dmg := g.RNG.RollSpec(m.Def.Damage)
 	g.log("The %s hits you for %d.", m.Def.Name, dmg)
-	g.hurtPlayer(dmg, m.Def.Name)
+	g.HurtPlayer(dmg, m.Def.Name)
 }
 
 // rangedAttack fires a bolt at the player from a distance, using the same
@@ -162,12 +162,12 @@ func (g *Game) rangedAttack(m *Creature) {
 	}
 	dmg := g.RNG.RollSpec(m.Def.Damage)
 	g.log("The %s blasts you for %d.", m.Def.Name, dmg)
-	g.hurtPlayer(dmg, m.Def.Name)
+	g.HurtPlayer(dmg, m.Def.Name)
 }
 
-// hurtPlayer applies dmg to the player and resolves death once (clamped HP +
+// HurtPlayer applies dmg to the player and resolves death once (clamped HP +
 // recorded cause), so melee and ranged attacks share one death path.
-func (g *Game) hurtPlayer(dmg int, cause string) {
+func (g *Game) HurtPlayer(dmg int, cause string) {
 	g.PlayerHP -= dmg
 	if g.PlayerHP <= 0 {
 		g.PlayerHP = 0

--- a/go/internal/game/identify.go
+++ b/go/internal/game/identify.go
@@ -88,6 +88,37 @@ func (g *Game) DisplayName(it *Item) string {
 	return it.Def.Name
 }
 
+// IdentifyItem marks an item's type as globally known without announcing it —
+// for sources that print their own message (a scroll of identify). A no-op for
+// kinds that are never hidden.
+func (g *Game) IdentifyItem(it *Item) {
+	if it == nil || it.Def == nil || !unidentifiable(it.Def.Kind) {
+		return
+	}
+	if g.Identified == nil {
+		g.Identified = map[string]bool{}
+	}
+	g.Identified[it.Def.ID] = true
+}
+
+// IsIdentified reports whether the player knows what an item is — always true for
+// kinds that never hide (weapons, armor, food, lights).
+func (g *Game) IsIdentified(it *Item) bool {
+	return it == nil || it.Def == nil || !unidentifiable(it.Def.Kind) || g.Identified[it.Def.ID]
+}
+
+// UnidentifiedInventory returns the carried items whose type is still hidden, in
+// inventory order — what a scroll of identify can reveal.
+func (g *Game) UnidentifiedInventory() []*Item {
+	var out []*Item
+	for _, it := range g.Inventory {
+		if !g.IsIdentified(it) {
+			out = append(out, it)
+		}
+	}
+	return out
+}
+
 // identify marks an item's type as globally known (use-identify), announcing the
 // reveal the first time it happens. A no-op for kinds that are never hidden.
 func (g *Game) identify(it *Item) {

--- a/go/internal/game/identify_test.go
+++ b/go/internal/game/identify_test.go
@@ -97,11 +97,51 @@ func TestUsePotionIdentifiesType(t *testing.T) {
 	}
 }
 
+func TestMorgueShowsUnidentifiedByAppearance(t *testing.T) {
+	g := identifyGame()
+	g.Inventory = append(g.Inventory, &Item{Def: g.Content.Items["healing"]})
+	txt := g.MorgueText()
+	if !strings.Contains(txt, g.appearances["healing"]) {
+		t.Errorf("morgue should list the unidentified potion by appearance, got:\n%s", txt)
+	}
+	if strings.Contains(txt, "potion of healing") {
+		t.Error("morgue should not reveal an unidentified potion's real name")
+	}
+}
+
 func TestZapWandIdentifies(t *testing.T) {
 	g := identifyGame()
 	wand := &Item{Def: g.Content.Items["force"], Charges: 2}
 	g.ZapWand(wand, Pos{2, 1}) // empty tile: fizzles, but still reveals the wand
 	if !g.Identified["force"] {
 		t.Error("zapping should identify the wand type")
+	}
+}
+
+func TestHurtPlayerResolvesDeath(t *testing.T) {
+	g := combatGame()
+	g.PlayerHP = 3
+	g.HurtPlayer(10, "a potion of pain")
+	if !g.Dead || g.PlayerHP != 0 || g.DeathCause != "a potion of pain" {
+		t.Errorf("HurtPlayer should kill at 0 HP with the cause, got dead=%v hp=%d cause=%q", g.Dead, g.PlayerHP, g.DeathCause)
+	}
+}
+
+func TestUnidentifiedInventoryFiltersAndDrops(t *testing.T) {
+	g := identifyGame()
+	p := &Item{Def: g.Content.Items["healing"]}
+	weapon := &Item{Def: g.Content.Items["dagger"]} // weapons are always identified
+	g.Inventory = append(g.Inventory, p, weapon)
+
+	un := g.UnidentifiedInventory()
+	if len(un) != 1 || un[0] != p {
+		t.Errorf("UnidentifiedInventory should list only the hidden potion, got %v", un)
+	}
+	g.IdentifyItem(p)
+	if len(g.UnidentifiedInventory()) != 0 {
+		t.Error("identifying the potion should drop it from the unidentified list")
+	}
+	if !g.IsIdentified(p) {
+		t.Error("IsIdentified should report the potion identified")
 	}
 }


### PR DESCRIPTION
## Consumable breadth — instant-healing/pain potions, identify/recharge scrolls (#15)

Four consumables that build on existing mechanics and make the new identify system *matter*: an unidentified potion is now a gamble between a big heal and a faceful of pain.

### What's new
- **Potion of instant healing** — restores 10–24 HP at once (faithful `heal(10 + rnd%15)` from `potions.c`).
- **Potion of pain** — damages the drinker (`power` = damage, via the now-exported `HurtPlayer`); can kill at low HP. This is the *stakes* for the identify system.
- **Scroll of identify** — reveals one still-unidentified item in your pack ("Your muddy potion is revealed to be a potion of healing"). Closes the identify loop.
- **Scroll of recharge** — tops up a carried wand with 3–5 charges.

### Engine helpers
- Exported `HurtPlayer(dmg, cause)` (was `hurtPlayer`) so behaviors can damage the player with proper death resolution.
- `IdentifyItem` (silent type reveal), `IsIdentified`, `UnidentifiedInventory` — the scroll of identify operates through these.
- Also lands the **morgue identify test** that was left out of #39 (test-only coverage for the already-merged morgue `DisplayName` change).

### Scope
`identify`/`recharge` pick a random eligible item rather than prompting (behaviors can't drive the Prompter) — a chosen-target version is a later refinement. The remaining potions/scrolls (speed, sleep, blindness, levitation, polymorph, energy; blink, recall, trap-detection, …) want a player status/EP model and come in dedicated increments.

### Tests (TDD)
- game: `HurtPlayer` damages + resolves death; `UnidentifiedInventory` lists only hidden carried items and drops them on identify.
- behaviors: instant healing restores HP; pain costs `Power` HP; identify reveals a carried item; recharge adds wand charges.
- data: golden for all four (uses + pain's power). Shipped-data boot validates the new `use` behaviors are registered.

`gofmt`/`go vet`/`go test ./...`/`go build` all green.

Part of #15 (consumable breadth).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added four new consumables: instant-healing potion, pain potion, identify scroll, and recharge scroll
  * Instant-healing potion restores player health
  * Identify scroll reveals unidentified items in inventory
  * Recharge scroll restores charges to wands
  * Pain potion damages the player

* **Tests**
  * Added test coverage for new consumables and identification mechanics

<!-- end of auto-generated comment: release notes by coderabbit.ai -->