### PR TITLE
feat: offensive spells — force bolt (targeted casting) — #15

### DIFF
--- a/docs/superpowers/plans/2026-06-08-offensive-spells-15j.md
+++ b/docs/superpowers/plans/2026-06-08-offensive-spells-15j.md
@@ -1,0 +1,48 @@
+# Offensive Spells 15j Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Give the spell system teeth: a **targeted attack spell** you aim with
+the cursor. Ships **force bolt** — cast it (`c`), aim, and blast a creature for
+EP. Reuses the cast loop (15i) plus the `Target` cursor and `lineOfSight` already
+built for wands/bows.
+
+## Design
+- A spellbook is now either a **utility** spell (a `use` behavior, e.g. first aid)
+  or a **targeted** spell (`ranged` + `damage`, no behavior). Relax spellbook
+  validation to require `use` **or** (`ranged > 0` and a valid `damage` spec);
+  `cost > 0` always.
+- **`Game.CastSpellAt(book, target)`**: refuse (no EP, no turn) when EP is too
+  low, the target is out of range, or `lineOfSight` is blocked; otherwise spend
+  EP, roll `damage` against the creature there (kill via `killCreature`), and
+  pass a turn.
+- **`ActCast`**: after the spell menu, if the chosen spell has `Ranged > 0`,
+  prompt `Target` and `CastSpellAt`; otherwise `CastSpell` (unchanged).
+
+**Scope:** single-target bolt. Line/beam spells (frost ray) and status/AoE spells
+are later — they layer on the same cast+target flow.
+
+## Task 1: content + game — targeted casting (TDD)
+**Files:** `internal/content/content.go` (spellbook validation),
+`internal/content/content_test.go`, `internal/game/spell.go` (CastSpellAt), tests
+- Validation: a damage spellbook (ranged + damage, no use) loads; a spellbook with
+  neither use nor ranged-damage is rejected.
+- `CastSpellAt` with the EP/range/LOS gates + damage.
+- Tests first: a ranged-damage spellbook validates; casting at a creature in
+  range/LOS spends EP + damages/kills + passes a turn; out of range / blocked /
+  too little EP each refuse (no EP spent).
+- Commit: `feat(game): targeted attack spells (CastSpellAt)`
+
+## Task 2: ui — aim on cast + data + ship
+**Files:** `internal/ui/ui.go`, `internal/ui/ui_test.go`, `data/items.toml`,
+`data/data_test.go`
+- `ActCast`: target when the spell has range, else cast in place.
+- `spellbook_force_bolt` (ranged, damage, cost; no use). Golden test.
+- Tests first: Run casts force bolt at a creature via a fake Target (creature dies,
+  EP drops).
+- Commit: `feat(data): spellbook of force bolt`
+- Full gate; push, PR, CodeRabbit loop → merge. Advances #15 (magic).
+
+## Done when
+Press `c`, pick force bolt, aim down a corridor, and blast a monster for EP —
+duck behind a wall and the spell has no shot. Suite green.

--- a/go/data/data_test.go
+++ b/go/data/data_test.go
@@ -143,6 +143,11 @@ func TestEmbeddedSpellbook(t *testing.T) {
 	if b == nil || b.Kind != "spellbook" || b.Use != "first_aid" || b.Cost <= 0 {
 		t.Errorf("spellbook_first_aid def unexpected: %+v", b)
 	}
+	// The force-bolt spellbook is a targeted attack spell (ranged + damage, no use).
+	fb := c.Items["spellbook_force_bolt"]
+	if fb == nil || fb.Kind != "spellbook" || fb.Ranged <= 0 || fb.Damage == "" || fb.Cost <= 0 {
+		t.Errorf("spellbook_force_bolt def unexpected: %+v", fb)
+	}
 }
 
 // TestEmbeddedConsumableBreadth checks the 15h consumables loaded with the right

--- a/go/data/items.toml
+++ b/go/data/items.toml
@@ -242,7 +242,8 @@ color = "blue"
 kind = "scroll"
 use = "reveal"
 
-# Spellbook (#15i) — carry it and press c to cast (costs EP). use = spell effect.
+# Spellbooks (#15i/j) — carry one and press c to cast (costs EP). A book is either
+# a utility spell (use = effect) or a targeted attack (ranged + damage).
 [item.spellbook_first_aid]
 name = "spellbook of first aid"
 glyph = "+"
@@ -251,6 +252,15 @@ kind = "spellbook"
 use = "first_aid"
 cost = 4
 power = 8
+
+[item.spellbook_force_bolt]
+name = "spellbook of force bolt"
+glyph = "+"
+color = "red"
+kind = "spellbook"
+ranged = 6
+damage = "2d6"
+cost = 5
 
 # Light source (#18) — carry it to see in the dark (light = sight radius there).
 [item.torch]

--- a/go/internal/content/content.go
+++ b/go/internal/content/content.go
@@ -403,8 +403,13 @@ func validateItem(i *ItemDef) error {
 			return fmt.Errorf("light item must provide light > 0")
 		}
 	case "spellbook":
-		if strings.TrimSpace(i.Use) == "" {
-			return fmt.Errorf("spellbook must have a non-empty use")
+		hasUse := strings.TrimSpace(i.Use) != ""
+		hasAttack := i.Ranged > 0 && i.Damage != ""
+		if !hasUse && !hasAttack {
+			return fmt.Errorf("spellbook needs a use behavior or a ranged damage spec")
+		}
+		if hasAttack && !validDamageSpec(i.Damage) {
+			return fmt.Errorf("spellbook damage %q is not a valid dice spec", i.Damage)
 		}
 		if i.Cost <= 0 {
 			return fmt.Errorf("spellbook must have an EP cost > 0")

--- a/go/internal/content/content_test.go
+++ b/go/internal/content/content_test.go
@@ -600,7 +600,18 @@ func TestLoadRejectsCostlessSpellbook(t *testing.T) {
 func TestLoadRejectsUselessSpellbook(t *testing.T) {
 	dir := writeItemsFixture(t, "[item.book]\nname=\"book\"\nglyph=\"+\"\ncolor=\"blue\"\nkind=\"spellbook\"\ncost=4\n")
 	if _, err := Load(os.DirFS(dir)); err == nil {
-		t.Fatal("expected error: a spellbook needs a use")
+		t.Fatal("expected error: a spellbook needs a use or a ranged damage spec")
+	}
+}
+
+func TestLoadDamageSpellbook(t *testing.T) {
+	dir := writeItemsFixture(t, "[item.bolt]\nname=\"spellbook of force bolt\"\nglyph=\"+\"\ncolor=\"red\"\nkind=\"spellbook\"\nranged=6\ndamage=\"2d6\"\ncost=5\n")
+	c, err := Load(os.DirFS(dir))
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if b := c.Items["bolt"]; b == nil || b.Ranged != 6 || b.Damage != "2d6" || b.Use != "" {
+		t.Errorf("force-bolt spellbook unexpected: %+v", b)
 	}
 }
 

--- a/go/internal/game/item.go
+++ b/go/internal/game/item.go
@@ -43,6 +43,9 @@ func (l *Level) RemoveItem(it *Item) {
 // doing nothing at runtime.
 func ValidateItemUses(c *content.Content, reg map[string]Behavior) error {
 	for id, it := range c.Items {
+		if it.Use == "" {
+			continue // e.g. a targeted (damage) spellbook has no use behavior
+		}
 		if it.Kind == "potion" || it.Kind == "food" || it.Kind == "scroll" || it.Kind == "spellbook" {
 			if _, ok := reg[it.Use]; !ok {
 				return fmt.Errorf("item %q references unknown behavior %q", id, it.Use)

--- a/go/internal/game/spell.go
+++ b/go/internal/game/spell.go
@@ -38,6 +38,43 @@ func (g *Game) CastSpell(book *Item) {
 	g.monstersAct()
 }
 
+// CastSpellAt casts a targeted attack spell from book at target: it checks EP,
+// range, and line of sight (any failure refuses the cast without spending EP or
+// a turn), then spends the EP cost, rolls the spell's damage against the creature
+// there (killing it at 0 HP) or fizzles into empty space, and passes a turn.
+func (g *Game) CastSpellAt(book *Item, target Pos) {
+	if g.Dead || g.Won {
+		return
+	}
+	if book == nil || book.Def == nil || book.Def.Kind != "spellbook" {
+		return
+	}
+	if g.EP < book.Def.Cost {
+		g.log("You lack the energy to cast %s.", book.Def.Name)
+		return
+	}
+	if chebyshev(g.Player, target) > book.Def.Ranged {
+		g.log("That is out of range.")
+		return
+	}
+	if !g.lineOfSight(g.Player, target) {
+		g.log("You don't have a clear shot.")
+		return
+	}
+	g.EP -= book.Def.Cost
+	if m := g.Level.CreatureAt(target); m != nil {
+		dmg := g.RNG.RollSpec(book.Def.Damage)
+		m.HP -= dmg
+		g.log("Your %s strikes the %s for %d.", book.Def.Name, m.Def.Name, dmg)
+		if m.HP <= 0 {
+			g.killCreature(m)
+		}
+	} else {
+		g.log("The spell dissipates against nothing.")
+	}
+	g.monstersAct()
+}
+
 // regenEP restores one EP every epRegenInterval turns, clamped to EPMax. Called
 // once per player turn. The counter pauses while EP is full.
 func (g *Game) regenEP() {

--- a/go/internal/game/spell_test.go
+++ b/go/internal/game/spell_test.go
@@ -60,6 +60,55 @@ func TestEPRegensOverTurnsAndClamps(t *testing.T) {
 	}
 }
 
+func TestCastSpellAtDamages(t *testing.T) {
+	g := combatGame() // player at (1,1), all floor
+	g.EP, g.EPMax = 10, 10
+	rat := &Creature{Def: &content.MonsterDef{ID: "rat", Name: "rat", HP: 3}, Pos: Pos{4, 1}, HP: 3}
+	g.Level.Creatures = append(g.Level.Creatures, rat)
+	book := &Item{Def: &content.ItemDef{Name: "spellbook of force bolt", Kind: "spellbook", Ranged: 6, Damage: "10d1", Cost: 5}}
+
+	g.CastSpellAt(book, Pos{4, 1})
+
+	if g.Level.CreatureAt(Pos{4, 1}) != nil {
+		t.Error("force bolt should kill the rat (10 dmg vs 3 HP)")
+	}
+	if g.EP != 5 {
+		t.Errorf("EP = %d, want 5 after a cost-5 cast", g.EP)
+	}
+}
+
+func TestCastSpellAtRefusedConditions(t *testing.T) {
+	mk := func() (*Game, *Item, Pos) {
+		g := combatGame()
+		g.EP, g.EPMax = 10, 10
+		rat := &Creature{Def: &content.MonsterDef{ID: "rat", Name: "rat", HP: 3}, Pos: Pos{4, 1}, HP: 3}
+		g.Level.Creatures = append(g.Level.Creatures, rat)
+		book := &Item{Def: &content.ItemDef{Name: "bolt", Kind: "spellbook", Ranged: 6, Damage: "10d1", Cost: 5}}
+		return g, book, rat.Pos
+	}
+
+	g, book, pos := mk()
+	g.EP = 2
+	g.CastSpellAt(book, pos)
+	if g.EP != 2 || g.Level.CreatureAt(pos) == nil {
+		t.Error("a spell you can't afford should not fire or spend EP")
+	}
+
+	g, book, pos = mk()
+	book.Def.Ranged = 1 // out of range (distance 3)
+	g.CastSpellAt(book, pos)
+	if g.EP != 10 || g.Level.CreatureAt(pos) == nil {
+		t.Error("an out-of-range cast should be refused (no EP spent)")
+	}
+
+	g, book, pos = mk()
+	g.Level.Set(Pos{3, 1}, g.Content.Tiles["wall"]) // block the line
+	g.CastSpellAt(book, pos)
+	if g.EP != 10 || g.Level.CreatureAt(pos) == nil {
+		t.Error("a cast with no line of sight should be refused (no EP spent)")
+	}
+}
+
 func TestSpellInventoryFiltersSpellbooks(t *testing.T) {
 	g := combatGame()
 	g.Inventory = []*Item{

--- a/go/internal/ui/ui.go
+++ b/go/internal/ui/ui.go
@@ -236,8 +236,17 @@ func Run(g *game.Game, p Prompter, r Renderer) error {
 			for i, it := range spells {
 				names[i] = fmt.Sprintf("%s (%d EP)", g.DisplayName(it), it.Def.Cost)
 			}
-			if idx, ok := p.Menu(MenuSpec{Title: "Cast which spell?", Items: names}); ok && idx >= 0 && idx < len(spells) {
-				g.CastSpell(spells[idx])
+			idx, ok := p.Menu(MenuSpec{Title: "Cast which spell?", Items: names})
+			if !ok || idx < 0 || idx >= len(spells) {
+				break
+			}
+			spell := spells[idx]
+			if spell.Def != nil && spell.Def.Ranged > 0 { // a targeted attack spell
+				if target, ok := p.Target(g.Player); ok {
+					g.CastSpellAt(spell, target)
+				}
+			} else {
+				g.CastSpell(spell)
 			}
 		}
 	}

--- a/go/internal/ui/ui_test.go
+++ b/go/internal/ui/ui_test.go
@@ -84,6 +84,25 @@ func TestRunCastSpell(t *testing.T) {
 	}
 }
 
+func TestRunCastForceBoltAtCreature(t *testing.T) {
+	g := testGame(t, []string{".....", ".@...", "....."})
+	g.RNG = rng.NewWithSeed(1)
+	g.EP, g.EPMax = 10, 10
+	g.Inventory = append(g.Inventory, &game.Item{Def: &content.ItemDef{Name: "spellbook of force bolt", Kind: "spellbook", Ranged: 6, Damage: "10d1", Cost: 5}})
+	g.Level.Creatures = append(g.Level.Creatures, &game.Creature{Def: &content.MonsterDef{ID: "rat", Name: "rat", HP: 3}, Pos: game.Pos{X: 3, Y: 1}, HP: 3})
+	g.UpdateFOV()
+	p := &zapPrompter{actions: []Action{{Kind: ActCast}, {Kind: ActQuit}}, target: game.Pos{X: 3, Y: 1}}
+	if err := Run(g, p, &nullRenderer{}); err != nil {
+		t.Fatal(err)
+	}
+	if len(g.Level.Creatures) != 0 {
+		t.Error("casting force bolt should have killed the rat")
+	}
+	if g.EP != 5 {
+		t.Errorf("EP = %d, want 5 after casting a cost-5 spell", g.EP)
+	}
+}
+
 func TestBuildViewShowsEffects(t *testing.T) {
 	g := testGame(t, []string{".@."})
 	g.PlayerHP, g.PlayerMax = 10, 20


### PR DESCRIPTION
## Offensive spells — force bolt (targeted casting) — #15

Gives the spell system teeth: a **targeted attack spell** you aim with the cursor. Ships **force bolt** — cast (`c`), aim, blast a creature for EP. Reuses the 15i cast loop plus the `Target` cursor + `lineOfSight` already built for wands/bows.

### What's new
- A spellbook is now either a **utility** spell (`use` behavior, e.g. first aid) or a **targeted attack** (`ranged` + `damage`, no behavior). Spellbook validation accepts either (and `cost > 0`); `ValidateItemUses` skips books with no `use`.
- **`Game.CastSpellAt(book, target)`** — refuses (no EP, no turn) when EP is too low, the target is out of range, or `lineOfSight` is blocked; otherwise spends EP, rolls the spell's damage against the creature (kill via `killCreature`), and passes a turn.
- **`ActCast`** aims (`Target` → `CastSpellAt`) when the chosen spell has range; utility spells still cast in place.
- **Data:** `spellbook_force_bolt` (ranged 6, 2d6, 5 EP).

### Scope
Single-target bolt. Line/beam spells (frost ray) and status/AoE spells layer on the same cast+target flow next.

### Tests (TDD)
- content: a ranged-damage spellbook (no use) validates; one with neither use nor ranged-damage is rejected.
- game: casting at a creature in range/LOS spends EP + kills + passes a turn; out of range / blocked LOS / too little EP each refuse with no EP spent.
- ui: Run casts force bolt at a creature via a fake Target (creature removed, EP drops) — assertion checks the creature is actually gone, not merely off the tile.
- data: `spellbook_force_bolt` golden.

`gofmt`/`go vet`/`go test ./...`/`go build` all green.

Part of #15 (magic — offensive spells).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added targeted spell-casting system with cursor-based positioning during combat.
  * Introduced Force Bolt spellbook with ranged attack capability and damage resolution.
  * Implemented range and line-of-sight validation for targeted spells.

* **Documentation**
  * Added offensive spells implementation plan documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->