### PR TITLE
feat: potion of blindness — #15

### DIFF
--- a/docs/superpowers/plans/2026-06-08-blindness-15k.md
+++ b/docs/superpowers/plans/2026-06-08-blindness-15k.md
@@ -1,0 +1,36 @@
+# Blindness 15k Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** The **potion of blindness** (`treasure_p_blindness`) — a faithful "bad"
+potion that adds a `blind` player status, shrinking your sight to a single tile
+until it wears off. Reuses the `visionRadius` plumbing from the darkness work, and
+lays the `blind` status that the `flash` spell will later inflict on monsters.
+
+## Design
+- A **`blind`** player effect (timed, no HP cost — the existing `tickEffects`
+  already decrements/expires unknown kinds). While active, **`visionRadius`
+  returns `BlindVisionRadius` (1)**, overriding level light and any torch.
+- `Game.HasEffect(kind)` mirrors `Creature.HasEffect` for the player.
+  `effectLabels["blind"] = "Blinded"` so the HUD shows it.
+- The **`blindness`** behavior grants `blind` for `Power` turns — another reason
+  to identify before you quaff.
+
+## Task 1: game + behavior (TDD)
+**Files:** `internal/game/effects.go` (HasEffect, label), `internal/game/fov.go`
+(BlindVisionRadius, visionRadius blind branch), `internal/behaviors/behaviors.go`,
+tests
+- Tests first: a blind player's `visionRadius` is `BlindVisionRadius` even with a
+  torch on a dark level; the `blindness` behavior adds the `blind` effect for
+  `Power` turns; the HUD label reads "Blinded".
+- Commit: `feat(game): blindness status shrinks vision`
+
+## Task 2: data + golden + ship
+**Files:** `data/items.toml`, `data/data_test.go`
+- `potion_blindness` (use `blindness`, power = blind turns). Golden test.
+- Commit: `feat(data): potion of blindness`
+- Full gate; push, PR, CodeRabbit loop → merge. Advances #15.
+
+## Done when
+Quaffing an unidentified potion can strike you blind — your view collapses to the
+tile you stand on until it passes. Suite green.

--- a/go/data/data_test.go
+++ b/go/data/data_test.go
@@ -133,6 +133,17 @@ func TestEmbeddedRangedWeapons(t *testing.T) {
 	}
 }
 
+// TestEmbeddedPotionBlindness checks the blindness potion loaded.
+func TestEmbeddedPotionBlindness(t *testing.T) {
+	c, err := content.Load(Files)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if p := c.Items["potion_blindness"]; p == nil || p.Kind != "potion" || p.Use != "blindness" || p.Power <= 0 {
+		t.Errorf("potion_blindness def unexpected: %+v", p)
+	}
+}
+
 // TestEmbeddedSpellbook checks the first-aid spellbook loaded.
 func TestEmbeddedSpellbook(t *testing.T) {
 	c, err := content.Load(Files)

--- a/go/data/items.toml
+++ b/go/data/items.toml
@@ -166,6 +166,14 @@ kind = "potion"
 use = "pain"
 power = 8
 
+[item.potion_blindness]
+name = "potion of blindness"
+glyph = "!"
+color = "black"
+kind = "potion"
+use = "blindness"
+power = 12
+
 [item.scroll_identify]
 name = "scroll of identify"
 glyph = "?"

--- a/go/internal/behaviors/behaviors.go
+++ b/go/internal/behaviors/behaviors.go
@@ -23,6 +23,7 @@ func Registry() map[string]game.Behavior {
 		"identify":        identifyScroll,
 		"recharge":        recharge,
 		"first_aid":       firstAid,
+		"blindness":       blindness,
 	}
 }
 
@@ -99,6 +100,12 @@ func identifyScroll(g *game.Game, it *game.Item) []string {
 	was := g.DisplayName(pick)
 	g.IdentifyItem(pick)
 	return []string{fmt.Sprintf("Your %s is revealed to be a %s.", was, pick.Def.Name)}
+}
+
+// blindness blinds the drinker for Power turns — a faithful "bad" potion.
+func blindness(g *game.Game, it *game.Item) []string {
+	g.AddEffect("blind", it.Def.Power)
+	return []string{fmt.Sprintf("You drink the %s and the world goes dark!", it.Def.Name)}
 }
 
 // firstAid is the first-aid spell — it knits wounds over time (a regen effect),

--- a/go/internal/behaviors/behaviors_test.go
+++ b/go/internal/behaviors/behaviors_test.go
@@ -142,6 +142,18 @@ func TestRechargeAddsCharges(t *testing.T) {
 	}
 }
 
+func TestBlindnessAddsEffect(t *testing.T) {
+	blind, ok := Registry()["blindness"]
+	if !ok {
+		t.Fatal("blindness not registered")
+	}
+	g := &game.Game{PlayerHP: 10, PlayerMax: 10}
+	blind(g, &game.Item{Def: &content.ItemDef{Name: "potion of blindness", Power: 8}})
+	if len(g.Effects) != 1 || g.Effects[0].Kind != "blind" || g.Effects[0].Turns != 8 {
+		t.Errorf("drinking blindness should blind the player for Power turns, got %v", g.Effects)
+	}
+}
+
 func TestFirstAidGrantsRegen(t *testing.T) {
 	firstAid, ok := Registry()["first_aid"]
 	if !ok {

--- a/go/internal/game/darkness_test.go
+++ b/go/internal/game/darkness_test.go
@@ -51,6 +51,30 @@ func TestCarriedTorchLightsTheDark(t *testing.T) {
 	}
 }
 
+func TestBlindnessOverridesVision(t *testing.T) {
+	g := combatGame()
+	g.Level.Dark = true
+	g.Inventory = append(g.Inventory, &Item{Def: &content.ItemDef{Name: "torch", Kind: "light", Light: 8}})
+	if r := g.visionRadius(); r != 8 { // sanity: a bright torch lights the dark
+		t.Fatalf("torch should give radius 8, got %d", r)
+	}
+	g.AddEffect("blind", 5)
+	if r := g.visionRadius(); r != BlindVisionRadius {
+		t.Errorf("a blind player should see only %d tiles, got %d", BlindVisionRadius, r)
+	}
+}
+
+func TestPlayerHasEffect(t *testing.T) {
+	g := &Game{}
+	if g.HasEffect("blind") {
+		t.Error("no effect should be present initially")
+	}
+	g.AddEffect("blind", 3)
+	if !g.HasEffect("blind") {
+		t.Error("HasEffect should report the active blind effect")
+	}
+}
+
 func TestTorchNoEffectWhenLit(t *testing.T) {
 	g := combatGame() // lit
 	g.Inventory = append(g.Inventory, &Item{Def: &content.ItemDef{Name: "torch", Kind: "light", Light: 99}})

--- a/go/internal/game/effects.go
+++ b/go/internal/game/effects.go
@@ -13,6 +13,18 @@ var effectLabels = map[string]string{
 	"poison": "Poisoned",
 	"regen":  "Regenerating",
 	"slow":   "Slowed",
+	"blind":  "Blinded",
+}
+
+// HasEffect reports whether a timed effect of the given kind is active on the
+// player.
+func (g *Game) HasEffect(kind string) bool {
+	for _, e := range g.Effects {
+		if e.Kind == kind {
+			return true
+		}
+	}
+	return false
 }
 
 // effectVerbs phrases how a source inflicts an effect, for the zap message.

--- a/go/internal/game/fov.go
+++ b/go/internal/game/fov.go
@@ -5,13 +5,18 @@ import "github.com/c0ze/tsl/internal/fov"
 // VisionRadius is how far the player can see on a normally-lit level, in tiles.
 // DarkVisionRadius is the reduced reach on an unlit (dark) level.
 const (
-	VisionRadius     = 8
-	DarkVisionRadius = 3
+	VisionRadius      = 8
+	DarkVisionRadius  = 3
+	BlindVisionRadius = 1
 )
 
-// visionRadius is the player's current sight radius. On a dark level it shrinks
-// to DarkVisionRadius, but a carried light source (a torch) pushes it back out.
+// visionRadius is the player's current sight radius. Blindness collapses it to a
+// single tile (overriding any light); otherwise a dark level shrinks it to
+// DarkVisionRadius, which a carried light source (a torch) pushes back out.
 func (g *Game) visionRadius() int {
+	if g.HasEffect("blind") {
+		return BlindVisionRadius
+	}
 	if g.Level == nil || !g.Level.Dark {
 		return VisionRadius
 	}


### PR DESCRIPTION
## Potion of blindness — #15

A faithful "bad" potion (`treasure_p_blindness`): quaffing an unknown potion can strike you near-blind, collapsing your view to the tile you stand on until it wears off. Reuses the `visionRadius` plumbing from the darkness work.

### What's new
- A **`blind`** player status (timed; the existing `tickEffects` already expires it). While active, **`visionRadius` returns `BlindVisionRadius` (1)**, overriding level light and any torch.
- `Game.HasEffect(kind)` (player) mirrors `Creature.HasEffect`; `effectLabels` shows "Blinded".
- The **`blindness`** behavior blinds the drinker for `Power` turns.
- **Data:** `potion_blindness` (black `!`, 12 turns).

This also lays the `blind` status the `flash` spell will later inflict on monsters.

### Tests (TDD)
- game: a blind player's `visionRadius` is 1 even with a bright torch on a dark level; `HasEffect` reports the blind status.
- behaviors: blindness adds the `blind` effect for `Power` turns.
- data: `potion_blindness` golden.

`gofmt`/`go vet`/`go test ./...`/`go build` all green.

Part of #15 (potions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Potion of Blindness: a new consumable item that temporarily blinds the player for multiple turns, drastically limiting vision range. The HUD displays a "Blinded" status indicator while the effect is active.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->