### PR TITLE
feat: frost ray — beam attack spell — #15

### DIFF
--- a/docs/superpowers/plans/2026-06-08-frost-ray-15l.md
+++ b/docs/superpowers/plans/2026-06-08-frost-ray-15l.md
@@ -1,0 +1,40 @@
+# Frost Ray 15l Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** A **beam** attack spell (`frost_ray` in `magic.c`): unlike force bolt's
+single hit, a frost ray lances in a straight line and **strikes every creature in
+its path** until a wall stops it. Extends the cast + target flow (15i/j) — no new
+subsystem.
+
+## Design
+- **`ItemDef.Beam bool`** (`beam`) marks a spellbook as a line attack. A beam
+  reuses `ranged` (length) and `damage`.
+- **`CastSpellAt`** branches: a beam spell spends EP and calls `fireBeam`; a
+  single-target spell keeps today's range + LOS path. `fireBeam` steps an
+  8-directional line from the player toward the aimed tile, up to `ranged`,
+  damaging each creature it crosses (`killCreature` on a kill) and stopping at the
+  first opaque tile (a wall or closed door).
+- The beam fires in the aimed direction (the cursor picks one of 8 directions); a
+  beam costs EP whether or not it hits (you loosed it).
+
+**Scope:** straight 8-directional beam. True Bresenham-through-target and
+elemental side effects (freezing) are later.
+
+## Task 1: content + game — beam casting (TDD)
+**Files:** `internal/content/content.go` (Beam field), `internal/game/spell.go`
+(fireBeam + CastSpellAt branch, signOf), tests
+- Tests first: a beam spellbook loads with `Beam`; casting a beam down a row of
+  two creatures kills **both** and spends EP; a wall between stops the beam at the
+  wall (a creature behind it is unharmed).
+- Commit: `feat(game): beam attack spells (frost ray)`
+
+## Task 2: data + golden + ship
+**Files:** `data/items.toml`, `data/data_test.go`
+- `spellbook_frost_ray` (beam, ranged, damage, cost). Golden test.
+- Commit: `feat(data): spellbook of frost ray`
+- Full gate; push, PR, CodeRabbit loop → merge. Advances #15 (magic).
+
+## Done when
+Cast frost ray down a corridor and watch it tear through a whole line of
+monsters, stopping at the far wall. Suite green.

--- a/go/data/data_test.go
+++ b/go/data/data_test.go
@@ -159,6 +159,11 @@ func TestEmbeddedSpellbook(t *testing.T) {
 	if fb == nil || fb.Kind != "spellbook" || fb.Ranged <= 0 || fb.Damage == "" || fb.Cost <= 0 {
 		t.Errorf("spellbook_force_bolt def unexpected: %+v", fb)
 	}
+	// The frost-ray spellbook is a beam attack (strikes a whole line).
+	fr := c.Items["spellbook_frost_ray"]
+	if fr == nil || fr.Kind != "spellbook" || !fr.Beam || fr.Ranged <= 0 || fr.Damage == "" || fr.Cost <= 0 {
+		t.Errorf("spellbook_frost_ray def unexpected: %+v", fr)
+	}
 }
 
 // TestEmbeddedConsumableBreadth checks the 15h consumables loaded with the right

--- a/go/data/items.toml
+++ b/go/data/items.toml
@@ -270,6 +270,17 @@ ranged = 6
 damage = "2d6"
 cost = 5
 
+# Beam spell — frost ray tears through a whole line of creatures.
+[item.spellbook_frost_ray]
+name = "spellbook of frost ray"
+glyph = "+"
+color = "cyan"
+kind = "spellbook"
+beam = true
+ranged = 6
+damage = "2d4"
+cost = 6
+
 # Light source (#18) — carry it to see in the dark (light = sight radius there).
 [item.torch]
 name = "torch"

--- a/go/internal/content/content.go
+++ b/go/internal/content/content.go
@@ -90,6 +90,7 @@ type ItemDef struct {
 	Ranged      int    `toml:"ranged"`       // weapon firing range in tiles (0 = melee only)
 	Light       int    `toml:"light"`        // vision radius provided while carried (0 = none)
 	Cost        int    `toml:"cost"`         // EP cost to cast (spellbooks)
+	Beam        bool   `toml:"beam"`         // a spell that strikes every creature in a line
 	NoSpawn     bool   `toml:"nospawn"`      // exclude from random floor loot (e.g. corpses)
 }
 

--- a/go/internal/content/content.go
+++ b/go/internal/content/content.go
@@ -443,6 +443,14 @@ func validateItem(i *ItemDef) error {
 	if i.Light < 0 {
 		return fmt.Errorf("light must be >= 0, got %d", i.Light)
 	}
+	if i.Beam { // a beam is a spellbook line attack: it needs the attack fields
+		if i.Kind != "spellbook" {
+			return fmt.Errorf("only a spellbook may be a beam")
+		}
+		if i.Ranged <= 0 || !validDamageSpec(i.Damage) {
+			return fmt.Errorf("a beam spellbook needs ranged > 0 and a valid damage spec")
+		}
+	}
 	return nil
 }
 

--- a/go/internal/content/content_test.go
+++ b/go/internal/content/content_test.go
@@ -604,6 +604,17 @@ func TestLoadRejectsUselessSpellbook(t *testing.T) {
 	}
 }
 
+func TestLoadBeamSpellbook(t *testing.T) {
+	dir := writeItemsFixture(t, "[item.ray]\nname=\"spellbook of frost ray\"\nglyph=\"+\"\ncolor=\"cyan\"\nkind=\"spellbook\"\nbeam=true\nranged=6\ndamage=\"2d4\"\ncost=6\n")
+	c, err := Load(os.DirFS(dir))
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if b := c.Items["ray"]; b == nil || !b.Beam || b.Ranged != 6 {
+		t.Errorf("frost-ray spellbook unexpected: %+v", b)
+	}
+}
+
 func TestLoadDamageSpellbook(t *testing.T) {
 	dir := writeItemsFixture(t, "[item.bolt]\nname=\"spellbook of force bolt\"\nglyph=\"+\"\ncolor=\"red\"\nkind=\"spellbook\"\nranged=6\ndamage=\"2d6\"\ncost=5\n")
 	c, err := Load(os.DirFS(dir))

--- a/go/internal/content/content_test.go
+++ b/go/internal/content/content_test.go
@@ -615,6 +615,13 @@ func TestLoadBeamSpellbook(t *testing.T) {
 	}
 }
 
+func TestLoadRejectsBeamWithoutAttack(t *testing.T) {
+	dir := writeItemsFixture(t, "[item.ray]\nname=\"bad ray\"\nglyph=\"+\"\ncolor=\"cyan\"\nkind=\"spellbook\"\nbeam=true\nuse=\"first_aid\"\ncost=6\n")
+	if _, err := Load(os.DirFS(dir)); err == nil {
+		t.Fatal("expected error: a beam spellbook needs ranged + damage")
+	}
+}
+
 func TestLoadDamageSpellbook(t *testing.T) {
 	dir := writeItemsFixture(t, "[item.bolt]\nname=\"spellbook of force bolt\"\nglyph=\"+\"\ncolor=\"red\"\nkind=\"spellbook\"\nranged=6\ndamage=\"2d6\"\ncost=5\n")
 	c, err := Load(os.DirFS(dir))

--- a/go/internal/game/spell.go
+++ b/go/internal/game/spell.go
@@ -53,6 +53,12 @@ func (g *Game) CastSpellAt(book *Item, target Pos) {
 		g.log("You lack the energy to cast %s.", book.Def.Name)
 		return
 	}
+	if book.Def.Beam { // a beam fires in the aimed direction, hitting all in its path
+		g.EP -= book.Def.Cost
+		g.fireBeam(book, target)
+		g.monstersAct()
+		return
+	}
 	if chebyshev(g.Player, target) > book.Def.Ranged {
 		g.log("That is out of range.")
 		return
@@ -73,6 +79,51 @@ func (g *Game) CastSpellAt(book *Item, target Pos) {
 		g.log("The spell dissipates against nothing.")
 	}
 	g.monstersAct()
+}
+
+// fireBeam traces a straight 8-directional ray from the player toward target, up
+// to the spell's range, damaging every creature it crosses (killing at 0 HP) and
+// stopping at the first opaque tile — a wall or a closed door.
+func (g *Game) fireBeam(book *Item, target Pos) {
+	dx, dy := signOf(target.X-g.Player.X), signOf(target.Y-g.Player.Y)
+	if dx == 0 && dy == 0 {
+		g.log("The %s fizzles.", book.Def.Name)
+		return
+	}
+	hits := 0
+	x, y := g.Player.X, g.Player.Y
+	for i := 0; i < book.Def.Ranged; i++ {
+		x += dx
+		y += dy
+		p := Pos{X: x, Y: y}
+		if !g.Level.InBounds(p) || !g.Level.At(p).Def.Transparent {
+			break // a wall (or the level edge) stops the ray
+		}
+		if m := g.Level.CreatureAt(p); m != nil {
+			dmg := g.RNG.RollSpec(book.Def.Damage)
+			m.HP -= dmg
+			g.log("Your %s rakes the %s for %d.", book.Def.Name, m.Def.Name, dmg)
+			if m.HP <= 0 {
+				g.killCreature(m)
+			}
+			hits++
+		}
+	}
+	if hits == 0 {
+		g.log("The ray strikes nothing.")
+	}
+}
+
+// signOf returns -1, 0, or +1 matching the sign of n.
+func signOf(n int) int {
+	switch {
+	case n > 0:
+		return 1
+	case n < 0:
+		return -1
+	default:
+		return 0
+	}
 }
 
 // regenEP restores one EP every epRegenInterval turns, clamped to EPMax. Called

--- a/go/internal/game/spell_test.go
+++ b/go/internal/game/spell_test.go
@@ -140,6 +140,9 @@ func TestFrostRayStoppedByWall(t *testing.T) {
 	if len(g.Level.Creatures) != 1 {
 		t.Error("a wall should stop the beam; the creature behind it should survive")
 	}
+	if g.EP != 4 {
+		t.Errorf("a beam still costs EP even when blocked: EP = %d, want 4", g.EP)
+	}
 }
 
 func TestSpellInventoryFiltersSpellbooks(t *testing.T) {

--- a/go/internal/game/spell_test.go
+++ b/go/internal/game/spell_test.go
@@ -109,6 +109,39 @@ func TestCastSpellAtRefusedConditions(t *testing.T) {
 	}
 }
 
+func TestFrostRayHitsLine(t *testing.T) {
+	g := combatGame() // 10x3 all floor, player at (1,1)
+	g.EP, g.EPMax = 10, 10
+	a := &Creature{Def: &content.MonsterDef{ID: "rat", Name: "rat", HP: 3}, Pos: Pos{3, 1}, HP: 3}
+	b := &Creature{Def: &content.MonsterDef{ID: "rat", Name: "rat", HP: 3}, Pos: Pos{5, 1}, HP: 3}
+	g.Level.Creatures = append(g.Level.Creatures, a, b)
+	book := &Item{Def: &content.ItemDef{Name: "spellbook of frost ray", Kind: "spellbook", Beam: true, Ranged: 8, Damage: "10d1", Cost: 6}}
+
+	g.CastSpellAt(book, Pos{5, 1}) // aim east, down the line of creatures
+
+	if len(g.Level.Creatures) != 0 {
+		t.Errorf("frost ray should strike every creature in the line, %d remain", len(g.Level.Creatures))
+	}
+	if g.EP != 4 {
+		t.Errorf("EP = %d, want 4 after a cost-6 cast", g.EP)
+	}
+}
+
+func TestFrostRayStoppedByWall(t *testing.T) {
+	g := combatGame()
+	g.EP, g.EPMax = 10, 10
+	g.Level.Set(Pos{4, 1}, g.Content.Tiles["wall"])
+	behind := &Creature{Def: &content.MonsterDef{ID: "rat", Name: "rat", HP: 3}, Pos: Pos{5, 1}, HP: 3}
+	g.Level.Creatures = append(g.Level.Creatures, behind)
+	book := &Item{Def: &content.ItemDef{Name: "ray", Kind: "spellbook", Beam: true, Ranged: 8, Damage: "10d1", Cost: 6}}
+
+	g.CastSpellAt(book, Pos{5, 1})
+
+	if len(g.Level.Creatures) != 1 {
+		t.Error("a wall should stop the beam; the creature behind it should survive")
+	}
+}
+
 func TestSpellInventoryFiltersSpellbooks(t *testing.T) {
 	g := combatGame()
 	g.Inventory = []*Item{


### PR DESCRIPTION
## Frost ray — a beam attack spell — #15

Unlike force bolt's single hit, **frost ray lances in a straight line and strikes every creature in its path** until a wall stops it. Extends the cast + target flow from 15i/j — no new subsystem.

### What's new
- **`ItemDef.Beam`** marks a spellbook as a line attack (reusing `ranged` for length, `damage` per hit).
- **`CastSpellAt`** branches: a beam spends EP and calls **`fireBeam`**, which steps an 8-directional ray from the player toward the aimed tile, up to `ranged`, damaging each creature it crosses (`killCreature` on a kill) and stopping at the first opaque tile (wall/closed door). A beam costs EP whether or not it connects.
- **Data:** `spellbook_frost_ray` (cyan `+`, beam, ranged 6, 2d4, 6 EP).

### Scope
Straight 8-directional beam. True Bresenham-through-target and a freezing side-effect are later.

### Tests (TDD)
- content: a beam spellbook loads with `Beam`.
- game: casting a beam down a row of two creatures kills **both** and spends EP; a wall between stops the beam (the creature behind it survives).
- data: `spellbook_frost_ray` golden.

`gofmt`/`go vet`/`go test ./...`/`go build` all green.

Part of #15 (magic — beam spells). The spell list now covers utility (first aid), single-target (force bolt), and line (frost ray).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "Frost Ray" beam spell that fires in a straight line, damages all creatures hit until blocked, and consumes EP

* **Configuration**
  * Spell configured with 6 range, 2d4 damage, 6 EP cost

* **Documentation**
  * Added implementation plan for the Frost Ray spell

* **Tests**
  * Added tests validating beam behavior, obstacle blocking, and EP consumption
<!-- end of auto-generated comment: release notes by coderabbit.ai -->