### PR TITLE
feat: flash — AoE blind spell — #15

### DIFF
--- a/docs/superpowers/plans/2026-06-08-flash-15m.md
+++ b/docs/superpowers/plans/2026-06-08-flash-15m.md
@@ -1,0 +1,39 @@
+# Flash 15m Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** The **flash** spell (`magic.c`): a burst of light that **blinds every
+creature around you**, so the pack loses your trail and you can slip away or
+reposition. Reuses the `blind` status (now on creatures) and adds a one-line AI
+rule. A utility spell — no target.
+
+## Design
+- **Blind AI:** in `monsterAct`, a creature with the `blind` effect can't find the
+  player at range — it only attacks when already adjacent; otherwise it holds.
+  (One check using the existing `Creature.HasEffect`.)
+- **`Game.FlashBlind(radius, turns) int`** blinds every creature within `radius`
+  (Chebyshev) of the player for `turns` and returns how many were blinded.
+- The **`flash`** behavior calls `FlashBlind(FlashRadius, Power)`; cast via the
+  utility path (no `ranged`, so `ActCast` casts it in place).
+
+**Scope:** blind only (no damage/light-pillar). Fixed radius.
+
+## Task 1: game — blind AI + FlashBlind (TDD)
+**Files:** `internal/game/combat.go` (monsterAct), `internal/game/spell.go`
+(FlashBlind, FlashRadius), tests
+- Tests first: a blinded monster at range holds instead of approaching (but still
+  melees when adjacent); `FlashBlind` blinds creatures within radius and returns
+  the count.
+- Commit: `feat(game): blinded monsters lose the player; FlashBlind AoE`
+
+## Task 2: behavior + data + ship
+**Files:** `internal/behaviors/behaviors.go`, `data/items.toml`,
+`internal/behaviors/behaviors_test.go`, `data/data_test.go`
+- `flash` behavior → `FlashBlind`. `spellbook_flash` (use `flash`, power = blind
+  turns, cost). Golden + behavior tests.
+- Commit: `feat(data): spellbook of flash`
+- Full gate; push, PR, CodeRabbit loop → merge. Advances #15 (magic).
+
+## Done when
+Cornered, cast flash: the monsters around you reel, blinded, and stop chasing for
+a while. Suite green.

--- a/go/data/data_test.go
+++ b/go/data/data_test.go
@@ -133,6 +133,17 @@ func TestEmbeddedRangedWeapons(t *testing.T) {
 	}
 }
 
+// TestEmbeddedFlash checks the flash spellbook loaded.
+func TestEmbeddedFlash(t *testing.T) {
+	c, err := content.Load(Files)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if b := c.Items["spellbook_flash"]; b == nil || b.Kind != "spellbook" || b.Use != "flash" || b.Cost <= 0 {
+		t.Errorf("spellbook_flash def unexpected: %+v", b)
+	}
+}
+
 // TestEmbeddedPotionBlindness checks the blindness potion loaded.
 func TestEmbeddedPotionBlindness(t *testing.T) {
 	c, err := content.Load(Files)

--- a/go/data/items.toml
+++ b/go/data/items.toml
@@ -261,6 +261,16 @@ use = "first_aid"
 cost = 4
 power = 8
 
+# Utility spell — flash blinds the creatures around you (power = blind turns).
+[item.spellbook_flash]
+name = "spellbook of flash"
+glyph = "+"
+color = "normal"
+kind = "spellbook"
+use = "flash"
+cost = 5
+power = 8
+
 [item.spellbook_force_bolt]
 name = "spellbook of force bolt"
 glyph = "+"

--- a/go/internal/behaviors/behaviors.go
+++ b/go/internal/behaviors/behaviors.go
@@ -24,6 +24,7 @@ func Registry() map[string]game.Behavior {
 		"recharge":        recharge,
 		"first_aid":       firstAid,
 		"blindness":       blindness,
+		"flash":           flash,
 	}
 }
 
@@ -106,6 +107,16 @@ func identifyScroll(g *game.Game, it *game.Item) []string {
 func blindness(g *game.Game, it *game.Item) []string {
 	g.AddEffect("blind", it.Def.Power)
 	return []string{fmt.Sprintf("You drink the %s and the world goes dark!", it.Def.Name)}
+}
+
+// flash is the flash spell — a burst of light that blinds the creatures around
+// the caster, breaking the pack's pursuit.
+func flash(g *game.Game, it *game.Item) []string {
+	n := g.FlashBlind(game.FlashRadius, it.Def.Power)
+	if n == 0 {
+		return []string{fmt.Sprintf("You cast %s, but no creatures are near.", it.Def.Name)}
+	}
+	return []string{fmt.Sprintf("Light erupts from %s, blinding %d nearby creature(s)!", it.Def.Name, n)}
 }
 
 // firstAid is the first-aid spell — it knits wounds over time (a regen effect),

--- a/go/internal/behaviors/behaviors_test.go
+++ b/go/internal/behaviors/behaviors_test.go
@@ -142,6 +142,21 @@ func TestRechargeAddsCharges(t *testing.T) {
 	}
 }
 
+func TestFlashBlindsNearby(t *testing.T) {
+	flash, ok := Registry()["flash"]
+	if !ok {
+		t.Fatal("flash not registered")
+	}
+	floor := &content.TileDef{ID: "floor", Glyph: ".", Color: content.ColorNormal, Passable: true, Transparent: true}
+	g := &game.Game{Level: game.NewLevel(10, 3, floor), Player: game.Pos{X: 1, Y: 1}}
+	rat := &game.Creature{Def: &content.MonsterDef{ID: "rat", Name: "rat", HP: 3}, Pos: game.Pos{X: 3, Y: 1}, HP: 3}
+	g.Level.Creatures = append(g.Level.Creatures, rat)
+	flash(g, &game.Item{Def: &content.ItemDef{Name: "spellbook of flash", Power: 6}})
+	if !rat.HasEffect("blind") {
+		t.Error("flash should blind a nearby creature")
+	}
+}
+
 func TestBlindnessAddsEffect(t *testing.T) {
 	blind, ok := Registry()["blindness"]
 	if !ok {

--- a/go/internal/game/combat.go
+++ b/go/internal/game/combat.go
@@ -229,6 +229,9 @@ func (g *Game) monsterAct(m *Creature) {
 		g.monsterAttacks(m)
 		return
 	}
+	if m.HasEffect("blind") {
+		return // blinded: it can flail at an adjacent foe but can't track at range
+	}
 	if m.Def.Ranged > 0 && dist <= m.Def.Ranged && g.lineOfSight(m.Pos, g.Player) {
 		g.rangedAttack(m)
 		return

--- a/go/internal/game/spell.go
+++ b/go/internal/game/spell.go
@@ -81,6 +81,22 @@ func (g *Game) CastSpellAt(book *Item, target Pos) {
 	g.monstersAct()
 }
 
+// FlashRadius is how far the flash spell's blinding light reaches.
+const FlashRadius = 4
+
+// FlashBlind blinds every creature within radius (Chebyshev) of the player for
+// turns and reports how many were blinded — the flash spell's area effect.
+func (g *Game) FlashBlind(radius, turns int) int {
+	n := 0
+	for _, m := range g.Level.Creatures {
+		if chebyshev(m.Pos, g.Player) <= radius {
+			m.AddEffect("blind", turns)
+			n++
+		}
+	}
+	return n
+}
+
 // fireBeam traces a straight 8-directional ray from the player toward target, up
 // to the spell's range, damaging every creature it crosses (killing at 0 HP) and
 // stopping at the first opaque tile — a wall or a closed door.

--- a/go/internal/game/spell_test.go
+++ b/go/internal/game/spell_test.go
@@ -145,6 +145,53 @@ func TestFrostRayStoppedByWall(t *testing.T) {
 	}
 }
 
+func TestFlashBlindBlindsNearby(t *testing.T) {
+	g := combatGame()                                                                             // player at (1,1)
+	near := &Creature{Def: &content.MonsterDef{ID: "a", Name: "a", HP: 3}, Pos: Pos{3, 1}, HP: 3} // dist 2
+	far := &Creature{Def: &content.MonsterDef{ID: "b", Name: "b", HP: 3}, Pos: Pos{9, 1}, HP: 3}  // dist 8
+	g.Level.Creatures = append(g.Level.Creatures, near, far)
+
+	n := g.FlashBlind(4, 6)
+
+	if n != 1 {
+		t.Errorf("FlashBlind radius 4 should blind 1 creature, got %d", n)
+	}
+	if !near.HasEffect("blind") {
+		t.Error("the near creature should be blinded")
+	}
+	if far.HasEffect("blind") {
+		t.Error("the far creature should be out of range")
+	}
+}
+
+func TestBlindMonsterHoldsAtRange(t *testing.T) {
+	g := combatGame()
+	rat := &Creature{Def: &content.MonsterDef{ID: "rat", Name: "rat", HP: 9, Damage: "1d1"}, Pos: Pos{5, 1}, HP: 9}
+	g.Level.Creatures = append(g.Level.Creatures, rat)
+	rat.AddEffect("blind", 10)
+	before := rat.Pos
+
+	g.monstersAct()
+
+	if rat.Pos != before {
+		t.Errorf("a blinded monster should hold position at range, moved to %v", rat.Pos)
+	}
+}
+
+func TestBlindMonsterStillMeleesAdjacent(t *testing.T) {
+	g := combatGame()
+	g.PlayerHP = 20
+	rat := &Creature{Def: &content.MonsterDef{ID: "rat", Name: "rat", HP: 9, Attack: 100, Dodge: 0, Damage: "1d2"}, Pos: Pos{2, 1}, HP: 9}
+	g.Level.Creatures = append(g.Level.Creatures, rat)
+	rat.AddEffect("blind", 10)
+
+	g.monstersAct()
+
+	if g.PlayerHP >= 20 {
+		t.Error("a blinded monster should still attack an adjacent player")
+	}
+}
+
 func TestSpellInventoryFiltersSpellbooks(t *testing.T) {
 	g := combatGame()
 	g.Inventory = []*Item{


### PR DESCRIPTION
## Flash — AoE blind spell — #15

A burst of light that **blinds every creature around you**, so the pack loses your trail and you can slip away or reposition. Reuses the `blind` status (this time on creatures) and adds a one-line AI rule.

### What's new
- **Blind AI:** a blinded creature can flail at an adjacent foe but **can't track the player at range** — it holds instead of approaching (one `HasEffect` check in `monsterAct`).
- **`Game.FlashBlind(radius, turns)`** blinds every creature within `radius` (Chebyshev) of the player and returns the count.
- The **`flash`** behavior calls `FlashBlind(FlashRadius=4, Power)`; cast via the utility path (no `ranged`, so it casts in place).
- **Data:** `spellbook_flash` (utility, 5 EP, 8 blind turns).

### Tests (TDD)
- game: `FlashBlind` blinds creatures within radius and returns the count; a blinded monster holds at range but still melees when adjacent.
- behaviors: flash blinds a nearby creature.
- data: `spellbook_flash` golden.

`gofmt`/`go vet`/`go test ./...`/`go build` all green.

Part of #15 (magic). Spell list now: first aid (heal), force bolt (single), frost ray (beam), flash (AoE control).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the Flash spell—a new utility spell that blinds all nearby creatures in an area-of-effect radius.
  * Updated blinded creature behavior: blinded enemies no longer move toward the player or launch ranged attacks, but will still engage in melee combat when adjacent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->