### PR TITLE
feat: potion of energy (restores EP) — #15

### DIFF
--- a/docs/superpowers/plans/2026-06-08-energy-15n.md
+++ b/docs/superpowers/plans/2026-06-08-energy-15n.md
@@ -1,0 +1,24 @@
+# Potion of Energy 15n Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** The **potion of energy** (`treasure_p_energy`) — restores **EP**,
+closing the spellcasting loop so you can refill your mana instead of only waiting
+for the slow regen.
+
+## Design
+- A **`restore_energy`** behavior raises `Game.EP` by `Power`, clamped to `EPMax`,
+  and reports how much was recovered (mirrors the existing `restoreHP` helper).
+- **`potion_energy`** (use `restore_energy`, power = EP restored).
+
+## Task 1: behavior + data + ship (TDD)
+**Files:** `internal/behaviors/behaviors.go`, `internal/behaviors/behaviors_test.go`,
+`data/items.toml`, `data/data_test.go`
+- Tests first: the behavior raises EP (clamped at max); the embedded potion loads.
+- Implement `restore_energy` (+ a `restoreEP` helper) and register it; add the
+  potion; golden test.
+- Commit: `feat: potion of energy (restores EP)`
+- Full gate; push, PR, CodeRabbit loop → merge. Advances #15.
+
+## Done when
+Quaff a potion of energy and your EP jumps back up, ready to cast again. Suite green.

--- a/go/data/data_test.go
+++ b/go/data/data_test.go
@@ -133,6 +133,17 @@ func TestEmbeddedRangedWeapons(t *testing.T) {
 	}
 }
 
+// TestEmbeddedPotionEnergy checks the energy potion loaded.
+func TestEmbeddedPotionEnergy(t *testing.T) {
+	c, err := content.Load(Files)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if p := c.Items["potion_energy"]; p == nil || p.Kind != "potion" || p.Use != "restore_energy" || p.Power <= 0 {
+		t.Errorf("potion_energy def unexpected: %+v", p)
+	}
+}
+
 // TestEmbeddedFlash checks the flash spellbook loaded.
 func TestEmbeddedFlash(t *testing.T) {
 	c, err := content.Load(Files)

--- a/go/data/items.toml
+++ b/go/data/items.toml
@@ -174,6 +174,15 @@ kind = "potion"
 use = "blindness"
 power = 12
 
+# Potion of energy — refills spell EP (power = EP restored). Closes the cast loop.
+[item.potion_energy]
+name = "potion of energy"
+glyph = "!"
+color = "magenta"
+kind = "potion"
+use = "restore_energy"
+power = 8
+
 [item.scroll_identify]
 name = "scroll of identify"
 glyph = "?"

--- a/go/internal/behaviors/behaviors.go
+++ b/go/internal/behaviors/behaviors.go
@@ -25,6 +25,7 @@ func Registry() map[string]game.Behavior {
 		"first_aid":       firstAid,
 		"blindness":       blindness,
 		"flash":           flash,
+		"restore_energy":  restoreEnergy,
 	}
 }
 
@@ -37,6 +38,23 @@ func restoreHP(g *game.Game, amount int) int {
 		g.PlayerHP = g.PlayerMax
 	}
 	return g.PlayerHP - before
+}
+
+// restoreEP adds amount to the player's EP, clamped to EPMax, and reports how
+// much was actually recovered.
+func restoreEP(g *game.Game, amount int) int {
+	before := g.EP
+	g.EP += amount
+	if g.EP > g.EPMax {
+		g.EP = g.EPMax
+	}
+	return g.EP - before
+}
+
+// restoreEnergy refills spell energy (a potion of energy).
+func restoreEnergy(g *game.Game, it *game.Item) []string {
+	gained := restoreEP(g, it.Def.Power)
+	return []string{fmt.Sprintf("You quaff the %s and your mind sharpens (+%d EP).", it.Def.Name, gained)}
 }
 
 func heal(g *game.Game, it *game.Item) []string {

--- a/go/internal/behaviors/behaviors_test.go
+++ b/go/internal/behaviors/behaviors_test.go
@@ -142,6 +142,23 @@ func TestRechargeAddsCharges(t *testing.T) {
 	}
 }
 
+func TestRestoreEnergyRefillsEP(t *testing.T) {
+	re, ok := Registry()["restore_energy"]
+	if !ok {
+		t.Fatal("restore_energy not registered")
+	}
+	g := &game.Game{EP: 2, EPMax: 10}
+	re(g, &game.Item{Def: &content.ItemDef{Name: "potion of energy", Power: 5}})
+	if g.EP != 7 {
+		t.Errorf("EP = %d, want 7 after restoring 5", g.EP)
+	}
+	g.EP = 8
+	re(g, &game.Item{Def: &content.ItemDef{Name: "potion of energy", Power: 5}})
+	if g.EP != 10 {
+		t.Errorf("EP should clamp at max, got %d", g.EP)
+	}
+}
+
 func TestFlashBlindsNearby(t *testing.T) {
 	flash, ok := Registry()["flash"]
 	if !ok {


### PR DESCRIPTION
## Potion of energy — restores EP — #15

The faithful `treasure_p_energy`: refills **spell EP**, closing the casting loop so you can recharge your mana instead of only waiting for the slow regen.

### What's new
- A **`restore_energy`** behavior raises `Game.EP` by `Power`, clamped to `EPMax` (via a new `restoreEP` helper mirroring `restoreHP`).
- **Data:** `potion_energy` (magenta `!`, +8 EP).

### Tests (TDD)
- behaviors: restoring raises EP and clamps at max.
- data: `potion_energy` golden.

`gofmt`/`go vet`/`go test ./...`/`go build` all green.

Part of #15 (potions/magic).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a new Potion of Energy consumable that restores spell energy points when used.

* **Documentation**
  * Added implementation plan for Potion of Energy with specifications and development requirements.

* **Tests**
  * Added validation tests for potion availability and energy restoration mechanics with maximum clamping.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->