### PR TITLE
feat: monster roster batch 3 (jackal/snake/spider/wolf/wisp/troll) — #13

### DIFF
--- a/go/data/data_test.go
+++ b/go/data/data_test.go
@@ -87,6 +87,40 @@ func TestEmbeddedImp(t *testing.T) {
 	}
 }
 
+// TestEmbeddedRosterBatch3 checks the third monster batch loaded with canon glyphs
+// and that at least one appears in a spawn table.
+func TestEmbeddedRosterBatch3(t *testing.T) {
+	c, err := content.Load(Files)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	want := map[string]rune{
+		"jackal": 'j', "cave_snake": 'S', "giant_spider": 'a',
+		"dire_wolf": 'd', "wisp": 'w', "troll": 'T',
+	}
+	for id, glyph := range want {
+		m := c.Monsters[id]
+		if m == nil {
+			t.Errorf("missing monster %q", id)
+			continue
+		}
+		if m.Rune() != glyph {
+			t.Errorf("%s glyph = %q, want %q", id, m.Rune(), glyph)
+		}
+	}
+	spawned := false
+	for _, l := range c.Levels {
+		for _, s := range l.Spawn {
+			if _, ok := want[s.Monster]; ok {
+				spawned = true
+			}
+		}
+	}
+	if !spawned {
+		t.Error("expected at least one batch-3 monster placed in a spawn table")
+	}
+}
+
 // TestDepthGatedTanks checks the tougher monsters only appear on deeper floors.
 func TestDepthGatedTanks(t *testing.T) {
 	c, err := content.Load(Files)

--- a/go/data/levels.toml
+++ b/go/data/levels.toml
@@ -30,6 +30,9 @@ weight = 2
 [[level.dungeon.spawn]]
 monster = "kobold"
 weight = 2
+[[level.dungeon.spawn]]
+monster = "jackal"
+weight = 2
 
 [level.catacombs]
 name = "the Catacombs"
@@ -56,6 +59,9 @@ weight = 2
 [[level.catacombs.spawn]]
 monster = "zombie"
 weight = 1
+[[level.catacombs.spawn]]
+monster = "giant_spider"
+weight = 2
 
 [level.ominous_cave]
 name = "the Ominous Cave"
@@ -78,6 +84,9 @@ monster = "merman"
 weight = 1
 [[level.ominous_cave.spawn]]
 monster = "bat"
+weight = 2
+[[level.ominous_cave.spawn]]
+monster = "cave_snake"
 weight = 2
 
 [level.laboratory]
@@ -126,6 +135,9 @@ weight = 2
 [[level.comm_hub.spawn]]
 monster = "skeleton"
 weight = 2
+[[level.comm_hub.spawn]]
+monster = "wisp"
+weight = 2
 
 [level.underpass]
 name = "the Underpass"
@@ -148,6 +160,9 @@ monster = "merman"
 weight = 1
 [[level.underpass.spawn]]
 monster = "zombie"
+weight = 2
+[[level.underpass.spawn]]
+monster = "dire_wolf"
 weight = 2
 
 [level.drowned_city]
@@ -215,6 +230,9 @@ monster = "ogre"
 weight = 2
 [[level.dragons_lair.spawn]]
 monster = "imp"
+weight = 2
+[[level.dragons_lair.spawn]]
+monster = "troll"
 weight = 2
 
 [level.chapel]

--- a/go/data/monsters.toml
+++ b/go/data/monsters.toml
@@ -177,6 +177,76 @@ speed = 110
 ranged = 5
 min_depth = 2
 
+# Roster batch 3 (#13) — more beasts across the tiers. Generic corpses where
+# edible; spiders and wisps leave none.
+[monster.jackal]
+name = "jackal"
+glyph = "j"
+color = "brown"
+hp = 4
+attack = 3
+dodge = 2
+damage = "1d3"
+speed = 140
+corpse = "carcass"
+
+[monster.cave_snake]
+name = "cave snake"
+glyph = "S"
+color = "green"
+hp = 6
+attack = 4
+dodge = 2
+damage = "1d4"
+speed = 100
+corpse = "carcass"
+
+[monster.giant_spider]
+name = "giant spider"
+glyph = "a"
+color = "magenta"
+hp = 7
+attack = 4
+dodge = 3
+damage = "1d4"
+speed = 110
+min_depth = 2
+
+[monster.dire_wolf]
+name = "dire wolf"
+glyph = "d"
+color = "brown"
+hp = 10
+attack = 5
+dodge = 2
+damage = "1d6"
+speed = 130
+corpse = "carcass"
+min_depth = 2
+
+[monster.wisp]
+name = "will-o-wisp"
+glyph = "w"
+color = "cyan"
+hp = 3
+attack = 3
+dodge = 4
+damage = "1d3"
+speed = 150
+min_depth = 2
+
+[monster.troll]
+name = "troll"
+glyph = "T"
+color = "green"
+hp = 24
+attack = 6
+dodge = 1
+damage = "2d4"
+speed = 90
+corpse = "carcass"
+min_depth = 3
+
 # Bosses (#16 2c). Deadly guardians — but you win by reaching the altar, so you
 # needn't kill them. Stats are tunable; gear breadth (#14) will make this fairer.
 [monster.elder_mummylich]


### PR DESCRIPTION
## Monster roster batch 3 — #13

Six more beasts across the tiers, bringing the bestiary to ~23 types. Pure data — no engine changes.

| Monster | Glyph | Tier | Notes |
|---|---|---|---|
| jackal | `j` | early | fast pack hunter (speed 140) |
| cave snake | `S` | early | |
| giant spider | `a` | mid | evasive, no corpse |
| dire wolf | `d` | mid | fast, hits hard |
| will-o-wisp | `w` | mid | very fast + evasive, no corpse |
| troll | `T` | deep | bruiser, 2d4, 24 HP |

Corpses reuse the generic `carcass`; spiders/wisps leave none. Each is placed in a level spawn table by depth (jackal/cave snake early; spider/wolf/wisp mid; troll deep).

### Tests
- `TestEmbeddedRosterBatch3` golden: all six load with the expected glyphs and at least one appears in a spawn table. The shipped-data boot validates corpse + spawn refs end-to-end.

`gofmt`/`go vet`/`go test ./...`/`go build` all green.

Part of #13 (toward the ~25 bestiary).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added six new monsters—jackal, cave_snake, giant_spider, dire_wolf, wisp, and troll—to the game
  * New creatures populate various dungeon levels including the catacombs, ominous cave, and dragon's lair
  * Each monster features unique combat attributes and depth-based spawn mechanics

<!-- end of auto-generated comment: release notes by coderabbit.ai -->