### PR TITLE
feat: rings & amulets — passive accessory equip slots (#14)

### DIFF
--- a/docs/superpowers/plans/2026-06-10-rings-amulets-14c.md
+++ b/docs/superpowers/plans/2026-06-10-rings-amulets-14c.md
@@ -1,0 +1,66 @@
+# Rings & Amulets 14c Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** **Rings and amulets** as passive accessory equip slots (#14) — two new
+worn slots, *separate* from weapon and armor, whose bonuses **stack** onto your
+hit and defense. The new mechanic is "two more equip slots," faithful to 0.40
+where items have an `equipped` flag and `item_type` covers body/feet/head/cloak
+plus rings and amulets (`common/item.h`, `common/gent.h: gent_amulet/gent_ring`).
+
+## Design
+- **Content:** two new item kinds, `ring` and `amulet`. Each carries passive
+  `attack` and/or `dodge` bonuses (reusing the existing `ItemDef.Attack`/`Dodge`
+  fields). Validation: a ring/amulet must grant at least one bonus (attack > 0
+  **or** dodge > 0) — analogous to "wand needs damage or effect".
+- **Equip slots:** `Game.Ring` and `Game.Amulet`, mirroring `Weapon`/`Armor`.
+  - `autoEquip` fills an empty slot on pickup (faithful default, never downgrades).
+  - `PlayerUse` on a ring/amulet "puts it on" (swaps into the slot); logs
+    `You put on the %s.`
+- **Stat folding:** generalise `playerAttackStat`/`playerDodgeStat` to sum the
+  relevant bonus across **all** equipped gear (weapon, armor, ring, amulet) via
+  a small `equippedGear()` helper. Weapons carry no dodge and armor no attack
+  today, so summing both fields across all slots is correct and extensible.
+  Damage dice stay weapon-only.
+- **Surfacing:** morgue lists worn ring/amulet; HUD status line shows a `Worn:`
+  segment when an accessory is equipped.
+- **Identify:** rings/amulets are identified-by-default this slice (not added to
+  `unidentifiable`), keeping the slice about the *equip-slot mechanic*. Shuffled
+  ring/amulet *appearances* are a faithful follow-up (slice 2), as is an
+  amulet-of-vitality **max-HP** bonus (needs an effective-max refactor).
+
+## Task 1: content kinds + validation (TDD)
+**Files:** `internal/content/content.go`, `internal/content/content_test.go`
+- Tests first: `ring`/`amulet` are valid kinds; a ring/amulet with no attack and
+  no dodge is rejected; one with a dodge bonus loads.
+- Implement: add `ring`/`amulet` to `validItemKinds`; add a `validateItem` case
+  requiring `Attack > 0 || Dodge > 0`.
+- Commit: `feat(content): ring and amulet accessory kinds`
+
+## Task 2: equip slots + stacked stats (TDD)
+**Files:** `internal/game/game.go`, `internal/game/use.go`,
+`internal/game/combat.go`, `internal/game/morgue.go`, and their `_test.go`.
+- Tests first: `PlayerUse` on a ring sets `g.Ring` and logs "put on"; `autoEquip`
+  fills an empty ring/amulet slot on pickup; `playerDodgeStat` reflects armor +
+  ring + amulet **stacked**; `playerAttackStat` reflects weapon + accessory;
+  re-using a ring swaps the slot; morgue lists the worn accessory.
+- Implement: `Ring`/`Amulet` fields; `equippedGear()`; fold the stat sums;
+  `autoEquip`/`PlayerUse` cases; morgue lines.
+- Commit: `feat(game): ring and amulet equip slots with stacked bonuses`
+
+## Task 3: HUD + data + golden + ship
+**Files:** `internal/ui/ui.go`, `internal/ui/ui_test.go`, `data/items.toml`,
+`data/data_test.go`.
+- Tests first: status line shows the worn accessory; the embedded rings/amulet
+  load with their bonuses.
+- Implement: `Worn:` HUD segment; add `ring_of_accuracy` (attack), 
+  `ring_of_protection` (dodge), `amulet_of_warding` (dodge); seed a couple into
+  spawn/loot as appropriate; golden test.
+- Commit: `feat(content): rings of accuracy/protection and amulet of warding`
+- Full gate (`go test ./...`, `gofmt`); push, PR, CodeRabbit loop → merge.
+  Advances #14.
+
+## Done when
+You can wear a ring **and** an amulet alongside your weapon and armor, their
+bonuses stack onto your hit/defense, the HUD and morgue show them, and the suite
+is green through CodeRabbit.

--- a/go/data/data_test.go
+++ b/go/data/data_test.go
@@ -149,6 +149,23 @@ func TestEmbeddedGear(t *testing.T) {
 	}
 }
 
+// TestEmbeddedAccessories checks the rings and amulet loaded with their bonuses.
+func TestEmbeddedAccessories(t *testing.T) {
+	c, err := content.Load(Files)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if r := c.Items["ring_of_accuracy"]; r == nil || r.Kind != "ring" || r.Attack <= 0 {
+		t.Errorf("ring_of_accuracy def unexpected: %+v", r)
+	}
+	if r := c.Items["ring_of_protection"]; r == nil || r.Kind != "ring" || r.Dodge <= 0 {
+		t.Errorf("ring_of_protection def unexpected: %+v", r)
+	}
+	if a := c.Items["amulet_of_warding"]; a == nil || a.Kind != "amulet" || a.Dodge <= 0 {
+		t.Errorf("amulet_of_warding def unexpected: %+v", a)
+	}
+}
+
 // TestEmbeddedRangedWeapons checks the shortbow and the ranged bosses loaded.
 func TestEmbeddedRangedWeapons(t *testing.T) {
 	c, err := content.Load(Files)

--- a/go/data/data_test.go
+++ b/go/data/data_test.go
@@ -155,14 +155,14 @@ func TestEmbeddedAccessories(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Load: %v", err)
 	}
-	if r := c.Items["ring_of_accuracy"]; r == nil || r.Kind != "ring" || r.Attack <= 0 {
-		t.Errorf("ring_of_accuracy def unexpected: %+v", r)
+	if r := c.Items["ring_of_accuracy"]; r == nil || r.Kind != "ring" || r.Attack != 2 {
+		t.Errorf("ring_of_accuracy def unexpected: %+v (want kind=ring attack=2)", r)
 	}
-	if r := c.Items["ring_of_protection"]; r == nil || r.Kind != "ring" || r.Dodge <= 0 {
-		t.Errorf("ring_of_protection def unexpected: %+v", r)
+	if r := c.Items["ring_of_protection"]; r == nil || r.Kind != "ring" || r.Dodge != 2 {
+		t.Errorf("ring_of_protection def unexpected: %+v (want kind=ring dodge=2)", r)
 	}
-	if a := c.Items["amulet_of_warding"]; a == nil || a.Kind != "amulet" || a.Dodge <= 0 {
-		t.Errorf("amulet_of_warding def unexpected: %+v", a)
+	if a := c.Items["amulet_of_warding"]; a == nil || a.Kind != "amulet" || a.Dodge != 3 {
+		t.Errorf("amulet_of_warding def unexpected: %+v (want kind=amulet dodge=3)", a)
 	}
 }
 

--- a/go/data/items.toml
+++ b/go/data/items.toml
@@ -307,3 +307,27 @@ glyph = "~"
 color = "red"
 kind = "light"
 light = 6
+
+# Accessories (#14) — rings and amulets are passive equip slots, separate from
+# weapon and armor, whose attack/dodge bonuses stack onto your hit and defense.
+# Faithful to 0.40's worn item_type/equipped model (common/item.h, gent_amulet).
+[item.ring_of_accuracy]
+name = "ring of accuracy"
+glyph = "="
+color = "magenta"
+kind = "ring"
+attack = 2
+
+[item.ring_of_protection]
+name = "ring of protection"
+glyph = "="
+color = "magenta"
+kind = "ring"
+dodge = 2
+
+[item.amulet_of_warding]
+name = "amulet of warding"
+glyph = "\""
+color = "magenta"
+kind = "amulet"
+dodge = 3

--- a/go/internal/content/content.go
+++ b/go/internal/content/content.go
@@ -100,7 +100,7 @@ func (i *ItemDef) Rune() rune {
 	return r
 }
 
-var validItemKinds = map[string]bool{"potion": true, "weapon": true, "armor": true, "food": true, "wand": true, "scroll": true, "light": true, "spellbook": true}
+var validItemKinds = map[string]bool{"potion": true, "weapon": true, "armor": true, "food": true, "wand": true, "scroll": true, "light": true, "spellbook": true, "ring": true, "amulet": true}
 
 // SpawnEntry is one weighted entry in a level's monster spawn table.
 type SpawnEntry struct {
@@ -432,6 +432,10 @@ func validateItem(i *ItemDef) error {
 		}
 		if i.Power < 0 {
 			return fmt.Errorf("food power must be >= 0, got %d", i.Power)
+		}
+	case "ring", "amulet":
+		if i.Attack <= 0 && i.Dodge <= 0 {
+			return fmt.Errorf("%s must grant an attack or dodge bonus", i.Kind)
 		}
 	}
 	if i.Effect != "" && i.EffectTurns <= 0 {

--- a/go/internal/content/content_test.go
+++ b/go/internal/content/content_test.go
@@ -679,3 +679,10 @@ func TestLoadRejectsBonuslessRing(t *testing.T) {
 		t.Fatal("expected error: an accessory needs an attack or dodge bonus")
 	}
 }
+
+func TestLoadRejectsBonuslessAmulet(t *testing.T) {
+	dir := writeItemsFixture(t, "[item.dud]\nname=\"dud amulet\"\nglyph=\"\\\"\"\ncolor=\"magenta\"\nkind=\"amulet\"\n")
+	if _, err := Load(os.DirFS(dir)); err == nil {
+		t.Fatal("expected error: an accessory needs an attack or dodge bonus")
+	}
+}

--- a/go/internal/content/content_test.go
+++ b/go/internal/content/content_test.go
@@ -650,3 +650,32 @@ func TestLoadRejectsNegativeItemRanged(t *testing.T) {
 		t.Fatal("expected error for negative item ranged")
 	}
 }
+
+func TestLoadRingItem(t *testing.T) {
+	dir := writeItemsFixture(t, "[item.ring]\nname=\"ring of protection\"\nglyph=\"=\"\ncolor=\"magenta\"\nkind=\"ring\"\ndodge=2\n")
+	c, err := Load(os.DirFS(dir))
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if r := c.Items["ring"]; r == nil || r.Kind != "ring" || r.Dodge != 2 {
+		t.Errorf("ring def unexpected: %+v", r)
+	}
+}
+
+func TestLoadAmuletItem(t *testing.T) {
+	dir := writeItemsFixture(t, "[item.amulet]\nname=\"amulet of warding\"\nglyph=\"\\\"\"\ncolor=\"magenta\"\nkind=\"amulet\"\ndodge=3\n")
+	c, err := Load(os.DirFS(dir))
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if a := c.Items["amulet"]; a == nil || a.Kind != "amulet" || a.Dodge != 3 {
+		t.Errorf("amulet def unexpected: %+v", a)
+	}
+}
+
+func TestLoadRejectsBonuslessRing(t *testing.T) {
+	dir := writeItemsFixture(t, "[item.dud]\nname=\"dud ring\"\nglyph=\"=\"\ncolor=\"magenta\"\nkind=\"ring\"\n")
+	if _, err := Load(os.DirFS(dir)); err == nil {
+		t.Fatal("expected error: an accessory needs an attack or dodge bonus")
+	}
+}

--- a/go/internal/game/combat.go
+++ b/go/internal/game/combat.go
@@ -63,11 +63,25 @@ func (g *Game) PlayerStep(d Direction) {
 	}
 }
 
-func (g *Game) playerAttackStat() int {
-	if g.Weapon != nil {
-		return playerAttack + g.Weapon.Def.Attack
+// equippedGear returns the items the player has worn or wielded, in slot order.
+// Accessories (ring, amulet) sit alongside weapon and armor so their bonuses
+// stack into the combat stats below.
+func (g *Game) equippedGear() []*Item {
+	var worn []*Item
+	for _, it := range []*Item{g.Weapon, g.Armor, g.Ring, g.Amulet} {
+		if it != nil && it.Def != nil {
+			worn = append(worn, it)
+		}
 	}
-	return playerAttack
+	return worn
+}
+
+func (g *Game) playerAttackStat() int {
+	atk := playerAttack
+	for _, it := range g.equippedGear() {
+		atk += it.Def.Attack
+	}
+	return atk
 }
 
 func (g *Game) playerDamageSpec() string {
@@ -78,10 +92,11 @@ func (g *Game) playerDamageSpec() string {
 }
 
 func (g *Game) playerDodgeStat() int {
-	if g.Armor != nil {
-		return playerDodge + g.Armor.Def.Dodge
+	dodge := playerDodge
+	for _, it := range g.equippedGear() {
+		dodge += it.Def.Dodge
 	}
-	return playerDodge
+	return dodge
 }
 
 func (g *Game) playerAttacks(m *Creature) {

--- a/go/internal/game/game.go
+++ b/go/internal/game/game.go
@@ -104,6 +104,8 @@ type Game struct {
 	Inventory   []*Item
 	Weapon      *Item
 	Armor       *Item
+	Ring        *Item // worn accessory: passive attack/dodge bonus
+	Amulet      *Item // worn accessory: passive attack/dodge bonus
 	Behaviors   map[string]Behavior
 	Won         bool
 	DeathCause  string

--- a/go/internal/game/morgue.go
+++ b/go/internal/game/morgue.go
@@ -33,6 +33,12 @@ func (g *Game) MorgueText() string {
 		worn = g.DisplayName(g.Armor)
 	}
 	fmt.Fprintf(&b, "Wielding: %s\nWearing: %s\n", wield, worn)
+	if g.Ring != nil {
+		fmt.Fprintf(&b, "On hand: %s\n", g.DisplayName(g.Ring))
+	}
+	if g.Amulet != nil {
+		fmt.Fprintf(&b, "Around neck: %s\n", g.DisplayName(g.Amulet))
+	}
 	fmt.Fprintf(&b, "Inventory (%d):\n", len(g.Inventory))
 	for _, it := range g.Inventory {
 		fmt.Fprintf(&b, "  - %s\n", g.DisplayName(it))

--- a/go/internal/game/morgue_test.go
+++ b/go/internal/game/morgue_test.go
@@ -3,6 +3,8 @@ package game
 import (
 	"strings"
 	"testing"
+
+	"github.com/c0ze/tsl/internal/content"
 )
 
 func TestMorgueTextOnDeath(t *testing.T) {
@@ -10,5 +12,17 @@ func TestMorgueTextOnDeath(t *testing.T) {
 	txt := g.MorgueText()
 	if !strings.Contains(txt, "Killed by: ghoul") || !strings.Contains(txt, "Location: the dungeon") {
 		t.Errorf("morgue missing expected lines:\n%s", txt)
+	}
+}
+
+func TestMorgueListsWornAccessories(t *testing.T) {
+	g := &Game{
+		PlayerHP: 5, PlayerMax: 10,
+		Ring:   &Item{Def: &content.ItemDef{Name: "ring of protection", Kind: "ring", Dodge: 2}},
+		Amulet: &Item{Def: &content.ItemDef{Name: "amulet of warding", Kind: "amulet", Dodge: 3}},
+	}
+	txt := g.MorgueText()
+	if !strings.Contains(txt, "ring of protection") || !strings.Contains(txt, "amulet of warding") {
+		t.Errorf("morgue should list worn accessories:\n%s", txt)
 	}
 }

--- a/go/internal/game/use.go
+++ b/go/internal/game/use.go
@@ -31,6 +31,16 @@ func (g *Game) autoEquip(it *Item) {
 			g.Armor = it
 			g.log("You wear the %s.", it.Def.Name)
 		}
+	case "ring":
+		if g.Ring == nil {
+			g.Ring = it
+			g.log("You put on the %s.", it.Def.Name)
+		}
+	case "amulet":
+		if g.Amulet == nil {
+			g.Amulet = it
+			g.log("You put on the %s.", it.Def.Name)
+		}
 	}
 }
 
@@ -51,6 +61,12 @@ func (g *Game) PlayerUse(it *Item) {
 	case "armor":
 		g.Armor = it
 		g.log("You wear the %s.", it.Def.Name)
+	case "ring":
+		g.Ring = it
+		g.log("You put on the %s.", it.Def.Name)
+	case "amulet":
+		g.Amulet = it
+		g.log("You put on the %s.", it.Def.Name)
 	case "potion", "food", "scroll":
 		g.identify(it) // using a consumable reveals what it was
 		if b, ok := g.Behaviors[it.Def.Use]; ok {

--- a/go/internal/game/use_test.go
+++ b/go/internal/game/use_test.go
@@ -128,6 +128,85 @@ func TestPickupAutoEquipsWhenSlotEmpty(t *testing.T) {
 	}
 }
 
+func TestUseRingEquipsIntoSlot(t *testing.T) {
+	g := useGame()
+	ring := &Item{Def: &content.ItemDef{ID: "ring_protect", Name: "ring of protection", Kind: "ring", Dodge: 2}}
+	g.Inventory = append(g.Inventory, ring)
+	g.PlayerUse(ring)
+	if g.Ring != ring {
+		t.Fatal("ring should be worn in the ring slot")
+	}
+	if got := g.playerDodgeStat(); got != playerDodge+2 {
+		t.Errorf("dodge = %d, want %d (base + ring)", got, playerDodge+2)
+	}
+}
+
+func TestUseAmuletEquipsIntoSlot(t *testing.T) {
+	g := useGame()
+	amulet := &Item{Def: &content.ItemDef{ID: "amulet_ward", Name: "amulet of warding", Kind: "amulet", Dodge: 3}}
+	g.Inventory = append(g.Inventory, amulet)
+	g.PlayerUse(amulet)
+	if g.Amulet != amulet {
+		t.Fatal("amulet should be worn in the amulet slot")
+	}
+	if got := g.playerDodgeStat(); got != playerDodge+3 {
+		t.Errorf("dodge = %d, want %d (base + amulet)", got, playerDodge+3)
+	}
+}
+
+// Accessory bonuses stack with armor (dodge) and weapon (attack) — the point of
+// separate equip slots.
+func TestAccessoryBonusesStack(t *testing.T) {
+	g := useGame()
+	g.Armor = &Item{Def: &content.ItemDef{Kind: "armor", Dodge: 4}}
+	g.Ring = &Item{Def: &content.ItemDef{Kind: "ring", Dodge: 2}}
+	g.Amulet = &Item{Def: &content.ItemDef{Kind: "amulet", Dodge: 3}}
+	if got, want := g.playerDodgeStat(), playerDodge+4+2+3; got != want {
+		t.Errorf("dodge = %d, want %d (base + armor + ring + amulet)", got, want)
+	}
+	g.Weapon = &Item{Def: &content.ItemDef{Kind: "weapon", Attack: 4, Damage: "1d4"}}
+	g.Ring = &Item{Def: &content.ItemDef{Kind: "ring", Attack: 2}}
+	if got, want := g.playerAttackStat(), playerAttack+4+2; got != want {
+		t.Errorf("attack = %d, want %d (base + weapon + ring)", got, want)
+	}
+}
+
+func TestPickupAutoEquipsAccessories(t *testing.T) {
+	g := useGame()
+	ring := &Item{Def: &content.ItemDef{ID: "r", Name: "ring", Kind: "ring", Dodge: 2}, Pos: g.Player}
+	g.Level.Items = append(g.Level.Items, ring)
+	g.PlayerPickup()
+	if g.Ring != ring {
+		t.Fatal("ring should auto-equip into the empty ring slot")
+	}
+	amulet := &Item{Def: &content.ItemDef{ID: "a", Name: "amulet", Kind: "amulet", Dodge: 3}, Pos: g.Player}
+	g.Level.Items = append(g.Level.Items, amulet)
+	g.PlayerPickup()
+	if g.Amulet != amulet {
+		t.Fatal("amulet should auto-equip into the empty amulet slot")
+	}
+	// a second ring must NOT auto-replace the worn one
+	ring2 := &Item{Def: &content.ItemDef{ID: "r2", Name: "ring of accuracy", Kind: "ring", Attack: 2}, Pos: g.Player}
+	g.Level.Items = append(g.Level.Items, ring2)
+	g.PlayerPickup()
+	if g.Ring != ring {
+		t.Error("second ring should not auto-replace the worn one")
+	}
+}
+
+// Re-using a ring while one is worn swaps the slot (a deliberate change).
+func TestUseRingSwapsSlot(t *testing.T) {
+	g := useGame()
+	r1 := &Item{Def: &content.ItemDef{ID: "r1", Name: "ring of protection", Kind: "ring", Dodge: 2}}
+	r2 := &Item{Def: &content.ItemDef{ID: "r2", Name: "ring of accuracy", Kind: "ring", Attack: 2}}
+	g.Inventory = append(g.Inventory, r1, r2)
+	g.PlayerUse(r1)
+	g.PlayerUse(r2)
+	if g.Ring != r2 {
+		t.Errorf("ring slot should hold the most recently worn ring")
+	}
+}
+
 func TestWandInventoryFilters(t *testing.T) {
 	g := useGame()
 	g.Inventory = append(g.Inventory,

--- a/go/internal/ui/ui.go
+++ b/go/internal/ui/ui.go
@@ -5,6 +5,7 @@ package ui
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/c0ze/tsl/internal/content"
 	"github.com/c0ze/tsl/internal/game"
@@ -130,10 +131,25 @@ func statusLine(g *game.Game) string {
 		s += fmt.Sprintf("   EP %d/%d", g.EP, g.EPMax)
 	}
 	s += fmt.Sprintf("   %s   Wield: %s   Wear: %s", loc, wield, wear)
+	if worn := wornAccessories(g); worn != "" {
+		s += "   Worn: " + worn
+	}
 	if eff := g.EffectsSummary(); eff != "" {
 		s += "   [" + eff + "]"
 	}
 	return s
+}
+
+// wornAccessories joins the display names of the worn ring and amulet, returning
+// "" when neither slot is filled (so the HUD omits the segment entirely).
+func wornAccessories(g *game.Game) string {
+	var names []string
+	for _, it := range []*game.Item{g.Ring, g.Amulet} {
+		if it != nil && it.Def != nil {
+			names = append(names, g.DisplayName(it))
+		}
+	}
+	return strings.Join(names, ", ")
 }
 
 // lastN returns up to the last n elements of s.

--- a/go/internal/ui/ui_test.go
+++ b/go/internal/ui/ui_test.go
@@ -62,6 +62,9 @@ func TestBuildViewShowsWornAccessories(t *testing.T) {
 	g.Ring = &game.Item{Def: &content.ItemDef{Name: "ring of protection", Kind: "ring", Dodge: 2}}
 	g.Amulet = &game.Item{Def: &content.ItemDef{Name: "amulet of warding", Kind: "amulet", Dodge: 3}}
 	v := BuildView(g)
+	if !strings.Contains(v.Status, "Worn:") {
+		t.Fatalf("status %q should include the Worn segment", v.Status)
+	}
 	for _, want := range []string{"ring of protection", "amulet of warding"} {
 		if !strings.Contains(v.Status, want) {
 			t.Errorf("status %q should show worn accessory %q", v.Status, want)

--- a/go/internal/ui/ui_test.go
+++ b/go/internal/ui/ui_test.go
@@ -57,6 +57,18 @@ func TestBuildViewStatusLine(t *testing.T) {
 	}
 }
 
+func TestBuildViewShowsWornAccessories(t *testing.T) {
+	g := testGame(t, []string{".@."})
+	g.Ring = &game.Item{Def: &content.ItemDef{Name: "ring of protection", Kind: "ring", Dodge: 2}}
+	g.Amulet = &game.Item{Def: &content.ItemDef{Name: "amulet of warding", Kind: "amulet", Dodge: 3}}
+	v := BuildView(g)
+	for _, want := range []string{"ring of protection", "amulet of warding"} {
+		if !strings.Contains(v.Status, want) {
+			t.Errorf("status %q should show worn accessory %q", v.Status, want)
+		}
+	}
+}
+
 func TestBuildViewShowsEP(t *testing.T) {
 	g := testGame(t, []string{".@."})
 	g.EP, g.EPMax = 7, 10


### PR DESCRIPTION
## What

Adds **rings and amulets** as passive accessory equip slots — two new worn
slots, *separate* from weapon and armor, whose bonuses **stack** onto your hit
and defense. This advances the gear epic (#14); the new mechanic is "two more
equip slots."

Faithful to 0.40, where items carry an `equipped` flag and `item_type` spans
body/feet/head/cloak plus rings and amulets (`common/item.h`, `common/gent.h:
gent_amulet`).

## How

- **Content** (`internal/content`): two new item kinds, `ring` and `amulet`,
  validated like other gear — each must grant at least one passive bonus
  (`attack > 0 || dodge > 0`).
- **Equip slots** (`internal/game`): `Game.Ring` / `Game.Amulet`. A new
  `equippedGear()` helper sums `attack`/`dodge` across **all** equipped items,
  so weapon + armor + ring + amulet bonuses stack. `autoEquip` fills an empty
  accessory slot on pickup (never downgrades); `PlayerUse` puts one on (swapping
  the slot). The morgue lists worn accessories.
- **HUD** (`internal/ui`): a new `Worn:` status segment, shown only when an
  accessory is equipped.
- **Data**: `ring_of_accuracy` (+2 attack), `ring_of_protection` (+2 dodge),
  `amulet_of_warding` (+3 dodge). They spawn as floor loot via the all-items
  pool, so they're immediately playable.

## Testing

- `internal/content`: ring/amulet load; a bonus-less accessory is rejected.
- `internal/game`: equip into slot + "put on" log; autoEquip fills empty slots;
  **bonuses stack** with armor/weapon; re-use swaps the slot; morgue lists them.
- `internal/ui`: status line shows worn accessories.
- `data`: golden test for the three embedded accessories.
- Full suite green; `go vet` and `gofmt` clean.

## Follow-ups (noted, out of scope)

- Shuffled ring/amulet **appearances** (unidentified accessories), reusing the
  identify framework.
- An **amulet of vitality** (max-HP bonus) — needs an effective-max refactor of
  the HP clamp.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Rings and amulets are equippable accessories with attack/dodge bonuses
  * New equip slots with auto-equip and use-to-swap behavior
  * Stat bonuses from all equipped items stack for combat calculations
  * HUD shows "Worn:" accessories; morgue outputs worn accessories

* **Documentation**
  * Added implementation plan for the accessories system

* **Tests**
  * Comprehensive tests validating accessory definitions, loading rules, equip/auto-equip, swapping, stacking, UI, and morgue output
<!-- end of auto-generated comment: release notes by coderabbit.ai -->