### PR TITLE
feat: monster roster batch 4 — six canonical 0.40 foes (#13)

### DIFF
--- a/docs/superpowers/plans/2026-06-10-roster-batch4-13e.md
+++ b/docs/superpowers/plans/2026-06-10-roster-batch4-13e.md
@@ -1,0 +1,36 @@
+# Monster Roster Batch 4 (13e) Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Six more canonical 0.40 monsters (#13), drawn straight from the
+bestiary glyphs in `common/glyph.c` — broadening the mid-to-deep tiers. The
+0.40 bestiary is much larger than what's ported so far; this batch adds beasts
+with free glyphs (no collisions with the current roster).
+
+## Monsters (names/glyphs verbatim from `common/glyph.c`)
+| id | name | glyph | color | role | min_depth |
+|----|------|-------|-------|------|-----------|
+| `hellhound` | hellhound | `h` | red | fast pack hunter | 2 |
+| `frostling` | frostling | `f` | cyan | nimble skirmisher (no corpse) | 2 |
+| `goatman` | goatman | `p` | brown | sturdy melee | 2 |
+| `tentacle` | tentacle | `l` | green | slow grabber (no corpse) | 3 |
+| `gloom_lord` | gloom lord | `K` | magenta | ranged caster (ranged 5) | 3 |
+| `giant_slimy_toad` | giant slimy toad | `Y` | green | deep tank | 3 |
+
+Stats follow the existing role conventions (fast/low-HP skirmishers vs.
+slow/high-HP tanks); the ranged gloom lord reuses the 13c ranged AI + LOS.
+Corpses reuse the generic `carcass` where edible; elementals/oozes leave none.
+
+## Task 1: data + spawns + golden + ship
+**Files:** `data/monsters.toml`, `data/levels.toml`, `data/data_test.go`
+- Test first: `TestEmbeddedRosterBatch4` asserts the six load with the right
+  glyphs and that at least one appears in a spawn table (mirrors batch 3).
+- Add the six `[monster.*]` blocks; wire them into mid/deep spawn tables at low
+  weights (depth enforced by which levels list them); golden test green.
+- Commit: `feat(content): monster roster batch 4 (hellhound, frostling, …)`
+- Full gate (`go test ./...`, `gofmt`); push, PR, CodeRabbit loop → merge.
+  Advances #13.
+
+## Done when
+Six more faithful foes prowl the mid-to-deep floors — including a second ranged
+caster (the gloom lord) — and the suite is green through CodeRabbit.

--- a/docs/superpowers/plans/2026-06-10-roster-batch4-13e.md
+++ b/docs/superpowers/plans/2026-06-10-roster-batch4-13e.md
@@ -8,6 +8,7 @@ bestiary glyphs in `common/glyph.c` — broadening the mid-to-deep tiers. The
 with free glyphs (no collisions with the current roster).
 
 ## Monsters (names/glyphs verbatim from `common/glyph.c`)
+
 | id | name | glyph | color | role | min_depth |
 |----|------|-------|-------|------|-----------|
 | `hellhound` | hellhound | `h` | red | fast pack hunter | 2 |

--- a/go/data/data_test.go
+++ b/go/data/data_test.go
@@ -144,16 +144,18 @@ func TestEmbeddedRosterBatch4(t *testing.T) {
 	if g := c.Monsters["gloom_lord"]; g != nil && g.Ranged <= 0 {
 		t.Errorf("gloom_lord should be ranged, got %+v", g)
 	}
-	spawned := false
+	seen := map[string]bool{}
 	for _, l := range c.Levels {
 		for _, s := range l.Spawn {
 			if _, ok := want[s.Monster]; ok {
-				spawned = true
+				seen[s.Monster] = true
 			}
 		}
 	}
-	if !spawned {
-		t.Error("expected at least one batch-4 monster placed in a spawn table")
+	for id := range want {
+		if !seen[id] {
+			t.Errorf("expected %q to appear in at least one spawn table", id)
+		}
 	}
 }
 

--- a/go/data/data_test.go
+++ b/go/data/data_test.go
@@ -121,6 +121,42 @@ func TestEmbeddedRosterBatch3(t *testing.T) {
 	}
 }
 
+func TestEmbeddedRosterBatch4(t *testing.T) {
+	c, err := content.Load(Files)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	want := map[string]rune{
+		"hellhound": 'h', "frostling": 'f', "goatman": 'p',
+		"tentacle": 'l', "gloom_lord": 'K', "giant_slimy_toad": 'Y',
+	}
+	for id, glyph := range want {
+		m := c.Monsters[id]
+		if m == nil {
+			t.Errorf("missing monster %q", id)
+			continue
+		}
+		if m.Rune() != glyph {
+			t.Errorf("%s glyph = %q, want %q", id, m.Rune(), glyph)
+		}
+	}
+	// the gloom lord is a second ranged caster — make sure that survived the port
+	if g := c.Monsters["gloom_lord"]; g != nil && g.Ranged <= 0 {
+		t.Errorf("gloom_lord should be ranged, got %+v", g)
+	}
+	spawned := false
+	for _, l := range c.Levels {
+		for _, s := range l.Spawn {
+			if _, ok := want[s.Monster]; ok {
+				spawned = true
+			}
+		}
+	}
+	if !spawned {
+		t.Error("expected at least one batch-4 monster placed in a spawn table")
+	}
+}
+
 // TestDepthGatedTanks checks the tougher monsters only appear on deeper floors.
 func TestDepthGatedTanks(t *testing.T) {
 	c, err := content.Load(Files)

--- a/go/data/levels.toml
+++ b/go/data/levels.toml
@@ -62,6 +62,9 @@ weight = 1
 [[level.catacombs.spawn]]
 monster = "giant_spider"
 weight = 2
+[[level.catacombs.spawn]]
+monster = "hellhound"
+weight = 1
 
 [level.ominous_cave]
 name = "the Ominous Cave"
@@ -115,6 +118,9 @@ weight = 2
 [[level.laboratory.spawn]]
 monster = "imp"
 weight = 1
+[[level.laboratory.spawn]]
+monster = "goatman"
+weight = 2
 
 [level.comm_hub]
 name = "the Communications Hub"
@@ -137,6 +143,9 @@ monster = "skeleton"
 weight = 2
 [[level.comm_hub.spawn]]
 monster = "wisp"
+weight = 2
+[[level.comm_hub.spawn]]
+monster = "frostling"
 weight = 2
 
 [level.underpass]
@@ -164,6 +173,9 @@ weight = 2
 [[level.underpass.spawn]]
 monster = "dire_wolf"
 weight = 2
+[[level.underpass.spawn]]
+monster = "tentacle"
+weight = 1
 
 [level.drowned_city]
 name = "the Drowned City"
@@ -186,6 +198,12 @@ weight = 1
 [[level.drowned_city.spawn]]
 monster = "imp"
 weight = 2
+[[level.drowned_city.spawn]]
+monster = "tentacle"
+weight = 2
+[[level.drowned_city.spawn]]
+monster = "giant_slimy_toad"
+weight = 2
 
 [level.frozen_vault]
 name = "the Vault of the Frozen Saint"
@@ -207,6 +225,12 @@ weight = 2
 [[level.frozen_vault.spawn]]
 monster = "ogre"
 weight = 2
+[[level.frozen_vault.spawn]]
+monster = "frostling"
+weight = 3
+[[level.frozen_vault.spawn]]
+monster = "gloom_lord"
+weight = 1
 
 [level.dragons_lair]
 name = "the Dragons Lair"
@@ -234,6 +258,9 @@ weight = 2
 [[level.dragons_lair.spawn]]
 monster = "troll"
 weight = 2
+[[level.dragons_lair.spawn]]
+monster = "hellhound"
+weight = 2
 
 [level.chapel]
 name = "the Chapel of Fallen Stars"
@@ -258,4 +285,7 @@ monster = "merman"
 weight = 1
 [[level.chapel.spawn]]
 monster = "wraith"
+weight = 2
+[[level.chapel.spawn]]
+monster = "gloom_lord"
 weight = 2

--- a/go/data/monsters.toml
+++ b/go/data/monsters.toml
@@ -247,6 +247,81 @@ speed = 90
 corpse = "carcass"
 min_depth = 3
 
+# Roster batch 4 (#13) — more of the canonical 0.40 bestiary (names/glyphs from
+# common/glyph.c), broadening the mid-to-deep tiers. Corpses reuse the generic
+# carcass where edible; elementals and oozes leave none.
+[monster.hellhound]
+name = "hellhound"
+glyph = "h"
+color = "red"
+hp = 8
+attack = 5
+dodge = 3
+damage = "1d5"
+speed = 140
+corpse = "carcass"
+min_depth = 2
+
+[monster.frostling]
+name = "frostling"
+glyph = "f"
+color = "cyan"
+hp = 5
+attack = 4
+dodge = 3
+damage = "1d4"
+speed = 110
+min_depth = 2
+
+[monster.goatman]
+name = "goatman"
+glyph = "p"
+color = "brown"
+hp = 9
+attack = 5
+dodge = 2
+damage = "1d6"
+speed = 95
+corpse = "carcass"
+min_depth = 2
+
+[monster.tentacle]
+name = "tentacle"
+glyph = "l"
+color = "green"
+hp = 12
+attack = 5
+dodge = 1
+damage = "1d6"
+speed = 70
+min_depth = 3
+
+# A second ranged caster (after the imp) — flings gloom across a lit room
+# (ranged = 5); break line of sight to force it to close.
+[monster.gloom_lord]
+name = "gloom lord"
+glyph = "K"
+color = "magenta"
+hp = 16
+attack = 5
+dodge = 3
+damage = "1d6"
+speed = 110
+ranged = 5
+min_depth = 3
+
+[monster.giant_slimy_toad]
+name = "giant slimy toad"
+glyph = "Y"
+color = "green"
+hp = 20
+attack = 4
+dodge = 1
+damage = "2d4"
+speed = 75
+corpse = "carcass"
+min_depth = 3
+
 # Bosses (#16 2c). Deadly guardians — but you win by reaching the altar, so you
 # needn't kill them. Stats are tunable; gear breadth (#14) will make this fairer.
 [monster.elder_mummylich]


### PR DESCRIPTION
## What

Adds **six more canonical 0.40 monsters**, drawn straight from the bestiary
glyphs in `common/glyph.c`, broadening the mid-to-deep tiers (#13). The 0.40
bestiary is much larger than what's ported so far; these all use free glyphs (no
collision with the current roster).

| id | name | glyph | role | depth |
|----|------|-------|------|-------|
| `hellhound` | hellhound | `h` | fast pack hunter | 2 |
| `frostling` | frostling | `f` | nimble skirmisher | 2 |
| `goatman` | goatman | `p` | sturdy melee | 2 |
| `tentacle` | tentacle | `l` | slow grabber | 3 |
| `gloom_lord` | gloom lord | `K` | **ranged caster** (ranged 5) | 3 |
| `giant_slimy_toad` | giant slimy toad | `Y` | deep tank | 3 |

The **gloom lord** is a second ranged caster (after the imp), reusing the 13c
ranged-AI + line-of-sight.

## How

- `data/monsters.toml`: six `[monster.*]` blocks with role-appropriate stats
  (fast/low-HP skirmishers vs. slow/high-HP tanks); corpses reuse the generic
  `carcass` where edible, elementals/oozes leave none.
- `data/levels.toml`: wired into thematic, depth-appropriate spawn tables —
  e.g. frostlings haunt the Frozen Vault, tentacles & toads infest the Drowned
  City, gloom lords stalk the deep floors and the Chapel.

## Testing

- `data`: `TestEmbeddedRosterBatch4` asserts the six load with the right glyphs,
  that the gloom lord is ranged, and that they reach the spawn tables.
- Full suite green; `gofmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Six new monsters added: hellhound, frostling, goatman, tentacle, gloom lord, and giant slimy toad; they now appear across multiple dungeon levels with low spawn rates.

* **Documentation**
  * Added an implementation plan describing the roster batch 4 rollout.

* **Tests**
  * Added validation tests to verify the new monsters are included, appear in spawn tables, and that gloom lord has ranged capability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->