### PR TITLE
feat: spellbook of noxious cloud — AoE poison spell (#15)

### DIFF
--- a/docs/superpowers/plans/2026-06-10-noxious-cloud-15o.md
+++ b/docs/superpowers/plans/2026-06-10-noxious-cloud-15o.md
@@ -1,0 +1,44 @@
+# Noxious Cloud Spell (15o) Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** A **noxious cloud** spell — a self-centred area-of-effect that
+**poisons** every nearby creature (damage-over-time area denial), rounding out
+the offensive spell kit alongside flash (AoE blind), frost ray (beam), force
+bolt (single-target), and first aid (heal). Advances #15.
+
+## Design
+- Generalise the flash spell's area logic into a shared helper
+  `affectNearby(radius, kind, turns) int` — applies a status effect to every
+  creature within Chebyshev `radius` of the player, returning the count.
+  `FlashBlind` becomes a thin wrapper (`affectNearby(r, "blind", t)`); a new
+  `PoisonNearby` wraps `affectNearby(r, "poison", t)`. No behaviour change to
+  flash; the existing FlashBlind test still passes.
+- Poison already damages creatures 1 HP/turn and kills via `killCreature`
+  (`tickCreatureEffects`), so the cloud deals real, lingering damage.
+- A `noxious_cloud` behaviour mirrors `flash`: casts `PoisonNearby(NoxiousRadius,
+  Power)`, reporting how many creatures were caught (or that none were near).
+- Data: `spellbook_noxious_cloud` (kind spellbook, use `noxious_cloud`, an EP
+  cost, power = poison turns). `NoxiousRadius = 3` (tighter than flash's 4,
+  since it does damage, not just control).
+
+## Task 1: engine helper (TDD)
+**Files:** `internal/game/spell.go`, `internal/game/spell_test.go`
+- Test first: `PoisonNearby` poisons creatures in radius (and a far one is
+  spared); a poisoned creature loses HP on the next `monstersAct`.
+- Implement `affectNearby`; rewrite `FlashBlind` over it; add `PoisonNearby` +
+  `NoxiousRadius`.
+- Commit: `feat(game): AoE poison via shared affectNearby helper`
+
+## Task 2: behaviour + data + golden + ship
+**Files:** `internal/behaviors/behaviors.go`, `internal/behaviors/behaviors_test.go`,
+`data/items.toml`, `data/data_test.go`
+- Test first: the behaviour poisons nearby creatures and reports the count; the
+  embedded spellbook loads with its cost.
+- Implement `noxious_cloud`, register it; add `spellbook_noxious_cloud`; golden.
+- Commit: `feat(content): spellbook of noxious cloud (AoE poison)`
+- Full gate; push, PR, CodeRabbit loop → merge.
+
+## Done when
+Cast noxious cloud and the pack around you starts bleeding HP each turn until the
+poison fades or kills them. Suite green through CodeRabbit.

--- a/go/data/data_test.go
+++ b/go/data/data_test.go
@@ -244,6 +244,17 @@ func TestEmbeddedFlash(t *testing.T) {
 	}
 }
 
+// TestEmbeddedNoxiousCloud checks the noxious cloud spellbook loaded.
+func TestEmbeddedNoxiousCloud(t *testing.T) {
+	c, err := content.Load(Files)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if b := c.Items["spellbook_noxious_cloud"]; b == nil || b.Kind != "spellbook" || b.Use != "noxious_cloud" || b.Cost <= 0 {
+		t.Errorf("spellbook_noxious_cloud def unexpected: %+v", b)
+	}
+}
+
 // TestEmbeddedPotionBlindness checks the blindness potion loaded.
 func TestEmbeddedPotionBlindness(t *testing.T) {
 	c, err := content.Load(Files)

--- a/go/data/items.toml
+++ b/go/data/items.toml
@@ -300,6 +300,17 @@ ranged = 6
 damage = "2d4"
 cost = 6
 
+# Noxious cloud (#15) — a self-centred AoE that poisons nearby creatures, who
+# then bleed HP each turn (NoxiousRadius = 3). Area denial, not burst.
+[item.spellbook_noxious_cloud]
+name = "spellbook of noxious cloud"
+glyph = "+"
+color = "green"
+kind = "spellbook"
+use = "noxious_cloud"
+cost = 6
+power = 6
+
 # Light source (#18) — carry it to see in the dark (light = sight radius there).
 [item.torch]
 name = "torch"

--- a/go/internal/behaviors/behaviors.go
+++ b/go/internal/behaviors/behaviors.go
@@ -25,6 +25,7 @@ func Registry() map[string]game.Behavior {
 		"first_aid":       firstAid,
 		"blindness":       blindness,
 		"flash":           flash,
+		"noxious_cloud":   noxiousCloud,
 		"restore_energy":  restoreEnergy,
 	}
 }
@@ -135,6 +136,17 @@ func flash(g *game.Game, it *game.Item) []string {
 		return []string{fmt.Sprintf("You cast %s, but no creatures are near.", it.Def.Name)}
 	}
 	return []string{fmt.Sprintf("Light erupts from %s, blinding %d nearby creature(s)!", it.Def.Name, n)}
+}
+
+// noxiousCloud is the noxious cloud spell — a billow of poison gas that afflicts
+// the creatures around the caster with damage-over-time (poison drains their HP
+// each turn until it fades or kills).
+func noxiousCloud(g *game.Game, it *game.Item) []string {
+	n := g.PoisonNearby(game.NoxiousRadius, it.Def.Power)
+	if n == 0 {
+		return []string{fmt.Sprintf("You cast %s, but no creatures are near.", it.Def.Name)}
+	}
+	return []string{fmt.Sprintf("A cloud of poison billows from %s, choking %d nearby creature(s)!", it.Def.Name, n)}
 }
 
 // firstAid is the first-aid spell — it knits wounds over time (a regen effect),

--- a/go/internal/behaviors/behaviors_test.go
+++ b/go/internal/behaviors/behaviors_test.go
@@ -174,6 +174,21 @@ func TestFlashBlindsNearby(t *testing.T) {
 	}
 }
 
+func TestNoxiousCloudPoisonsNearby(t *testing.T) {
+	noxious, ok := Registry()["noxious_cloud"]
+	if !ok {
+		t.Fatal("noxious_cloud not registered")
+	}
+	floor := &content.TileDef{ID: "floor", Glyph: ".", Color: content.ColorNormal, Passable: true, Transparent: true}
+	g := &game.Game{Level: game.NewLevel(10, 3, floor), Player: game.Pos{X: 1, Y: 1}}
+	rat := &game.Creature{Def: &content.MonsterDef{ID: "rat", Name: "rat", HP: 3}, Pos: game.Pos{X: 3, Y: 1}, HP: 3}
+	g.Level.Creatures = append(g.Level.Creatures, rat)
+	noxious(g, &game.Item{Def: &content.ItemDef{Name: "spellbook of noxious cloud", Power: 6}})
+	if !rat.HasEffect("poison") {
+		t.Error("noxious cloud should poison a nearby creature")
+	}
+}
+
 func TestBlindnessAddsEffect(t *testing.T) {
 	blind, ok := Registry()["blindness"]
 	if !ok {

--- a/go/internal/game/spell.go
+++ b/go/internal/game/spell.go
@@ -84,17 +84,35 @@ func (g *Game) CastSpellAt(book *Item, target Pos) {
 // FlashRadius is how far the flash spell's blinding light reaches.
 const FlashRadius = 4
 
-// FlashBlind blinds every creature within radius (Chebyshev) of the player for
-// turns and reports how many were blinded — the flash spell's area effect.
-func (g *Game) FlashBlind(radius, turns int) int {
+// NoxiousRadius is how far the noxious cloud spell's poison spreads — tighter
+// than the flash, since it deals damage rather than only controlling.
+const NoxiousRadius = 3
+
+// affectNearby applies status effect `kind` for `turns` to every creature within
+// Chebyshev `radius` of the player, returning how many were affected — the shared
+// core of the player's self-centred area spells.
+func (g *Game) affectNearby(radius int, kind string, turns int) int {
 	n := 0
 	for _, m := range g.Level.Creatures {
 		if chebyshev(m.Pos, g.Player) <= radius {
-			m.AddEffect("blind", turns)
+			m.AddEffect(kind, turns)
 			n++
 		}
 	}
 	return n
+}
+
+// FlashBlind blinds every creature within radius of the player for turns and
+// reports how many were blinded — the flash spell's area effect.
+func (g *Game) FlashBlind(radius, turns int) int {
+	return g.affectNearby(radius, "blind", turns)
+}
+
+// PoisonNearby poisons every creature within radius of the player for turns and
+// reports how many were caught — the noxious cloud spell's area effect. Poison
+// then drains 1 HP/turn via tickCreatureEffects until it fades or kills.
+func (g *Game) PoisonNearby(radius, turns int) int {
+	return g.affectNearby(radius, "poison", turns)
 }
 
 // fireBeam traces a straight 8-directional ray from the player toward target, up

--- a/go/internal/game/spell_test.go
+++ b/go/internal/game/spell_test.go
@@ -164,6 +164,31 @@ func TestFlashBlindBlindsNearby(t *testing.T) {
 	}
 }
 
+func TestPoisonNearbyPoisonsAndDamages(t *testing.T) {
+	g := combatGame()                                                                             // player at (1,1)
+	near := &Creature{Def: &content.MonsterDef{ID: "a", Name: "a", HP: 3}, Pos: Pos{3, 1}, HP: 3} // dist 2
+	far := &Creature{Def: &content.MonsterDef{ID: "b", Name: "b", HP: 3}, Pos: Pos{9, 1}, HP: 3}  // dist 8
+	g.Level.Creatures = append(g.Level.Creatures, near, far)
+
+	n := g.PoisonNearby(3, 5)
+
+	if n != 1 {
+		t.Errorf("PoisonNearby radius 3 should poison 1 creature, got %d", n)
+	}
+	if !near.HasEffect("poison") {
+		t.Error("the near creature should be poisoned")
+	}
+	if far.HasEffect("poison") {
+		t.Error("the far creature should be out of range")
+	}
+	// poison is damage-over-time: the next turn costs the near creature HP
+	hp := near.HP
+	g.monstersAct()
+	if near.HP >= hp {
+		t.Errorf("poison should cost the near creature HP: %d -> %d", hp, near.HP)
+	}
+}
+
 func TestBlindMonsterHoldsAtRange(t *testing.T) {
 	g := combatGame()
 	rat := &Creature{Def: &content.MonsterDef{ID: "rat", Name: "rat", HP: 9, Damage: "1d1"}, Pos: Pos{5, 1}, HP: 9}


### PR DESCRIPTION
## What

Adds a **noxious cloud** spell — a self-centred area-of-effect that **poisons**
every nearby creature, who then bleed HP each turn until the poison fades or
kills. It rounds out the offensive spell kit with *area damage-over-time*,
alongside flash (AoE blind), frost ray (beam), force bolt (single-target), and
first aid (heal). Advances #15.

## How

- **Engine** (`internal/game/spell.go`): generalised the flash spell's area
  logic into a shared `affectNearby(radius, kind, turns)` helper. `FlashBlind`
  is now a thin wrapper over it (no behaviour change), and a new `PoisonNearby`
  wraps it with the `poison` effect. Poison already drains 1 HP/turn and kills
  via `killCreature` (`tickCreatureEffects`), so the cloud deals real, lingering
  damage. `NoxiousRadius = 3` (tighter than flash's 4, since it damages).
- **Behaviour** (`internal/behaviors`): `noxious_cloud` casts
  `PoisonNearby(NoxiousRadius, power)` and reports how many were caught.
- **Data**: `spellbook_noxious_cloud` (cost 6, power = 6 turns of poison).

## Testing

- `game`: `PoisonNearby` poisons creatures in radius (sparing a far one) and the
  poison costs the near creature HP on the next turn; the existing `FlashBlind`
  test still passes through the refactor.
- `behaviors`: the `noxious_cloud` behaviour poisons a nearby creature.
- `data`: golden test for the embedded spellbook.
- Full suite green; `go vet` + `gofmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new "Noxious Cloud" spell that poisons nearby enemies in an area-of-effect attack with adjustable power and cost parameters.

* **Refactor**
  * Refactored shared spell logic to improve code reusability across multiple area-of-effect spell implementations.

* **Documentation**
  * Added implementation documentation outlining the design and development plan for the new spell feature.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->