### PR TITLE
feat: wand of confusion — new confuse status effect (#15)

### DIFF
--- a/docs/superpowers/plans/2026-06-10-wand-confusion-15p.md
+++ b/docs/superpowers/plans/2026-06-10-wand-confusion-15p.md
@@ -1,0 +1,42 @@
+# Wand of Confusion (15p) Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** A **wand of confusion** — a new `confuse` status effect with its own AI
+behaviour: a confused creature lurches in a random direction each turn and is too
+disoriented to press an attack, breaking a dangerous foe's pursuit. It parallels
+the existing `blind` mechanic and reuses the effect-wand path (like the wands of
+venom/slowing), so the wand itself needs no new zap code. Advances #15.
+
+## Design
+- **`confuse` effect:** add HUD label ("Confused") and zap verb ("confuses") to
+  `effectLabels`/`effectVerbs`.
+- **AI branch** (`monsterAct`): a top-of-function check — if the creature
+  `HasEffect("confuse")`, call a new `stepRandom(m)` and return, so it never
+  reaches the attack/track/pursue logic. `stepRandom` moves one tile in a random
+  direction via `g.RNG`; it won't lurch onto the player (so a confused creature
+  can't attack), another creature, or a wall — those just stumble in place.
+- **Wand:** `wand_confusion` (kind wand, `effect = "confuse"`, `effect_turns`).
+  The existing `ZapWand` effect path applies it.
+
+## Task 1: confuse effect + wandering AI (TDD)
+**Files:** `internal/game/effects.go`, `internal/game/combat.go`,
+`internal/game/combat_test.go`
+- Tests first: a confused creature adjacent to the player does **not** damage it
+  over a turn (it can't attack), while a non-confused control creature does; the
+  confused creature still ticks the effect down and resumes attacking once it
+  expires.
+- Implement the label/verb entries, the `monsterAct` confuse branch, and
+  `stepRandom`.
+- Commit: `feat(game): confuse status effect (wandering AI)`
+
+## Task 2: wand data + golden + ship
+**Files:** `data/items.toml`, `data/data_test.go`
+- Test first: the embedded `wand_confusion` loads with `effect = "confuse"`.
+- Add the wand; golden test green.
+- Commit: `feat(content): wand of confusion`
+- Full gate (`go test ./...`, `gofmt`); push, PR, CodeRabbit loop → merge.
+
+## Done when
+Zap a charging foe with the wand of confusion and it lurches harmlessly around
+the room instead of attacking, until the confusion wears off. Suite green.

--- a/go/data/data_test.go
+++ b/go/data/data_test.go
@@ -492,6 +492,20 @@ func TestEmbeddedSlowingWand(t *testing.T) {
 	}
 }
 
+func TestEmbeddedConfusionWand(t *testing.T) {
+	c, err := content.Load(Files)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	w := c.Items["wand_confusion"]
+	if w == nil || w.Kind != "wand" || w.Effect != "confuse" || w.EffectTurns <= 0 {
+		t.Errorf("wand_confusion def unexpected: %+v", w)
+	}
+	if w != nil && w.Damage != "" {
+		t.Errorf("wand_confusion should be a pure status wand (no damage), got %q", w.Damage)
+	}
+}
+
 // TestEmbeddedDungeon validates the shipped level graph loads with exactly one
 // start and the expected starter levels.
 func TestEmbeddedDungeon(t *testing.T) {

--- a/go/data/items.toml
+++ b/go/data/items.toml
@@ -244,6 +244,17 @@ effect = "slow"
 effect_turns = 10
 power = 5
 
+# Wand of confusion (#15) — a pure status wand: the target lurches around at
+# random and can't press an attack until the confusion wears off (effect_turns).
+[item.wand_confusion]
+name = "wand of confusion"
+glyph = "/"
+color = "magenta"
+kind = "wand"
+effect = "confuse"
+effect_turns = 8
+power = 5
+
 # Scrolls (#15) — read (r) to invoke. Glyph ?.
 [item.scroll_teleport]
 name = "scroll of teleportation"

--- a/go/internal/game/combat.go
+++ b/go/internal/game/combat.go
@@ -239,6 +239,10 @@ func (g *Game) monstersAct() {
 // monsterAct is a single monster action: attack the player if adjacent, else
 // step toward the player if within sense range.
 func (g *Game) monsterAct(m *Creature) {
+	if m.HasEffect("confuse") {
+		g.stepRandom(m) // disoriented: it lurches at random and can't press an attack
+		return
+	}
 	dist := chebyshev(m.Pos, g.Player)
 	if dist == 1 {
 		g.monsterAttacks(m)
@@ -273,6 +277,21 @@ func (g *Game) stepToward(m *Creature, target Pos) {
 	}
 	if !g.Level.Passable(dst) {
 		g.openDoor(dst) // open a door in the way (spends this move); a plain wall is a no-op
+		return
+	}
+	m.Pos = dst
+}
+
+// stepRandom moves m one tile in a random direction — a confused creature's
+// aimless lurch. It won't stumble onto the player (so a confused creature never
+// attacks), onto another creature, or into a wall; those just cost the turn.
+func (g *Game) stepRandom(m *Creature) {
+	dx, dy := g.RNG.Intn(3)-1, g.RNG.Intn(3)-1
+	if dx == 0 && dy == 0 {
+		return // stumbles in place
+	}
+	dst := Pos{m.Pos.X + dx, m.Pos.Y + dy}
+	if dst == g.Player || g.Level.CreatureAt(dst) != nil || !g.Level.Passable(dst) {
 		return
 	}
 	m.Pos = dst

--- a/go/internal/game/combat_test.go
+++ b/go/internal/game/combat_test.go
@@ -237,3 +237,26 @@ func TestKillCreatureNoCorpse(t *testing.T) {
 		t.Error("monster with no corpse should drop nothing")
 	}
 }
+
+func TestConfusedMonsterCannotAttack(t *testing.T) {
+	g := combatGame() // player at (1,1)
+	rat := &Creature{Def: &content.MonsterDef{ID: "rat", Name: "rat", Attack: 99, Dodge: 0, Damage: "5d1", HP: 9}, Pos: Pos{2, 1}, HP: 9}
+	g.Level.Creatures = append(g.Level.Creatures, rat)
+	rat.AddEffect("confuse", 5)
+	hp := g.PlayerHP
+	g.monstersAct()
+	if g.PlayerHP != hp {
+		t.Errorf("a confused creature should be too disoriented to attack: HP %d -> %d", hp, g.PlayerHP)
+	}
+}
+
+func TestAdjacentMonsterAttacksWhenNotConfused(t *testing.T) {
+	g := combatGame() // control: same setup, no confusion
+	rat := &Creature{Def: &content.MonsterDef{ID: "rat", Name: "rat", Attack: 99, Dodge: 0, Damage: "5d1", HP: 9}, Pos: Pos{2, 1}, HP: 9}
+	g.Level.Creatures = append(g.Level.Creatures, rat)
+	hp := g.PlayerHP
+	g.monstersAct()
+	if g.PlayerHP >= hp {
+		t.Errorf("an adjacent creature should attack the player, HP unchanged at %d", g.PlayerHP)
+	}
+}

--- a/go/internal/game/effects.go
+++ b/go/internal/game/effects.go
@@ -10,10 +10,11 @@ type Effect struct {
 
 // effectLabels maps effect kinds to their HUD labels.
 var effectLabels = map[string]string{
-	"poison": "Poisoned",
-	"regen":  "Regenerating",
-	"slow":   "Slowed",
-	"blind":  "Blinded",
+	"poison":  "Poisoned",
+	"regen":   "Regenerating",
+	"slow":    "Slowed",
+	"blind":   "Blinded",
+	"confuse": "Confused",
 }
 
 // HasEffect reports whether a timed effect of the given kind is active on the
@@ -29,8 +30,9 @@ func (g *Game) HasEffect(kind string) bool {
 
 // effectVerbs phrases how a source inflicts an effect, for the zap message.
 var effectVerbs = map[string]string{
-	"poison": "poisons",
-	"slow":   "slows",
+	"poison":  "poisons",
+	"slow":    "slows",
+	"confuse": "confuses",
 }
 
 // effectVerb returns the verb describing inflicting kind, with a generic


### PR DESCRIPTION
## What

Adds a **wand of confusion** and the **`confuse`** status effect behind it. A
confused creature lurches in a random direction each turn and is too disoriented
to press an attack — zap a charging foe and it stumbles harmlessly around the
room until the confusion wears off. It parallels the existing `blind` mechanic
and rounds out the wand kit (force-bolt / venom / slowing → **confusion**).
Advances #15.

## How

- **`confuse` effect** (`internal/game/effects.go`): HUD label "Confused" and zap
  verb "confuses".
- **Wandering AI** (`internal/game/combat.go`): a top-of-`monsterAct` branch —
  if the creature `HasEffect("confuse")`, it calls the new `stepRandom(m)` and
  returns, never reaching the attack/track/pursue logic. `stepRandom` moves one
  tile in a random direction via the game RNG and **won't** lurch onto the
  player (so a confused creature can't attack), onto another creature, or into a
  wall — those just cost the turn.
- **Wand** (`data/items.toml`): `wand_confusion` (`effect = "confuse"`, 8 turns),
  a pure status wand that reuses the existing `ZapWand` effect path — no new zap
  code.

## Testing

- `game`: a confused creature adjacent to the player deals **no** damage over a
  turn (it can't attack); an unconfused control creature in the same setup does.
- `data`: golden test — `wand_confusion` loads as a no-damage status wand with
  `effect = "confuse"`.
- Full suite green; `go vet` + `gofmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Wand of Confusion: a new wand item that confuses enemies for multiple turns
  * Confused monsters now wander randomly instead of attacking or pursuing the player
  * Added confusion status effect visibility in the HUD

<!-- end of auto-generated comment: release notes by coderabbit.ai -->