### PR TITLE
feat: scroll of scare monster — new fear effect + flee AI (#15)

### DIFF
--- a/docs/superpowers/plans/2026-06-10-scare-monster-15q.md
+++ b/docs/superpowers/plans/2026-06-10-scare-monster-15q.md
@@ -1,0 +1,45 @@
+# Scroll of Scare Monster (15q) Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** A **scroll of scare monster** — a new `fear` status effect with **flee**
+AI (the inverse of pursuit): a frightened creature runs *away* from the player
+and won't attack. Delivered as a self-centred AoE (read the scroll → every nearby
+creature flees), reusing the `affectNearby` helper from #50. It pairs with the
+confuse wand (#52) as a second crowd-control tool and rounds out the scroll kit.
+Advances #15.
+
+## Design
+- **`fear` effect:** HUD label ("Afraid") + verb ("frightens").
+- **Flee AI** (`monsterAct`): a branch after the confuse check — if the creature
+  `HasEffect("fear")`, call a new `stepAway(m, g.Player)` and return (so it never
+  attacks/pursues). `stepAway` steps one tile directly away from the player using
+  the existing `signOf`; if that tile is blocked (wall, another creature, or the
+  player), the cornered creature holds.
+- **AoE delivery:** an exported `ScareNearby(radius, turns) int` wrapping
+  `affectNearby(radius, "fear", turns)` (mirrors `FlashBlind`/`PoisonNearby`); a
+  `scare` behaviour calls it; `scroll_scare_monster` (kind scroll, use `scare`)
+  is read via the existing read verb.
+
+## Task 1: fear effect + flee AI (TDD)
+**Files:** `internal/game/effects.go`, `internal/game/combat.go`,
+`internal/game/spell.go`, `internal/game/*_test.go`
+- Tests first: a feared creature adjacent to the player **flees** — it increases
+  its distance and deals no damage; `ScareNearby` applies fear within radius
+  (sparing a far creature).
+- Implement the label/verb, the `monsterAct` fear branch + `stepAway`, and
+  `ScareNearby` + `ScareRadius`.
+- Commit: `feat(game): fear status effect (flee AI) + ScareNearby`
+
+## Task 2: behaviour + data + golden + ship
+**Files:** `internal/behaviors/behaviors.go`, `internal/behaviors/behaviors_test.go`,
+`data/items.toml`, `data/data_test.go`
+- Test first: the `scare` behaviour frightens nearby creatures; the embedded
+  `scroll_scare_monster` loads with use `scare`.
+- Implement `scare`, register it; add the scroll; golden test.
+- Commit: `feat(content): scroll of scare monster (AoE fear)`
+- Full gate; push, PR, CodeRabbit loop → merge.
+
+## Done when
+Read a scroll of scare monster and the pack around you turns and flees instead of
+closing in, buying you room to escape or pick them off. Suite green.

--- a/go/data/data_test.go
+++ b/go/data/data_test.go
@@ -475,6 +475,9 @@ func TestEmbeddedScrolls(t *testing.T) {
 	if s := c.Items["scroll_magic_mapping"]; s == nil || s.Kind != "scroll" || s.Use != "reveal" {
 		t.Errorf("scroll_magic_mapping def unexpected: %+v", s)
 	}
+	if s := c.Items["scroll_scare_monster"]; s == nil || s.Kind != "scroll" || s.Use != "scare" || s.Power <= 0 {
+		t.Errorf("scroll_scare_monster def unexpected: %+v", s)
+	}
 }
 
 // TestEmbeddedSlowingWand checks the control (slowing) wand loaded.

--- a/go/data/items.toml
+++ b/go/data/items.toml
@@ -270,6 +270,16 @@ color = "blue"
 kind = "scroll"
 use = "reveal"
 
+# Scroll of scare monster (#15) — a wave of terror: every nearby creature flees
+# the player (fear effect) for `power` turns instead of attacking.
+[item.scroll_scare_monster]
+name = "scroll of scare monster"
+glyph = "?"
+color = "red"
+kind = "scroll"
+use = "scare"
+power = 8
+
 # Spellbooks (#15i/j) — carry one and press c to cast (costs EP). A book is either
 # a utility spell (use = effect) or a targeted attack (ranged + damage).
 [item.spellbook_first_aid]

--- a/go/internal/behaviors/behaviors.go
+++ b/go/internal/behaviors/behaviors.go
@@ -26,6 +26,7 @@ func Registry() map[string]game.Behavior {
 		"blindness":       blindness,
 		"flash":           flash,
 		"noxious_cloud":   noxiousCloud,
+		"scare":           scare,
 		"restore_energy":  restoreEnergy,
 	}
 }
@@ -147,6 +148,16 @@ func noxiousCloud(g *game.Game, it *game.Item) []string {
 		return []string{fmt.Sprintf("You cast %s, but no creatures are near.", it.Def.Name)}
 	}
 	return []string{fmt.Sprintf("A cloud of poison billows from %s, choking %d nearby creature(s)!", it.Def.Name, n)}
+}
+
+// scare is the scroll of scare monster — a wave of terror that sends the nearby
+// creatures fleeing instead of pressing their attack.
+func scare(g *game.Game, it *game.Item) []string {
+	n := g.ScareNearby(game.ScareRadius, it.Def.Power)
+	if n == 0 {
+		return []string{fmt.Sprintf("You read the %s, but no creatures are near.", it.Def.Name)}
+	}
+	return []string{fmt.Sprintf("You read the %s; %d nearby creature(s) turn and flee!", it.Def.Name, n)}
 }
 
 // firstAid is the first-aid spell — it knits wounds over time (a regen effect),

--- a/go/internal/behaviors/behaviors_test.go
+++ b/go/internal/behaviors/behaviors_test.go
@@ -189,6 +189,21 @@ func TestNoxiousCloudPoisonsNearby(t *testing.T) {
 	}
 }
 
+func TestScareFrightensNearby(t *testing.T) {
+	scare, ok := Registry()["scare"]
+	if !ok {
+		t.Fatal("scare not registered")
+	}
+	floor := &content.TileDef{ID: "floor", Glyph: ".", Color: content.ColorNormal, Passable: true, Transparent: true}
+	g := &game.Game{Level: game.NewLevel(10, 3, floor), Player: game.Pos{X: 1, Y: 1}}
+	rat := &game.Creature{Def: &content.MonsterDef{ID: "rat", Name: "rat", HP: 3}, Pos: game.Pos{X: 3, Y: 1}, HP: 3}
+	g.Level.Creatures = append(g.Level.Creatures, rat)
+	scare(g, &game.Item{Def: &content.ItemDef{Name: "scroll of scare monster", Power: 6}})
+	if !rat.HasEffect("fear") {
+		t.Error("scare should frighten a nearby creature")
+	}
+}
+
 func TestBlindnessAddsEffect(t *testing.T) {
 	blind, ok := Registry()["blindness"]
 	if !ok {

--- a/go/internal/game/combat.go
+++ b/go/internal/game/combat.go
@@ -243,6 +243,10 @@ func (g *Game) monsterAct(m *Creature) {
 		g.stepRandom(m) // disoriented: it lurches at random and can't press an attack
 		return
 	}
+	if m.HasEffect("fear") {
+		g.stepAway(m, g.Player) // frightened: it flees the player instead of attacking
+		return
+	}
 	dist := chebyshev(m.Pos, g.Player)
 	if dist == 1 {
 		g.monsterAttacks(m)
@@ -277,6 +281,21 @@ func (g *Game) stepToward(m *Creature, target Pos) {
 	}
 	if !g.Level.Passable(dst) {
 		g.openDoor(dst) // open a door in the way (spends this move); a plain wall is a no-op
+		return
+	}
+	m.Pos = dst
+}
+
+// stepAway moves m one tile directly away from `from` — a frightened creature's
+// flight. If the retreat tile is blocked (a wall, another creature, or the
+// player), the cornered creature holds its ground.
+func (g *Game) stepAway(m *Creature, from Pos) {
+	dx, dy := signOf(m.Pos.X-from.X), signOf(m.Pos.Y-from.Y)
+	if dx == 0 && dy == 0 {
+		return // on top of the player (shouldn't happen): nowhere to flee
+	}
+	dst := Pos{m.Pos.X + dx, m.Pos.Y + dy}
+	if dst == g.Player || g.Level.CreatureAt(dst) != nil || !g.Level.Passable(dst) {
 		return
 	}
 	m.Pos = dst

--- a/go/internal/game/combat.go
+++ b/go/internal/game/combat.go
@@ -265,17 +265,7 @@ func (g *Game) monsterAct(m *Creature) {
 }
 
 func (g *Game) stepToward(m *Creature, target Pos) {
-	step := func(a, b int) int {
-		switch {
-		case b > a:
-			return 1
-		case b < a:
-			return -1
-		default:
-			return 0
-		}
-	}
-	dst := Pos{m.Pos.X + step(m.Pos.X, target.X), m.Pos.Y + step(m.Pos.Y, target.Y)}
+	dst := Pos{m.Pos.X + signOf(target.X-m.Pos.X), m.Pos.Y + signOf(target.Y-m.Pos.Y)}
 	if dst == g.Player || g.Level.CreatureAt(dst) != nil {
 		return
 	}

--- a/go/internal/game/combat_test.go
+++ b/go/internal/game/combat_test.go
@@ -260,3 +260,19 @@ func TestAdjacentMonsterAttacksWhenNotConfused(t *testing.T) {
 		t.Errorf("an adjacent creature should attack the player, HP unchanged at %d", g.PlayerHP)
 	}
 }
+
+func TestFearedMonsterFleesInsteadOfAttacking(t *testing.T) {
+	g := combatGame() // player at (1,1)
+	rat := &Creature{Def: &content.MonsterDef{ID: "rat", Name: "rat", Attack: 99, Dodge: 0, Damage: "5d1", HP: 9}, Pos: Pos{2, 1}, HP: 9}
+	g.Level.Creatures = append(g.Level.Creatures, rat)
+	rat.AddEffect("fear", 5)
+	hp := g.PlayerHP
+	before := chebyshev(rat.Pos, g.Player)
+	g.monstersAct()
+	if g.PlayerHP != hp {
+		t.Errorf("a frightened creature should flee, not attack: HP %d -> %d", hp, g.PlayerHP)
+	}
+	if got := chebyshev(rat.Pos, g.Player); got <= before {
+		t.Errorf("a frightened creature should increase its distance from the player (%d -> %d)", before, got)
+	}
+}

--- a/go/internal/game/effects.go
+++ b/go/internal/game/effects.go
@@ -15,6 +15,7 @@ var effectLabels = map[string]string{
 	"slow":    "Slowed",
 	"blind":   "Blinded",
 	"confuse": "Confused",
+	"fear":    "Afraid",
 }
 
 // HasEffect reports whether a timed effect of the given kind is active on the
@@ -33,6 +34,7 @@ var effectVerbs = map[string]string{
 	"poison":  "poisons",
 	"slow":    "slows",
 	"confuse": "confuses",
+	"fear":    "frightens",
 }
 
 // effectVerb returns the verb describing inflicting kind, with a generic

--- a/go/internal/game/spell.go
+++ b/go/internal/game/spell.go
@@ -115,6 +115,16 @@ func (g *Game) PoisonNearby(radius, turns int) int {
 	return g.affectNearby(radius, "poison", turns)
 }
 
+// ScareRadius is how far the scroll of scare monster's terror spreads.
+const ScareRadius = 4
+
+// ScareNearby frightens every creature within radius of the player for turns and
+// reports how many fled — the scroll of scare monster's area effect. A
+// frightened creature flees the player (stepAway) instead of attacking.
+func (g *Game) ScareNearby(radius, turns int) int {
+	return g.affectNearby(radius, "fear", turns)
+}
+
 // fireBeam traces a straight 8-directional ray from the player toward target, up
 // to the spell's range, damaging every creature it crosses (killing at 0 HP) and
 // stopping at the first opaque tile — a wall or a closed door.

--- a/go/internal/game/spell_test.go
+++ b/go/internal/game/spell_test.go
@@ -189,6 +189,25 @@ func TestPoisonNearbyPoisonsAndDamages(t *testing.T) {
 	}
 }
 
+func TestScareNearbyFrightens(t *testing.T) {
+	g := combatGame()                                                                             // player at (1,1)
+	near := &Creature{Def: &content.MonsterDef{ID: "a", Name: "a", HP: 3}, Pos: Pos{3, 1}, HP: 3} // dist 2
+	far := &Creature{Def: &content.MonsterDef{ID: "b", Name: "b", HP: 3}, Pos: Pos{9, 1}, HP: 3}  // dist 8
+	g.Level.Creatures = append(g.Level.Creatures, near, far)
+
+	n := g.ScareNearby(3, 5)
+
+	if n != 1 {
+		t.Errorf("ScareNearby radius 3 should frighten 1 creature, got %d", n)
+	}
+	if !near.HasEffect("fear") {
+		t.Error("the near creature should be frightened")
+	}
+	if far.HasEffect("fear") {
+		t.Error("the far creature should be out of range")
+	}
+}
+
 func TestBlindMonsterHoldsAtRange(t *testing.T) {
 	g := combatGame()
 	rat := &Creature{Def: &content.MonsterDef{ID: "rat", Name: "rat", HP: 9, Damage: "1d1"}, Pos: Pos{5, 1}, HP: 9}


### PR DESCRIPTION
## What

Adds a **scroll of scare monster** and the **`fear`** status effect behind it. A
frightened creature *flees* the player (the inverse of pursuit) and won't
attack. Read the scroll and every nearby creature turns and runs — buying you
room to escape or pick them off. It pairs with the confusion wand (#52) as a
second crowd-control tool. Advances #15.

## How

- **`fear` effect** (`internal/game/effects.go`): HUD label "Afraid", verb
  "frightens".
- **Flee AI** (`internal/game/combat.go`): a `monsterAct` branch after the
  confuse check — a `fear`-afflicted creature calls the new `stepAway(m, player)`
  and returns (never attacks/pursues). `stepAway` steps one tile directly away
  using the existing `signOf`; a cornered creature (wall / another creature / the
  player behind it) holds.
- **AoE delivery** (`internal/game/spell.go`): `ScareNearby(radius, turns)` wraps
  the shared `affectNearby` helper (mirrors `FlashBlind`/`PoisonNearby`); a
  `scare` behaviour calls it; `scroll_scare_monster` (use `scare`, 8 turns) is
  read via the existing read verb.

## Testing

- `game`: a frightened creature adjacent to the player **flees** (increases its
  distance) and deals no damage; `ScareNearby` frightens within radius (sparing a
  far creature).
- `behaviors`: the `scare` behaviour frightens a nearby creature.
- `data`: golden test — `scroll_scare_monster` loads with use `scare`.
- Full suite green; `go vet` + `gofmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Scroll of Scare Monster that applies an area-effect fear, causing nearby creatures to become "Afraid" and flee instead of attacking.
* **Documentation**
  * New design/plan doc describing the fear effect, HUD label, flee behavior, and rollout steps.
* **Tests**
  * Added unit tests validating the scare scroll, fear effect, and fleeing monster behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->