### PR TITLE
Player turn-energy scheduler (tick loop)

### DIFF
--- a/docs/superpowers/plans/2026-06-10-player-energy-scheduler-16a.md
+++ b/docs/superpowers/plans/2026-06-10-player-energy-scheduler-16a.md
@@ -25,16 +25,19 @@ is the engine half.
   (`game.c:150-175`), so the player's effect clocks and EP regen stay per
   player-turn, not per world tick.
 - `play()` opens with `goto creature_turn` for the player: the player always
-  moves first. We keep that by starting `playerEnergy` at a full turn.
+  moves first. We keep that via the surplus convention below — a zero surplus
+  means "exactly ready to act", so a fresh game's zero value needs no builder
+  initialization.
 
 ## Design
-- `Game.playerEnergy int` (start `turnCost` in builders: ready to act first).
+- `Game.playerEnergy int`: the player's surplus beyond the turn just taken (the
+  C's `move_counter − TURN_TIME`), so the zero value means ready to act first.
 - `playerSpeed()`: base 100; `haste` → +30 (`hasteBonus`, C `HASTE_AMOUNT`);
   `slow` → halved (same rule monsters use in `monstersAct`); floor 1.
 - `advanceWorld()` — the per-player-turn entry, replacing `monstersAct()` at all
   8 production call sites (PlayerStep/ZapWand/fire/spell×3/use×2):
   `tickEffects()` + `regenEP()` once, pay `turnCost`, then
-  `for playerEnergy < turnCost { playerEnergy += playerSpeed(); worldTick() }`.
+  `for playerEnergy < 0 { playerEnergy += playerSpeed(); worldTick() }`.
 - `worldTick()` — old `monstersAct` minus the player bookkeeping: monster effect
   ticks + energy banking + actions. Tests that drove single ticks via
   `monstersAct()` rename mechanically.

--- a/docs/superpowers/plans/2026-06-10-player-energy-scheduler-16a.md
+++ b/docs/superpowers/plans/2026-06-10-player-energy-scheduler-16a.md
@@ -1,0 +1,65 @@
+# Player turn-energy scheduler (16a) Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Port the C tick scheduler to the player. In 0.40 (`game.c play()` /
+`increment_counters()`) *every* creature — the player included — banks
+`attr_speed` into `move_counter` each tick and acts when it reaches `TURN_TIME`;
+the player is just another creature with `BASE_SPEED` 100. Our engine already
+does this for monsters (`Energy`/`speedOf`) but the player implicitly acts once
+per world advance, so nothing can ever speed up or slow down the *player*. This
+PR makes the player a first-class energy citizen, unlocking haste/slow on the
+player and, next, potions of speed/slowing (16b) and sleep. Multi-PR arc; this
+is the engine half.
+
+## C grounding
+- `game.c:590-600`: each tick `move_counter += attr_current(attr_speed)`; a
+  creature whose counter reaches `TURN_TIME` (1000) acts and pays it back.
+- `rules.h`: `BASE_SPEED 100`, `HASTE_AMOUNT 30`, `HASTE_LENGTH 20`,
+  `SLOW_LENGTH 20`.
+- `effect.c std_effect()`: `effect_haste` = speed +30; `effect_slow` = speed −1
+  (vestigial — a −1 on a 100 scale is noise; our shipped monster slow halves
+  speed, so the player mirrors that for one consistent rule).
+- Per-**turn** vs per-**tick**: `pass_time_on_effects` (effect TTLs) and
+  `energy()` (EP regen) run only when a creature actually takes its turn
+  (`game.c:150-175`), so the player's effect clocks and EP regen stay per
+  player-turn, not per world tick.
+- `play()` opens with `goto creature_turn` for the player: the player always
+  moves first. We keep that by starting `playerEnergy` at a full turn.
+
+## Design
+- `Game.playerEnergy int` (start `turnCost` in builders: ready to act first).
+- `playerSpeed()`: base 100; `haste` → +30 (`hasteBonus`, C `HASTE_AMOUNT`);
+  `slow` → halved (same rule monsters use in `monstersAct`); floor 1.
+- `advanceWorld()` — the per-player-turn entry, replacing `monstersAct()` at all
+  8 production call sites (PlayerStep/ZapWand/fire/spell×3/use×2):
+  `tickEffects()` + `regenEP()` once, pay `turnCost`, then
+  `for playerEnergy < turnCost { playerEnergy += playerSpeed(); worldTick() }`.
+- `worldTick()` — old `monstersAct` minus the player bookkeeping: monster effect
+  ticks + energy banking + actions. Tests that drove single ticks via
+  `monstersAct()` rename mechanically.
+- At speed 100 exactly one tick passes per turn — existing behavior is
+  unchanged. Slowed: two ticks per turn (monsters act twice). Hasted: every few
+  turns zero ticks pass (a free player action), averaging 1.3 actions per tick.
+- `haste` joins `effectLabels` ("Hastened").
+
+## Task 1: scheduler (TDD)
+**Files:** `internal/game/scheduler_test.go` (new), `internal/game/combat.go`,
+`internal/game/game.go`, `internal/game/effects.go`, callers in
+`fire.go`/`spell.go`/`use.go`, builder in `build.go`.
+- Tests first (red): baseline — one `advanceWorld()` moves a distant rat 1 tile;
+  slowed player — 2 tiles; hasted player — 4 turns close 4 tiles, the 5th is a
+  free action (rat frozen), the 6th moves again; slowed player's own poison
+  still burns 1 HP per player turn (TTLs are per-turn, not per-tick).
+- Implement (green): `playerEnergy`/`playerSpeed()`/`advanceWorld()`/`worldTick()`,
+  swap call sites, rename in tests.
+- Commit: `feat(game): player turn-energy scheduler (tick loop)`
+
+## Task 2: gate + ship
+- gofmt + go vet + full `go test ./...`; branch, push, PR, CodeRabbit loop →
+  merge with merge commit.
+
+## Done when
+A slowed player watches every monster move twice between his steps; a hasted
+player periodically gets a free action. An unaffected game plays exactly as
+before. Suite green.

--- a/go/internal/game/combat.go
+++ b/go/internal/game/combat.go
@@ -13,16 +13,34 @@ const senseRange = 8 // how close a monster must be to notice the player
 
 const (
 	turnCost     = 100 // energy needed for one action
-	defaultSpeed = 100 // energy per turn for a monster with no speed set
+	defaultSpeed = 100 // energy per tick for an average creature (C rules.h BASE_SPEED)
+	hasteBonus   = 30  // flat speed bonus while hasted (C rules.h HASTE_AMOUNT)
 )
 
-// speedOf is a monster's energy gain per turn (a non-positive def speed means
-// "average", matching the player's one action per turn).
+// speedOf is a monster's energy gain per tick (a non-positive def speed means
+// "average").
 func speedOf(m *Creature) int {
 	if m.Def.Speed > 0 {
 		return m.Def.Speed
 	}
 	return defaultSpeed
+}
+
+// playerSpeed is the player's energy gain per world tick (the C's attr_speed,
+// base BASE_SPEED): haste adds a flat bonus, slow halves — the same rule
+// monsters use (the C's literal -1 for slow is vestigial on a 100 scale).
+func (g *Game) playerSpeed() int {
+	speed := defaultSpeed
+	if g.HasEffect("haste") {
+		speed += hasteBonus
+	}
+	if g.HasEffect("slow") {
+		speed /= 2
+	}
+	if speed < 1 {
+		speed = 1
+	}
+	return speed
 }
 
 // log appends a message to the game log.
@@ -59,7 +77,7 @@ func (g *Game) PlayerStep(d Direction) {
 		acted = true
 	}
 	if acted { // a blocked move into a wall doesn't pass the turn
-		g.monstersAct()
+		g.advanceWorld()
 	}
 }
 
@@ -155,7 +173,7 @@ func (g *Game) ZapWand(it *Item, target Pos) {
 	} else {
 		g.log("The bolt fizzles against nothing.")
 	}
-	g.monstersAct()
+	g.advanceWorld()
 }
 
 func (g *Game) monsterAttacks(m *Creature) {
@@ -192,16 +210,34 @@ func (g *Game) HurtPlayer(dmg int, cause string) {
 	}
 }
 
-// monstersAct advances the world after the player's turn. Each living monster
-// gains energy equal to its speed and acts for every full turn's worth it
-// holds, so faster monsters act more often (the C's move_counter / TURN_TIME
-// model). Leftover energy carries to the next turn.
-func (g *Game) monstersAct() {
+// advanceWorld passes the player's turn. The per-turn bookkeeping (effect
+// clocks, EP regen) runs once — in the C these happen per creature-turn, not
+// per tick (game.c pass_time_on_effects/energy) — then the player pays for the
+// action and the world ticks until the player has banked the next turn.
+// playerEnergy holds the player's surplus beyond the turn just taken (the C's
+// move_counter minus TURN_TIME), so at base speed exactly one tick passes; a
+// slowed player owes two, and a hasted player sometimes none (a free action).
+func (g *Game) advanceWorld() {
 	g.tickEffects()
 	if g.Dead {
 		return // status effects (e.g. poison) killed the player
 	}
 	g.regenEP()
+	g.playerEnergy -= turnCost
+	for g.playerEnergy < 0 {
+		g.playerEnergy += g.playerSpeed()
+		g.worldTick()
+		if g.Dead {
+			return
+		}
+	}
+}
+
+// worldTick is one tick of world time. Each living monster gains energy equal
+// to its speed and acts for every full turn's worth it holds, so faster
+// monsters act more often (the C's move_counter / TURN_TIME model). Leftover
+// energy carries to the next tick.
+func (g *Game) worldTick() {
 	// snapshot to avoid mutation surprises when creatures are removed
 	snapshot := make([]*Creature, len(g.Level.Creatures))
 	copy(snapshot, g.Level.Creatures)

--- a/go/internal/game/combat_test.go
+++ b/go/internal/game/combat_test.go
@@ -43,7 +43,7 @@ func TestMonsterAttacksAndCanKillPlayer(t *testing.T) {
 	// Player waits in place (steps into a wall-less open tile west and back is
 	// unnecessary); just run monster turns directly.
 	for i := 0; i < 50 && !g.Dead; i++ {
-		g.monstersAct()
+		g.worldTick()
 	}
 	if !g.Dead {
 		t.Fatal("player should be dead after the ogre attacks")
@@ -55,7 +55,7 @@ func TestMonsterMovesTowardPlayer(t *testing.T) {
 	rat := &Creature{Def: &content.MonsterDef{ID: "rat", Glyph: "r", HP: 3, Attack: 1, Dodge: 1, Damage: "1d1"}, Pos: Pos{8, 1}, HP: 3}
 	g.Level.Creatures = append(g.Level.Creatures, rat)
 	before := rat.Pos.X
-	g.monstersAct()
+	g.worldTick()
 	if rat.Pos.X >= before {
 		t.Errorf("rat at x=%d should have stepped toward the player (x decreasing), was %d", rat.Pos.X, before)
 	}
@@ -66,7 +66,7 @@ func TestFasterMonsterActsMultipleTimes(t *testing.T) {
 	rat := &Creature{Def: &content.MonsterDef{ID: "rat", Name: "rat", Glyph: "r", HP: 9, Attack: 1, Dodge: 1, Damage: "1d1", Speed: 250}, Pos: Pos{8, 1}, HP: 9}
 	g.Level.Creatures = append(g.Level.Creatures, rat)
 	before := rat.Pos.X
-	g.monstersAct() // speed 250 → 250 energy → acts twice (250-100-100=50)
+	g.worldTick() // speed 250 → 250 energy → acts twice (250-100-100=50)
 	if before-rat.Pos.X != 2 {
 		t.Errorf("speed-250 monster stepped %d tiles in one turn, want 2", before-rat.Pos.X)
 	}
@@ -77,7 +77,7 @@ func TestDefaultSpeedActsOnce(t *testing.T) {
 	rat := &Creature{Def: &content.MonsterDef{ID: "rat", Glyph: "r", HP: 9, Attack: 1, Dodge: 1, Damage: "1d1"}, Pos: Pos{8, 1}, HP: 9} // Speed 0 → default 100
 	g.Level.Creatures = append(g.Level.Creatures, rat)
 	before := rat.Pos.X
-	g.monstersAct()
+	g.worldTick()
 	if before-rat.Pos.X != 1 {
 		t.Errorf("default-speed monster stepped %d tiles, want 1", before-rat.Pos.X)
 	}
@@ -187,8 +187,8 @@ func TestSlowedMonsterActsLessOften(t *testing.T) {
 	g.Level.Creatures = append(g.Level.Creatures, rat)
 	rat.AddEffect("slow", 10)
 	start := rat.Pos.X
-	g.monstersAct() // gains 50 energy: not enough to act
-	g.monstersAct() // 50+50=100: acts once
+	g.worldTick() // gains 50 energy: not enough to act
+	g.worldTick() // 50+50=100: acts once
 	if moved := start - rat.Pos.X; moved != 1 {
 		t.Errorf("slowed default-speed monster moved %d tiles in two turns, want 1", moved)
 	}
@@ -217,7 +217,7 @@ func TestPoisonedMonsterDiesOverTurns(t *testing.T) {
 	rat.AddEffect("poison", 8)
 
 	for i := 0; i < 8 && g.Level.CreatureAt(rat.Pos) == rat; i++ {
-		g.monstersAct()
+		g.worldTick()
 	}
 	for _, m := range g.Level.Creatures {
 		if m == rat {
@@ -244,7 +244,7 @@ func TestConfusedMonsterCannotAttack(t *testing.T) {
 	g.Level.Creatures = append(g.Level.Creatures, rat)
 	rat.AddEffect("confuse", 5)
 	hp := g.PlayerHP
-	g.monstersAct()
+	g.worldTick()
 	if g.PlayerHP != hp {
 		t.Errorf("a confused creature should be too disoriented to attack: HP %d -> %d", hp, g.PlayerHP)
 	}
@@ -255,7 +255,7 @@ func TestAdjacentMonsterAttacksWhenNotConfused(t *testing.T) {
 	rat := &Creature{Def: &content.MonsterDef{ID: "rat", Name: "rat", Attack: 99, Dodge: 0, Damage: "5d1", HP: 9}, Pos: Pos{2, 1}, HP: 9}
 	g.Level.Creatures = append(g.Level.Creatures, rat)
 	hp := g.PlayerHP
-	g.monstersAct()
+	g.worldTick()
 	if g.PlayerHP >= hp {
 		t.Errorf("an adjacent creature should attack the player, HP unchanged at %d", g.PlayerHP)
 	}
@@ -268,7 +268,7 @@ func TestFearedMonsterFleesInsteadOfAttacking(t *testing.T) {
 	rat.AddEffect("fear", 5)
 	hp := g.PlayerHP
 	before := chebyshev(rat.Pos, g.Player)
-	g.monstersAct()
+	g.worldTick()
 	if g.PlayerHP != hp {
 		t.Errorf("a frightened creature should flee, not attack: HP %d -> %d", hp, g.PlayerHP)
 	}

--- a/go/internal/game/door_test.go
+++ b/go/internal/game/door_test.go
@@ -45,7 +45,7 @@ func TestMonsterOpensDoor(t *testing.T) {
 	rat := &Creature{Def: &content.MonsterDef{ID: "rat", Name: "rat", HP: 3, Damage: "1d1"}, Pos: Pos{3, 1}, HP: 3}
 	g.Level.Creatures = append(g.Level.Creatures, rat)
 
-	g.monstersAct() // rat steps toward the player, blocked by the closed door
+	g.worldTick() // rat steps toward the player, blocked by the closed door
 
 	if g.Level.At(Pos{2, 1}).Def.ID != "door_open" {
 		t.Errorf("a monster should open a door in its path, got %q", g.Level.At(Pos{2, 1}).Def.ID)

--- a/go/internal/game/effects.go
+++ b/go/internal/game/effects.go
@@ -13,6 +13,7 @@ var effectLabels = map[string]string{
 	"poison":  "Poisoned",
 	"regen":   "Regenerating",
 	"slow":    "Slowed",
+	"haste":   "Hastened",
 	"blind":   "Blinded",
 	"confuse": "Confused",
 	"fear":    "Afraid",
@@ -97,7 +98,7 @@ func (g *Game) tickCreatureEffects(m *Creature) bool {
 }
 
 // tickEffects applies each active effect's per-turn outcome, then decrements and
-// expires them. Called once per player action (from monstersAct).
+// expires them. Called once per player turn (from advanceWorld).
 func (g *Game) tickEffects() {
 	if len(g.Effects) == 0 {
 		return

--- a/go/internal/game/fire.go
+++ b/go/internal/game/fire.go
@@ -37,5 +37,5 @@ func (g *Game) FireWeapon(target Pos) {
 	} else {
 		g.log("Your shot flies into empty space.")
 	}
-	g.monstersAct()
+	g.advanceWorld()
 }

--- a/go/internal/game/game.go
+++ b/go/internal/game/game.go
@@ -89,29 +89,30 @@ func (l *Level) Passable(p Pos) bool {
 
 // Game is the whole game state.
 type Game struct {
-	Content     *content.Content
-	Level       *Level
-	Dungeon     *Dungeon
-	Player      Pos
-	RNG         *rng.MT
-	PlayerHP    int
-	PlayerMax   int
-	EP          int // energy points: the spellcasting resource
-	EPMax       int
-	epTurn      int // counter for slow EP regeneration
-	Messages    []string
-	Dead        bool
-	Inventory   []*Item
-	Weapon      *Item
-	Armor       *Item
-	Ring        *Item // worn accessory: passive attack/dodge bonus
-	Amulet      *Item // worn accessory: passive attack/dodge bonus
-	Behaviors   map[string]Behavior
-	Won         bool
-	DeathCause  string
-	Effects     []Effect
-	Identified  map[string]bool   // item ids whose type is globally known this game
-	appearances map[string]string // item id -> shuffled cosmetic name while unidentified
+	Content      *content.Content
+	Level        *Level
+	Dungeon      *Dungeon
+	Player       Pos
+	RNG          *rng.MT
+	PlayerHP     int
+	PlayerMax    int
+	EP           int // energy points: the spellcasting resource
+	EPMax        int
+	epTurn       int // counter for slow EP regeneration
+	playerEnergy int // turn-energy surplus banked toward the next action (see advanceWorld)
+	Messages     []string
+	Dead         bool
+	Inventory    []*Item
+	Weapon       *Item
+	Armor        *Item
+	Ring         *Item // worn accessory: passive attack/dodge bonus
+	Amulet       *Item // worn accessory: passive attack/dodge bonus
+	Behaviors    map[string]Behavior
+	Won          bool
+	DeathCause   string
+	Effects      []Effect
+	Identified   map[string]bool   // item ids whose type is globally known this game
+	appearances  map[string]string // item id -> shuffled cosmetic name while unidentified
 }
 
 // Move attempts to move the player one step in d. It returns true if the player

--- a/go/internal/game/ranged_test.go
+++ b/go/internal/game/ranged_test.go
@@ -28,7 +28,7 @@ func TestRangedMonsterShootsAcrossRoom(t *testing.T) {
 	g.Level.Creatures = append(g.Level.Creatures, imp)
 	before := imp.Pos
 
-	g.monstersAct()
+	g.worldTick()
 
 	if g.PlayerHP >= 20 {
 		t.Errorf("a ranged monster with line of sight should hit the player, HP=%d", g.PlayerHP)
@@ -46,7 +46,7 @@ func TestRangedMonsterBlockedApproaches(t *testing.T) {
 	g.Level.Creatures = append(g.Level.Creatures, imp)
 	beforeX := imp.Pos.X
 
-	g.monstersAct()
+	g.worldTick()
 
 	if g.PlayerHP != 20 {
 		t.Errorf("a monster with no line of sight should not shoot, HP=%d", g.PlayerHP)
@@ -63,7 +63,7 @@ func TestRangedMonsterOutOfRangeApproaches(t *testing.T) {
 	g.Level.Creatures = append(g.Level.Creatures, imp)
 	beforeX := imp.Pos.X
 
-	g.monstersAct()
+	g.worldTick()
 
 	if g.PlayerHP != 20 {
 		t.Errorf("an out-of-range ranged monster should not shoot, HP=%d", g.PlayerHP)

--- a/go/internal/game/scheduler_test.go
+++ b/go/internal/game/scheduler_test.go
@@ -1,0 +1,70 @@
+package game
+
+import (
+	"testing"
+
+	"github.com/c0ze/tsl/internal/content"
+)
+
+// schedulerGame is a combat corridor with a pursuing rat seven tiles east, so
+// tick counts are observable as tiles closed.
+func schedulerGame() (*Game, *Creature) {
+	g := combatGame()
+	rat := &Creature{Def: &content.MonsterDef{ID: "rat", Glyph: "r", HP: 3, Attack: 0, Dodge: 1, Damage: "1d1"}, Pos: Pos{8, 1}, HP: 3}
+	g.Level.Creatures = append(g.Level.Creatures, rat)
+	return g, rat
+}
+
+func TestSchedulerOneTickPerTurnAtBaseSpeed(t *testing.T) {
+	g, rat := schedulerGame()
+	g.advanceWorld()
+	if rat.Pos.X != 7 {
+		t.Errorf("at base speed one turn is one tick: rat should be at x=7, got x=%d", rat.Pos.X)
+	}
+}
+
+func TestSlowedPlayerGivesMonstersTwoTicks(t *testing.T) {
+	g, rat := schedulerGame()
+	g.AddEffect("slow", 10)
+	g.advanceWorld()
+	if rat.Pos.X != 6 {
+		t.Errorf("a slowed player owes two ticks per turn: rat should be at x=6, got x=%d", rat.Pos.X)
+	}
+}
+
+func TestHastedPlayerGetsFreeAction(t *testing.T) {
+	g, rat := schedulerGame()
+	g.AddEffect("haste", 20)
+	for i := 0; i < 4; i++ {
+		g.advanceWorld()
+	}
+	if rat.Pos.X != 4 {
+		t.Fatalf("first four hasted turns each pass a tick: rat should be at x=4, got x=%d", rat.Pos.X)
+	}
+	g.advanceWorld() // banked surplus covers this turn: no tick passes
+	if rat.Pos.X != 4 {
+		t.Errorf("fifth hasted turn is free: rat should still be at x=4, got x=%d", rat.Pos.X)
+	}
+	g.advanceWorld()
+	if rat.Pos.X != 3 {
+		t.Errorf("sixth turn ticks again: rat should be at x=3, got x=%d", rat.Pos.X)
+	}
+}
+
+func TestPlayerEffectsBurnPerTurnNotPerTick(t *testing.T) {
+	g, _ := schedulerGame()
+	g.AddEffect("slow", 10)
+	g.AddEffect("poison", 3)
+	g.advanceWorld() // two world ticks pass, but the player's own clocks run once
+	if g.PlayerHP != 19 {
+		t.Errorf("poison burns once per player turn even when slowed: want HP 19, got %d", g.PlayerHP)
+	}
+}
+
+func TestHasteHUDLabel(t *testing.T) {
+	g := combatGame()
+	g.AddEffect("haste", 5)
+	if got := g.EffectsSummary(); got != "Hastened" {
+		t.Errorf("EffectsSummary = %q, want %q", got, "Hastened")
+	}
+}

--- a/go/internal/game/spell.go
+++ b/go/internal/game/spell.go
@@ -35,7 +35,7 @@ func (g *Game) CastSpell(book *Item) {
 	} else {
 		g.log("The spell fizzles.")
 	}
-	g.monstersAct()
+	g.advanceWorld()
 }
 
 // CastSpellAt casts a targeted attack spell from book at target: it checks EP,
@@ -56,7 +56,7 @@ func (g *Game) CastSpellAt(book *Item, target Pos) {
 	if book.Def.Beam { // a beam fires in the aimed direction, hitting all in its path
 		g.EP -= book.Def.Cost
 		g.fireBeam(book, target)
-		g.monstersAct()
+		g.advanceWorld()
 		return
 	}
 	if chebyshev(g.Player, target) > book.Def.Ranged {
@@ -78,7 +78,7 @@ func (g *Game) CastSpellAt(book *Item, target Pos) {
 	} else {
 		g.log("The spell dissipates against nothing.")
 	}
-	g.monstersAct()
+	g.advanceWorld()
 }
 
 // FlashRadius is how far the flash spell's blinding light reaches.

--- a/go/internal/game/spell_test.go
+++ b/go/internal/game/spell_test.go
@@ -183,7 +183,7 @@ func TestPoisonNearbyPoisonsAndDamages(t *testing.T) {
 	}
 	// poison is damage-over-time: the next turn costs the near creature HP
 	hp := near.HP
-	g.monstersAct()
+	g.worldTick()
 	if near.HP >= hp {
 		t.Errorf("poison should cost the near creature HP: %d -> %d", hp, near.HP)
 	}
@@ -215,7 +215,7 @@ func TestBlindMonsterHoldsAtRange(t *testing.T) {
 	rat.AddEffect("blind", 10)
 	before := rat.Pos
 
-	g.monstersAct()
+	g.worldTick()
 
 	if rat.Pos != before {
 		t.Errorf("a blinded monster should hold position at range, moved to %v", rat.Pos)
@@ -229,7 +229,7 @@ func TestBlindMonsterStillMeleesAdjacent(t *testing.T) {
 	g.Level.Creatures = append(g.Level.Creatures, rat)
 	rat.AddEffect("blind", 10)
 
-	g.monstersAct()
+	g.worldTick()
 
 	if g.PlayerHP >= 20 {
 		t.Error("a blinded monster should still attack an adjacent player")

--- a/go/internal/game/use.go
+++ b/go/internal/game/use.go
@@ -14,7 +14,7 @@ func (g *Game) PlayerPickup() {
 	g.Inventory = append(g.Inventory, it)
 	g.log("You pick up the %s.", it.Def.Name)
 	g.autoEquip(it)
-	g.monstersAct()
+	g.advanceWorld()
 }
 
 // autoEquip wields/wears a just-picked-up weapon or armor when its slot is empty
@@ -76,7 +76,7 @@ func (g *Game) PlayerUse(it *Item) {
 		}
 		g.removeInventory(it)
 	}
-	g.monstersAct()
+	g.advanceWorld()
 }
 
 func (g *Game) hasInventoryItem(it *Item) bool {


### PR DESCRIPTION
## Summary
Ports the C tick scheduler to the player — the engine half of the turn-energy arc (plan 16a). In 0.40 (`game.c play()` / `increment_counters()`) **every** creature banks `attr_speed` into `move_counter` each tick and acts at `TURN_TIME`; the player is just an average creature at `BASE_SPEED` 100. Our engine already did this for monsters, but the player implicitly acted once per world advance, so nothing could ever speed up or slow down the *player*.

- `advanceWorld()` (replacing `monstersAct()` at all call sites) passes one player turn: per-turn bookkeeping (effect clocks + EP regen — per creature-*turn* in the C, not per tick), pay `turnCost`, then tick the world until the player is back in credit. `playerEnergy` is the surplus beyond the turn just taken (the C's `move_counter − TURN_TIME`).
- `worldTick()` is the old `monstersAct` body (monster effect ticks + energy banking + actions), unchanged.
- `playerSpeed()`: base 100; `haste` +30 (C `HASTE_AMOUNT`); `slow` halves — the same rule monsters already use (the C's literal −1 for slow is vestigial on a 100 scale). `haste` gets a HUD label ("Hastened").
- At base speed exactly one tick passes per turn, so an unaffected game plays bit-identically. Slowed: monsters act twice between player actions. Hasted: every ~4th–5th action is free.

Unlocks next: potions of speed/slowing (16b), later sleep.

## Test plan
- New `scheduler_test.go`: baseline 1 tick/turn; slowed → rat closes 2 tiles per turn; hasted → 4 turns tick, 5th free, 6th ticks (exact C cadence at speed 130); player poison burns per *turn* not per tick while slowed; HUD label.
- Existing single-tick tests renamed mechanically `monstersAct` → `worldTick` (same semantics).
- gofmt + go vet + full `go test ./...` green (10/10 packages).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Player now uses a turn-energy scheduler so haste/slow change action cadence; monsters and world time advance per tick until the player banks the next turn.
  * Haste status appears in the HUD.

* **Tests**
  * Added scheduler tests and updated combat, ranged, spell, door, and use tests to validate tick-based turn progression.

* **Documentation**
  * Added a detailed implementation and rollout plan for the player energy scheduler.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->