### PR TITLE
Potions of speed and slowing

### DIFF
--- a/docs/superpowers/plans/2026-06-10-potions-speed-slowing-16b.md
+++ b/docs/superpowers/plans/2026-06-10-potions-speed-slowing-16b.md
@@ -1,0 +1,47 @@
+# Potions of speed & slowing (16b) Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** The content half of the turn-energy arc: **potion of speed** and
+**potion of slowing**, both in 0.40's `item_table_potion` spawn table
+(`treasure.c` cases 4–5). The 16a scheduler already gives `haste`/`slow` on the
+player real teeth (free actions / double monster ticks); these potions are the
+faithful way to acquire them. Advances #15.
+
+## C grounding
+- `treasure.c:1012`: "potion of speed", description "It speeds you up, duh.";
+  `treasure.c:992`: "potion of slowing", "Slows a creature down." Both spawn
+  from `item_table_potion` (`treasure.c:2294`), so they join floor loot and the
+  random-appearance shuffle like every potion.
+- `potions.c treasure_p_speed`: expire `effect_slow`, prolong `effect_haste`
+  for `HASTE_LENGTH` (20); message "You move faster!".
+- `potions.c treasure_p_slowing`: expire `effect_haste`, prolong `effect_slow`
+  for `SLOW_LENGTH` (20); message "You feel very sluggish.".
+
+## Design
+- `Game.RemoveEffect(kind)` — the engine hook for the C's `effect_expire`:
+  drops an active player effect by kind (no-op when absent).
+- Behaviors `haste` and `slowness` (registered): cancel the opposite effect,
+  apply theirs for `Power` turns, return the C message.
+- Data: `potion_speed` (use `haste`, power 20 = `HASTE_LENGTH`) and
+  `potion_slowing` (use `slowness`, power 20 = `SLOW_LENGTH`); spawnable
+  (no `nospawn`), so they enter loot and the appearance pool automatically.
+
+## Task 1: RemoveEffect + behaviors (TDD)
+**Files:** `internal/game/effects.go` + test, `internal/behaviors/behaviors.go`
++ test.
+- Tests first: `RemoveEffect` drops only the named effect; `haste` behavior
+  applies haste *and* cancels an active slow; `slowness` applies slow and
+  cancels an active haste.
+- Commit: `feat(game): RemoveEffect + haste/slowness behaviors`
+
+## Task 2: data + golden + ship
+**Files:** `data/items.toml`, `data/data_test.go`.
+- Tests first: both defs load with the right kind/use/power.
+- Commit: `feat(content): potions of speed and slowing`
+- Full gate; push, PR, CodeRabbit loop → merge.
+
+## Done when
+Quaffing an unidentified potion can now grant 20 turns of haste (periodic free
+actions) or sandbag you for 20 turns while the pack closes in twice per step —
+and identifies the type, like 0.40. Suite green.

--- a/go/data/data_test.go
+++ b/go/data/data_test.go
@@ -544,3 +544,18 @@ func TestEmbeddedDungeon(t *testing.T) {
 		t.Error("altar tile should be a win tile")
 	}
 }
+
+// TestEmbeddedSpeedPotions checks the haste/slow potion pair loaded (16b):
+// 20 turns each, the C HASTE_LENGTH/SLOW_LENGTH.
+func TestEmbeddedSpeedPotions(t *testing.T) {
+	c, err := content.Load(Files)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if p := c.Items["potion_speed"]; p == nil || p.Kind != "potion" || p.Use != "haste" || p.Power != 20 {
+		t.Errorf("potion_speed def unexpected: %+v", p)
+	}
+	if p := c.Items["potion_slowing"]; p == nil || p.Kind != "potion" || p.Use != "slowness" || p.Power != 20 {
+		t.Errorf("potion_slowing def unexpected: %+v", p)
+	}
+}

--- a/go/data/items.toml
+++ b/go/data/items.toml
@@ -174,6 +174,24 @@ kind = "potion"
 use = "blindness"
 power = 12
 
+# Turn-energy pair (16b): haste/slow on the player, 20 turns each
+# (C rules.h HASTE_LENGTH/SLOW_LENGTH); each cancels the other on quaff.
+[item.potion_speed]
+name = "potion of speed"
+glyph = "!"
+color = "brown"
+kind = "potion"
+use = "haste"
+power = 20
+
+[item.potion_slowing]
+name = "potion of slowing"
+glyph = "!"
+color = "blue"
+kind = "potion"
+use = "slowness"
+power = 20
+
 # Potion of energy — refills spell EP (power = EP restored). Closes the cast loop.
 [item.potion_energy]
 name = "potion of energy"

--- a/go/internal/behaviors/behaviors.go
+++ b/go/internal/behaviors/behaviors.go
@@ -28,7 +28,25 @@ func Registry() map[string]game.Behavior {
 		"noxious_cloud":   noxiousCloud,
 		"scare":           scare,
 		"restore_energy":  restoreEnergy,
+		"haste":           haste,
+		"slowness":        slowness,
 	}
+}
+
+// haste speeds the player up for Power turns, cancelling an active slow
+// (C potions.c treasure_p_speed).
+func haste(g *game.Game, it *game.Item) []string {
+	g.RemoveEffect("slow")
+	g.AddEffect("haste", it.Def.Power)
+	return []string{"You move faster!"}
+}
+
+// slowness drags the player down for Power turns, cancelling an active haste
+// (C potions.c treasure_p_slowing).
+func slowness(g *game.Game, it *game.Item) []string {
+	g.RemoveEffect("haste")
+	g.AddEffect("slow", it.Def.Power)
+	return []string{"You feel very sluggish."}
 }
 
 // restoreHP adds amount to the player's HP, clamped to PlayerMax, and reports

--- a/go/internal/behaviors/behaviors_test.go
+++ b/go/internal/behaviors/behaviors_test.go
@@ -248,3 +248,41 @@ func TestEatMushroomHealsAndPoisons(t *testing.T) {
 		t.Error("eating the red mushroom should poison the player")
 	}
 }
+
+func TestHasteCancelsSlowAndHastens(t *testing.T) {
+	haste, ok := Registry()["haste"]
+	if !ok {
+		t.Fatal("haste not registered")
+	}
+	g := &game.Game{PlayerHP: 10, PlayerMax: 10}
+	g.AddEffect("slow", 10)
+	msgs := haste(g, &game.Item{Def: &content.ItemDef{Name: "potion of speed", Power: 20}})
+	if g.HasEffect("slow") {
+		t.Error("a potion of speed cancels slow (C potions.c)")
+	}
+	if !g.HasEffect("haste") {
+		t.Error("expected a haste effect from the potion of speed")
+	}
+	if len(msgs) == 0 || msgs[0] != "You move faster!" {
+		t.Errorf("expected the C message, got %v", msgs)
+	}
+}
+
+func TestSlownessCancelsHasteAndSlows(t *testing.T) {
+	slowness, ok := Registry()["slowness"]
+	if !ok {
+		t.Fatal("slowness not registered")
+	}
+	g := &game.Game{PlayerHP: 10, PlayerMax: 10}
+	g.AddEffect("haste", 10)
+	msgs := slowness(g, &game.Item{Def: &content.ItemDef{Name: "potion of slowing", Power: 20}})
+	if g.HasEffect("haste") {
+		t.Error("a potion of slowing cancels haste (C potions.c)")
+	}
+	if !g.HasEffect("slow") {
+		t.Error("expected a slow effect from the potion of slowing")
+	}
+	if len(msgs) == 0 || msgs[0] != "You feel very sluggish." {
+		t.Errorf("expected the C message, got %v", msgs)
+	}
+}

--- a/go/internal/game/effects.go
+++ b/go/internal/game/effects.go
@@ -72,6 +72,17 @@ func (g *Game) AddEffect(kind string, turns int) {
 	g.Effects = addEffect(g.Effects, kind, turns)
 }
 
+// RemoveEffect drops an active player effect by kind (the C's effect_expire,
+// e.g. a potion of speed cancelling slow); an absent kind is a no-op.
+func (g *Game) RemoveEffect(kind string) {
+	for i, e := range g.Effects {
+		if e.Kind == kind {
+			g.Effects = append(g.Effects[:i], g.Effects[i+1:]...)
+			return
+		}
+	}
+}
+
 // tickCreatureEffects applies each of a creature's active effects (poison costs
 // it 1 HP), decrements and expires them, and resolves death through killCreature
 // when its HP reaches 0. It reports whether the creature died this tick.

--- a/go/internal/game/effects_test.go
+++ b/go/internal/game/effects_test.go
@@ -117,3 +117,20 @@ func TestCreatureAddEffectRefreshesToLonger(t *testing.T) {
 		t.Errorf("shorter refresh should not shorten, got %d", m.Effects[0].Turns)
 	}
 }
+
+func TestRemoveEffectDropsOnlyNamedKind(t *testing.T) {
+	g := &Game{}
+	g.AddEffect("slow", 10)
+	g.AddEffect("poison", 5)
+	g.RemoveEffect("slow")
+	if g.HasEffect("slow") {
+		t.Error("slow should be gone after RemoveEffect")
+	}
+	if !g.HasEffect("poison") {
+		t.Error("poison should be untouched by removing slow")
+	}
+	g.RemoveEffect("haste") // absent kind: a no-op
+	if len(g.Effects) != 1 {
+		t.Errorf("expected 1 effect left, got %v", g.Effects)
+	}
+}


### PR DESCRIPTION
## Summary
The content half of the turn-energy arc (plan 16b, on top of #54). Both potions are in 0.40's `item_table_potion` spawn table (`treasure.c` cases 4–5):

- **Potion of speed** (`potions.c treasure_p_speed`): cancels an active slow, grants **haste for 20 turns** (C `HASTE_LENGTH`) — periodic free player actions under the new scheduler. "You move faster!"
- **Potion of slowing** (`treasure_p_slowing`): cancels an active haste, **slow for 20 turns** (C `SLOW_LENGTH`) — monsters act twice between your steps. "You feel very sluggish."
- New engine hook `Game.RemoveEffect(kind)` — the C's `effect_expire` for the cancel-the-opposite rule.
- Data-only beyond that: two TOML potions (no `nospawn`), so they join floor loot and the random-appearance shuffle like every 0.40 potion; quaffing identifies the type.

## Test plan
- `RemoveEffect` drops only the named effect; absent kind is a no-op.
- `haste` behavior applies haste and cancels slow; `slowness` applies slow and cancels haste; both return the C messages.
- Golden data test: both defs load with kind/use/power 20.
- gofmt + go vet + full `go test ./...` green (10/10 packages).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added potions of speed and slowing to the game
  * Potions of speed grant 20 turns of haste, enabling faster movement
  * Potions of slowing grant 20 turns of slowness, reducing movement speed
  * Speed and slowing effects now counteract each other when applied

<!-- end of auto-generated comment: release notes by coderabbit.ai -->