### PR TITLE
Potion of sleep

### DIFF
--- a/docs/superpowers/plans/2026-06-10-potion-sleep-16c.md
+++ b/docs/superpowers/plans/2026-06-10-potion-sleep-16c.md
@@ -1,0 +1,59 @@
+# Potion of sleep (16c) Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** The **potion of sleep** (0.40 `item_table_potion` case 8) and the
+`sleep` status effect — the third class unlocked by the 16a scheduler: a
+sleeping creature simply doesn't get its turns. Advances #15.
+
+## C grounding
+- `potions.c treasure_p_sleep` → `tranquilize()` (`sleep.c`): apply
+  `effect_sleep` for `SLEEP_DURATION` (25, `rules.h:126`); "You fall asleep!";
+  always identifies for the player.
+- `game.c:178-191`: when a sleeping creature's turn comes up, the turn is
+  skipped (ttl decrements); at the end it wakes — "You wake up!" /
+  "wakes up.".
+- `combat.c:479`: being attacked wakes the defender (`creature_sleep(d, false)`).
+- While the player sleeps, the C main loop keeps running without prompting —
+  the world advances around the sleeper; `pass_time_on_effects`/`energy()`
+  still run each of the sleeper's turns (poison ticks, EP regens).
+
+## Design
+- Effect kind `sleep` (HUD "Asleep").
+- **Player:** split `advanceWorld()` into `passTurn()` (the existing body) plus
+  a wrapper loop: `passTurn(); for HasEffect("sleep") && !Dead { passTurn() }`.
+  Any sleep source — this potion, future traps — immediately runs the slept
+  turns with no player action, exactly the C pacing. TTL burns via
+  `tickEffects` (≤ Power iterations); on natural expiry tickEffects logs
+  "You wake up!".
+- **Wake on damage:** `HurtPlayer` (melee + ranged both funnel through it):
+  if the player survives and is asleep, `RemoveEffect("sleep")` + "You wake
+  up!" — exits the sleep loop early.
+- **Monsters:** `monsterAct` holds while `sleep` is active (like blind's hold);
+  `playerAttacks` wakes a sleeping target via a new `Creature.RemoveEffect`.
+- **Behavior `tranquilize`** (the C's name): `AddEffect("sleep", Power)`,
+  "You fall asleep!". Data: `potion_sleep`, use `tranquilize`, power 25.
+  PlayerUse already identifies on quaff (C: always identifies).
+- Out of scope: monster-targeted sleep (wands/throwing), spawn-asleep AI,
+  `attr_p_sleep` immunity — none needed for the potion.
+
+## Task 1: sleep effect + scheduler loop + wake rules (TDD)
+**Files:** `internal/game/{effects,combat,creature}.go` + tests.
+- Tests first: one player action while asleep(3) passes 3 extra world ticks
+  (rat closes 4 tiles total) and ends with "You wake up!"; a monster's hit
+  wakes the sleeping player early; a sleeping monster doesn't attack from
+  adjacency; hitting a sleeping monster removes its sleep.
+- Commit: `feat(game): sleep status effect (turn-skipping + wake-on-damage)`
+
+## Task 2: behavior + data + ship
+**Files:** `internal/behaviors/behaviors.go` + test, `data/items.toml`,
+`data/data_test.go`.
+- Tests first: `tranquilize` applies sleep for Power turns with the C message;
+  `potion_sleep` loads (potion / tranquilize / 25).
+- Commit: `feat(content): potion of sleep`
+- Full gate; push, PR, CodeRabbit loop → merge.
+
+## Done when
+Quaffing the wrong unidentified potion knocks you out for 25 turns while the
+dungeon keeps moving — unless something hits you awake first. Sleeping monsters
+hold until struck. Suite green.

--- a/go/data/data_test.go
+++ b/go/data/data_test.go
@@ -559,3 +559,15 @@ func TestEmbeddedSpeedPotions(t *testing.T) {
 		t.Errorf("potion_slowing def unexpected: %+v", p)
 	}
 }
+
+// TestEmbeddedSleepPotion checks the knockout potion loaded (16c): 25 turns,
+// the C SLEEP_DURATION.
+func TestEmbeddedSleepPotion(t *testing.T) {
+	c, err := content.Load(Files)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if p := c.Items["potion_sleep"]; p == nil || p.Kind != "potion" || p.Use != "tranquilize" || p.Power != 25 {
+		t.Errorf("potion_sleep def unexpected: %+v", p)
+	}
+}

--- a/go/data/items.toml
+++ b/go/data/items.toml
@@ -192,6 +192,16 @@ kind = "potion"
 use = "slowness"
 power = 20
 
+# Knockout potion (16c): 25 lost turns (C rules.h SLEEP_DURATION) unless
+# something hits you awake first.
+[item.potion_sleep]
+name = "potion of sleep"
+glyph = "!"
+color = "cyan"
+kind = "potion"
+use = "tranquilize"
+power = 25
+
 # Potion of energy — refills spell EP (power = EP restored). Closes the cast loop.
 [item.potion_energy]
 name = "potion of energy"

--- a/go/internal/behaviors/behaviors.go
+++ b/go/internal/behaviors/behaviors.go
@@ -30,7 +30,15 @@ func Registry() map[string]game.Behavior {
 		"restore_energy":  restoreEnergy,
 		"haste":           haste,
 		"slowness":        slowness,
+		"tranquilize":     tranquilize,
 	}
+}
+
+// tranquilize knocks the player out for Power turns (C sleep.c tranquilize via
+// potions.c treasure_p_sleep); the slept turns play out in advanceWorld.
+func tranquilize(g *game.Game, it *game.Item) []string {
+	g.AddEffect("sleep", it.Def.Power)
+	return []string{"You fall asleep!"}
 }
 
 // haste speeds the player up for Power turns, cancelling an active slow

--- a/go/internal/behaviors/behaviors_test.go
+++ b/go/internal/behaviors/behaviors_test.go
@@ -286,3 +286,18 @@ func TestSlownessCancelsHasteAndSlows(t *testing.T) {
 		t.Errorf("expected the C message, got %v", msgs)
 	}
 }
+
+func TestTranquilizePutsPlayerToSleep(t *testing.T) {
+	tranq, ok := Registry()["tranquilize"]
+	if !ok {
+		t.Fatal("tranquilize not registered")
+	}
+	g := &game.Game{PlayerHP: 10, PlayerMax: 10}
+	msgs := tranq(g, &game.Item{Def: &content.ItemDef{Name: "potion of sleep", Power: 25}})
+	if !g.HasEffect("sleep") {
+		t.Error("expected a sleep effect from the potion of sleep")
+	}
+	if len(msgs) == 0 || msgs[0] != "You fall asleep!" {
+		t.Errorf("expected the C message, got %v", msgs)
+	}
+}

--- a/go/internal/game/combat.go
+++ b/go/internal/game/combat.go
@@ -118,6 +118,7 @@ func (g *Game) playerDodgeStat() int {
 }
 
 func (g *Game) playerAttacks(m *Creature) {
+	m.RemoveEffect("sleep") // being attacked wakes a sleeper (C combat.c)
 	if !g.RNG.Chance(g.playerAttackStat(), m.Def.Dodge) {
 		g.log("You miss the %s.", m.Def.Name)
 		return
@@ -207,17 +208,34 @@ func (g *Game) HurtPlayer(dmg int, cause string) {
 		g.Dead = true
 		g.DeathCause = cause
 		g.log("You die.")
+		return
+	}
+	if g.HasEffect("sleep") { // pain cuts sleep short (C combat.c wakes the defender)
+		g.RemoveEffect("sleep")
+		g.log("You wake up!")
 	}
 }
 
-// advanceWorld passes the player's turn. The per-turn bookkeeping (effect
+// advanceWorld passes the player's turn — and, while the player is asleep,
+// keeps passing turns with no player action, the way the C main loop skips a
+// sleeping creature's turns without prompting (game.c effect_sleep). Sleep
+// ends by tickEffects expiry or by being hit awake (HurtPlayer), so the loop
+// is bounded by the effect's duration.
+func (g *Game) advanceWorld() {
+	g.passTurn()
+	for g.HasEffect("sleep") && !g.Dead {
+		g.passTurn()
+	}
+}
+
+// passTurn is a single player turn. The per-turn bookkeeping (effect
 // clocks, EP regen) runs once — in the C these happen per creature-turn, not
 // per tick (game.c pass_time_on_effects/energy) — then the player pays for the
 // action and the world ticks until the player has banked the next turn.
 // playerEnergy holds the player's surplus beyond the turn just taken (the C's
 // move_counter minus TURN_TIME), so at base speed exactly one tick passes; a
 // slowed player owes two, and a hasted player sometimes none (a free action).
-func (g *Game) advanceWorld() {
+func (g *Game) passTurn() {
 	g.tickEffects()
 	if g.Dead {
 		return // status effects (e.g. poison) killed the player
@@ -275,6 +293,9 @@ func (g *Game) worldTick() {
 // monsterAct is a single monster action: attack the player if adjacent, else
 // step toward the player if within sense range.
 func (g *Game) monsterAct(m *Creature) {
+	if m.HasEffect("sleep") {
+		return // asleep: it loses the turn outright (C game.c effect_sleep skip)
+	}
 	if m.HasEffect("confuse") {
 		g.stepRandom(m) // disoriented: it lurches at random and can't press an attack
 		return

--- a/go/internal/game/combat.go
+++ b/go/internal/game/combat.go
@@ -118,11 +118,11 @@ func (g *Game) playerDodgeStat() int {
 }
 
 func (g *Game) playerAttacks(m *Creature) {
-	m.RemoveEffect("sleep") // being attacked wakes a sleeper (C combat.c)
 	if !g.RNG.Chance(g.playerAttackStat(), m.Def.Dodge) {
 		g.log("You miss the %s.", m.Def.Name)
 		return
 	}
+	m.RemoveEffect("sleep") // a landed hit wakes a sleeper; a whiff doesn't (C combat.c)
 	dmg := g.RNG.RollSpec(g.playerDamageSpec())
 	m.HP -= dmg
 	g.log("You hit the %s for %d.", m.Def.Name, dmg)

--- a/go/internal/game/creature.go
+++ b/go/internal/game/creature.go
@@ -27,6 +27,17 @@ func (m *Creature) AddEffect(kind string, turns int) {
 	m.Effects = addEffect(m.Effects, kind, turns)
 }
 
+// RemoveEffect drops an active effect by kind (e.g. a struck sleeper waking);
+// an absent kind is a no-op.
+func (m *Creature) RemoveEffect(kind string) {
+	for i, e := range m.Effects {
+		if e.Kind == kind {
+			m.Effects = append(m.Effects[:i], m.Effects[i+1:]...)
+			return
+		}
+	}
+}
+
 // HasEffect reports whether a timed effect of the given kind is currently active
 // on the creature.
 func (m *Creature) HasEffect(kind string) bool {

--- a/go/internal/game/effects.go
+++ b/go/internal/game/effects.go
@@ -17,6 +17,7 @@ var effectLabels = map[string]string{
 	"blind":   "Blinded",
 	"confuse": "Confused",
 	"fear":    "Afraid",
+	"sleep":   "Asleep",
 }
 
 // HasEffect reports whether a timed effect of the given kind is active on the
@@ -127,6 +128,8 @@ func (g *Game) tickEffects() {
 		e.Turns--
 		if e.Turns > 0 {
 			kept = append(kept, e)
+		} else if e.Kind == "sleep" {
+			g.log("You wake up!") // sleep ran its course (C creature_sleep)
 		}
 	}
 	g.Effects = kept

--- a/go/internal/game/sleep_test.go
+++ b/go/internal/game/sleep_test.go
@@ -1,0 +1,71 @@
+package game
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/c0ze/tsl/internal/content"
+)
+
+func hasMessage(g *Game, want string) bool {
+	for _, m := range g.Messages {
+		if strings.Contains(m, want) {
+			return true
+		}
+	}
+	return false
+}
+
+func TestSleepingPlayerLosesTurns(t *testing.T) {
+	g, rat := schedulerGame()
+	g.AddEffect("sleep", 3)
+	g.advanceWorld() // the turn sleep took hold; the slept turns run right after
+	if rat.Pos.X != 5 {
+		t.Errorf("three turns pass while the player sleeps: rat should be at x=5, got x=%d", rat.Pos.X)
+	}
+	if g.HasEffect("sleep") {
+		t.Error("sleep should have run its course")
+	}
+	if !hasMessage(g, "You wake up!") {
+		t.Errorf("expected the C wake message, got %v", g.Messages)
+	}
+}
+
+func TestDamageWakesSleepingPlayer(t *testing.T) {
+	g := combatGame()
+	ogre := &Creature{Def: &content.MonsterDef{ID: "ogre", Name: "ogre", Glyph: "O", HP: 99, Attack: 1000, Dodge: 0, Damage: "1d2"}, Pos: Pos{2, 1}, HP: 99}
+	g.Level.Creatures = append(g.Level.Creatures, ogre)
+	g.AddEffect("sleep", 25)
+	g.advanceWorld()
+	if g.HasEffect("sleep") {
+		t.Error("the ogre's blow should have woken the player long before 25 turns")
+	}
+	if g.PlayerHP >= 20 {
+		t.Errorf("the player should have been hit awake, HP still %d", g.PlayerHP)
+	}
+	if g.PlayerHP < 18 {
+		t.Errorf("waking on the first hit should cost at most one 1d2 swing, HP %d", g.PlayerHP)
+	}
+	if !hasMessage(g, "You wake up!") {
+		t.Errorf("expected the C wake message, got %v", g.Messages)
+	}
+}
+
+func TestSleepingMonsterHoldsUntilStruck(t *testing.T) {
+	g := combatGame()
+	rat := &Creature{Def: &content.MonsterDef{ID: "rat", Name: "rat", Glyph: "r", HP: 9, Attack: 1000, Dodge: 0, Damage: "5d6"}, Pos: Pos{2, 1}, HP: 9}
+	g.Level.Creatures = append(g.Level.Creatures, rat)
+	rat.AddEffect("sleep", 50)
+	hp := g.PlayerHP
+	g.worldTick()
+	if g.PlayerHP != hp {
+		t.Error("a sleeping monster must not attack")
+	}
+	if rat.Pos != (Pos{2, 1}) {
+		t.Error("a sleeping monster must not move")
+	}
+	g.PlayerStep(DirE) // strike it: the hit (or even a miss beside it) wakes it
+	if !g.Dead && rat.HP < 9 && rat.HasEffect("sleep") {
+		t.Error("a struck monster should wake (sleep effect removed)")
+	}
+}

--- a/go/internal/game/sleep_test.go
+++ b/go/internal/game/sleep_test.go
@@ -64,8 +64,22 @@ func TestSleepingMonsterHoldsUntilStruck(t *testing.T) {
 	if rat.Pos != (Pos{2, 1}) {
 		t.Error("a sleeping monster must not move")
 	}
-	g.PlayerStep(DirE) // strike it: the hit (or even a miss beside it) wakes it
+	g.PlayerStep(DirE) // strike it: a landed hit wakes it
 	if !g.Dead && rat.HP < 9 && rat.HasEffect("sleep") {
 		t.Error("a struck monster should wake (sleep effect removed)")
+	}
+}
+
+func TestMissedSwingDoesNotWakeMonster(t *testing.T) {
+	g := combatGame()
+	// Dodge so high the player's swing is all but guaranteed to whiff; the C
+	// wakes the sleeper only after a hit lands ("we *hit* before the enemy
+	// wakes up", combat.c).
+	rat := &Creature{Def: &content.MonsterDef{ID: "rat", Name: "rat", Glyph: "r", HP: 9, Attack: 0, Dodge: 100000, Damage: "1d1"}, Pos: Pos{2, 1}, HP: 9}
+	g.Level.Creatures = append(g.Level.Creatures, rat)
+	rat.AddEffect("sleep", 50)
+	g.PlayerStep(DirE)
+	if rat.HP == 9 && !rat.HasEffect("sleep") {
+		t.Error("a missed swing must not wake a sleeping monster (C combat.c)")
 	}
 }


### PR DESCRIPTION
## Summary
Plan 16c — the third consumable class unlocked by the turn-energy scheduler (#54): **sleep**, a creature simply losing its turns. All grounded in the C:

- **`sleep` status effect**: while the player is asleep, `advanceWorld` keeps passing turns with no player action — the C main loop's `effect_sleep` skip (`game.c:178-191`), so the dungeon moves around the sleeper at full pace (effect clocks and EP regen still run each slept turn, as in the C). Natural expiry logs "You wake up!" (`sleep.c creature_sleep`).
- **Wake on damage**: a surviving player who takes a hit is shaken awake (`combat.c:479`), exiting the sleep loop early. Symmetrically, a sleeping monster holds (loses its turns) until the player strikes it — `playerAttacks` wakes it via a new `Creature.RemoveEffect`.
- **Potion of sleep** (0.40 `item_table_potion` case 8, `potions.c treasure_p_sleep` → `tranquilize()`): 25 turns (C `SLEEP_DURATION`), "You fall asleep!", quaffing identifies. Joins floor loot + the appearance shuffle.
- Out of scope (noted in the plan): monster-targeted sleep delivery, spawn-asleep AI, `attr_p_sleep` immunity.

## Test plan
- Sleeping player with sleep(3): one engine call passes 3 world ticks (rat closes 3 tiles), ends awake with the C message.
- An adjacent ogre hits the 25-turn sleeper awake on the first blow (HP −1d2, effect gone, message logged).
- A sleeping monster neither moves nor attacks; striking it removes its sleep.
- `tranquilize` behavior + golden data test (potion/tranquilize/25).
- gofmt + go vet + full `go test ./...` green (10/10 packages).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Potion of Sleep that applies a sleep status effect; sleepers skip turns until it ends.
  * Monsters also can be asleep and lose their turns; attacking a sleeping monster wakes it.

* **Behavior**
  * Players wake immediately if they take damage; wake message shown when sleep ends or is interrupted.

* **Tests**
  * Added tests covering potion properties, tranquilize behavior, turn-skipping, wake-on-damage, and wake-on-attack.

* **Documentation**
  * Added implementation plan and acceptance criteria for the sleep feature.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->