### PR TITLE
Water & drowning (swimming arc 1/3)

### DIFF
--- a/docs/superpowers/plans/2026-06-10-water-drowning-18a.md
+++ b/docs/superpowers/plans/2026-06-10-water-drowning-18a.md
@@ -1,0 +1,63 @@
+# Water & drowning (18a) Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** First PR of the swimming arc (`swimming.c`): **water pools** as
+terrain plus the **drowning** rules for the player. In 0.40 water is
+*impassable on foot* — `creature.c move_creature` only admits `free_swim`/
+`permaswim` creatures, floaters, the **blinded** (a stumble), or forced pushes —
+so this PR ships the terrain, the blind-stumble entry, and the swim-fatigue/
+drowning clock. Later PRs: potion of levitation (float over water/lava, the
+player's real way in; 0.40 potion table case 7), then the Lurker pool
+encounter. Advances #18.
+
+## C grounding
+- `tiles.c:37`: water is `walkable=false`, `opaque=false`; glyph `_` plain
+  (`glyph.c:56 set_glyph(gent_water,'_',A_NORMAL)`).
+- `creature.c move_creature`: a blinded creature may blunder into water; a
+  sighted walker simply can't step in. Stepping from water back onto floor is
+  a normal walk.
+- `swimming.c swim()` (run right after each creature's turn, `game.c`):
+  on water `swim_fatigue++`; when `fatigue > attr_swimming` (player base 0)
+  take 1 damage; on dry land fatigue resets to 0. Player death: "You drown..."
+  (morgue cause "drowned").
+- Pools: `level->water` pools per level (`places.c`: the Dungeon `rnd%2`,
+  worm-cave levels `3+rnd%3`, the Lurker level `5+rnd%5`), each an
+  `area_cloud` blob of `5+rnd%20` tiles carved out of floor (`content.c:250`).
+- Out of scope here: monster drowning/free-swim (no monster can enter water
+  yet — pursuit only walks passable tiles), levitation, pushes, item
+  destruction in water (nothing can drop there yet), lava.
+
+## Design
+- `TileDef.Water bool` (`water = true` in tiles.toml on a new `water` tile,
+  passable=false so existing movement/AI treat it as a wall by default).
+- **Blind stumble:** `PlayerStep` — when the destination tile is water and the
+  player is blind, enter it (costs the turn); sighted bumps stay no-ops.
+- **Swim clock:** `Game.swimFatigue int`. In `passTurn` (the C runs `swim()`
+  per creature-turn): standing on water → `swimFatigue++`, and past the
+  player's swimming skill (0, attr-less for now) lose 1 HP — death is
+  `DeathCause` "drowned" with "You drown...". On land the counter resets.
+- **Pools in gen:** per-level pool count range in levels.toml (dungeon 0–1
+  like the C Dungeon; deeper levels 3–5), carved as random blobs of 5–24
+  floor tiles turned to water.
+
+## Task 1: water tile + stumble + drowning (TDD)
+**Files:** `data/tiles.toml`, `internal/content` (Water flag),
+`internal/game/{game,combat}.go`, new `internal/game/swim_test.go`.
+- Tests first: sighted step into water is a no-turn bump; blind step enters;
+  each turn standing in water costs 1 HP; wading out resets the clock (no
+  damage after re-land); drowning at 0 HP sets cause "drowned" and logs
+  "You drown...".
+- Commit: `feat(game): water tiles, blind stumble-in, swim fatigue + drowning`
+
+## Task 2: pools in level gen + ship
+**Files:** `data/levels.toml`, `internal/content` (pool range),
+`internal/gen` + tests.
+- Tests first: a level configured with pools generates water tiles in a
+  connected blob within the configured size band; a zero-pool level has none.
+- Commit: `feat(gen): water pools carved per level (C add_pools)`
+- Full gate; push, PR, CodeRabbit loop → merge.
+
+## Done when
+Deep levels grow dark pools of `_` that block your path; blunder in blind and
+each turn under water bleeds 1 HP until you wade out — or drown. Suite green.

--- a/go/data/data_test.go
+++ b/go/data/data_test.go
@@ -585,6 +585,9 @@ func TestEmbeddedWaterLevels(t *testing.T) {
 	if l := c.Levels["dungeon"]; l == nil || l.Water != 1 {
 		t.Errorf("dungeon should have 1 water pool, got %+v", l)
 	}
+	if l := c.Levels["underpass"]; l == nil || l.Water != 3 {
+		t.Errorf("underpass should have 3 water pools, got %+v", l)
+	}
 	if l := c.Levels["drowned_city"]; l == nil || l.Water != 4 {
 		t.Errorf("drowned_city should have 4 water pools, got %+v", l)
 	}

--- a/go/data/data_test.go
+++ b/go/data/data_test.go
@@ -571,3 +571,21 @@ func TestEmbeddedSleepPotion(t *testing.T) {
 		t.Errorf("potion_sleep def unexpected: %+v", p)
 	}
 }
+
+// TestEmbeddedWaterLevels checks the water tile + per-level pool counts loaded
+// (18a): the Dungeon dips a toe, the Drowned City earns its name.
+func TestEmbeddedWaterLevels(t *testing.T) {
+	c, err := content.Load(Files)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if w := c.Tiles["water"]; w == nil || !w.Water || w.Passable || !w.Transparent {
+		t.Errorf("water tile def unexpected: %+v", w)
+	}
+	if l := c.Levels["dungeon"]; l == nil || l.Water != 1 {
+		t.Errorf("dungeon should have 1 water pool, got %+v", l)
+	}
+	if l := c.Levels["drowned_city"]; l == nil || l.Water != 4 {
+		t.Errorf("drowned_city should have 4 water pools, got %+v", l)
+	}
+}

--- a/go/data/levels.toml
+++ b/go/data/levels.toml
@@ -12,6 +12,7 @@ height = 24
 start = true
 links = ["catacombs", "ominous_cave"]
 monsters = 8
+water = 1
 [[level.dungeon.spawn]]
 monster = "ratman"
 weight = 3
@@ -167,6 +168,7 @@ height = 24
 links = ["ominous_cave", "drowned_city"]
 monsters = 10
 dark = true
+water = 3
 [[level.underpass.spawn]]
 monster = "ratman"
 weight = 2
@@ -195,6 +197,7 @@ width = 60
 height = 24
 links = ["laboratory", "dragons_lair", "underpass"]
 monsters = 12
+water = 4
 [[level.drowned_city.spawn]]
 monster = "merman"
 weight = 4

--- a/go/data/tiles.toml
+++ b/go/data/tiles.toml
@@ -49,3 +49,12 @@ glyph = "'"
 color = "brown"
 passable = true
 transparent = true
+
+# Deep water (#18, C tiles.c): impassable on foot — only the blinded stumble in
+# (later: levitation floats over) — and each turn spent in it drains the wader.
+[tile.water]
+glyph = "_"
+color = "blue"
+passable = false
+transparent = true
+water = true

--- a/go/internal/content/content.go
+++ b/go/internal/content/content.go
@@ -122,6 +122,7 @@ type LevelDef struct {
 	Altar    bool         `toml:"altar"` // place an ascension altar (a win tile)
 	Boss     string       `toml:"boss"`  // a guaranteed monster placed once on the level
 	Traps    int          `toml:"traps"` // number of dart_trap tiles to scatter
+	Water    int          `toml:"water"` // number of water pools to carve (C level->water)
 	Doors    bool         `toml:"doors"` // place closed doors in room doorways
 	Dark     bool         `toml:"dark"`  // unlit level: the player sees only a small radius
 }

--- a/go/internal/content/content.go
+++ b/go/internal/content/content.go
@@ -39,6 +39,7 @@ type TileDef struct {
 	Passable    bool   `toml:"passable"`
 	Transparent bool   `toml:"transparent"`
 	Win         bool   `toml:"win"`          // stepping onto this tile wins (the ascension altar)
+	Water       bool   `toml:"water"`        // deep water: impassable on foot, drowns waders (#18)
 	Effect      string `toml:"effect"`       // status effect applied when stepped on ("" = none)
 	EffectTurns int    `toml:"effect_turns"` // duration of Effect
 	OpensTo     string `toml:"opens_to"`     // tile id this becomes when opened ("" = not a door)

--- a/go/internal/content/content.go
+++ b/go/internal/content/content.go
@@ -308,6 +308,14 @@ func validateLevels(c *Content) error {
 				return fmt.Errorf("level %q: traps set but no dart_trap effect tile is defined", id)
 			}
 		}
+		if l.Water < 0 {
+			return fmt.Errorf("level %q: water must be >= 0, got %d", id, l.Water)
+		}
+		if l.Water > 0 {
+			if t, ok := c.Tiles["water"]; !ok || !t.Water {
+				return fmt.Errorf("level %q: water pools set but no water tile is defined", id)
+			}
+		}
 	}
 	if starts != 1 {
 		return fmt.Errorf("levels: need exactly one start level, found %d", starts)

--- a/go/internal/game/combat.go
+++ b/go/internal/game/combat.go
@@ -75,6 +75,11 @@ func (g *Game) PlayerStep(d Direction) {
 	} else if g.openDoor(dst) { // blocked by a closed door: open it (costs the turn)
 		g.log("You open the door.")
 		acted = true
+	} else if g.Level.InBounds(dst) && g.Level.At(dst).Def.Water && g.HasEffect("blind") {
+		// Deep water turns away a sighted walker, but the blinded blunder
+		// straight in (C move_creature).
+		g.Player = dst
+		acted = true
 	}
 	if acted { // a blocked move into a wall doesn't pass the turn
 		g.advanceWorld()
@@ -236,6 +241,10 @@ func (g *Game) advanceWorld() {
 // move_counter minus TURN_TIME), so at base speed exactly one tick passes; a
 // slowed player owes two, and a hasted player sometimes none (a free action).
 func (g *Game) passTurn() {
+	g.swimCheck()
+	if g.Dead {
+		return // drowned
+	}
 	g.tickEffects()
 	if g.Dead {
 		return // status effects (e.g. poison) killed the player
@@ -248,6 +257,32 @@ func (g *Game) passTurn() {
 		if g.Dead {
 			return
 		}
+	}
+}
+
+// playerSwimming is the player's swimming skill — how many turns of deep water
+// are free before fatigue bites (C attr_swimming, base 0; gear may raise it
+// when the attribute lands).
+const playerSwimming = 0
+
+// swimCheck is the C's swim() for the player, run right after each turn's
+// action: a turn spent in deep water adds fatigue, and past the swimming skill
+// each turn costs 1 HP until the swimmer drowns; dry land resets the count.
+func (g *Game) swimCheck() {
+	if !g.Level.At(g.Player).Def.Water {
+		g.swimFatigue = 0
+		return
+	}
+	g.swimFatigue++
+	if g.swimFatigue <= playerSwimming {
+		return
+	}
+	g.PlayerHP--
+	if g.PlayerHP <= 0 {
+		g.PlayerHP = 0
+		g.Dead = true
+		g.DeathCause = "drowned"
+		g.log("You drown...")
 	}
 }
 

--- a/go/internal/game/combat.go
+++ b/go/internal/game/combat.go
@@ -281,7 +281,7 @@ func (g *Game) swimCheck() {
 	if g.PlayerHP <= 0 {
 		g.PlayerHP = 0
 		g.Dead = true
-		g.DeathCause = "drowned"
+		g.DeathCause = "drowning"
 		g.log("You drown...")
 	}
 }

--- a/go/internal/game/game.go
+++ b/go/internal/game/game.go
@@ -100,6 +100,7 @@ type Game struct {
 	EPMax        int
 	epTurn       int // counter for slow EP regeneration
 	playerEnergy int // turn-energy surplus banked toward the next action (see advanceWorld)
+	swimFatigue  int // consecutive turns spent in deep water (see swimCheck)
 	Messages     []string
 	Dead         bool
 	Inventory    []*Item

--- a/go/internal/game/swim_test.go
+++ b/go/internal/game/swim_test.go
@@ -65,8 +65,8 @@ func TestPlayerDrowns(t *testing.T) {
 	if !g.Dead {
 		t.Fatal("at 1 HP the first turn under water drowns the player")
 	}
-	if g.DeathCause != "drowned" {
-		t.Errorf("morgue cause should be %q, got %q", "drowned", g.DeathCause)
+	if g.DeathCause != "drowning" {
+		t.Errorf("morgue cause should be %q, got %q", "drowning", g.DeathCause)
 	}
 	if !hasMessage(g, "You drown...") {
 		t.Errorf("expected the C drowning message, got %v", g.Messages)

--- a/go/internal/game/swim_test.go
+++ b/go/internal/game/swim_test.go
@@ -1,0 +1,74 @@
+package game
+
+import (
+	"testing"
+
+	"github.com/c0ze/tsl/internal/content"
+)
+
+// waterGame is a corridor with a water tile directly east of the player.
+func waterGame() *Game {
+	g := combatGame()
+	water := &content.TileDef{ID: "water", Glyph: "_", Passable: false, Transparent: true, Water: true}
+	g.Level.Set(Pos{2, 1}, water)
+	return g
+}
+
+func TestSightedPlayerCannotWalkIntoWater(t *testing.T) {
+	g := waterGame()
+	g.PlayerStep(DirE)
+	if g.Player != (Pos{1, 1}) {
+		t.Errorf("a sighted walker can't enter water (C move_creature), player at %v", g.Player)
+	}
+}
+
+func TestBlindPlayerStumblesIntoWater(t *testing.T) {
+	g := waterGame()
+	g.AddEffect("blind", 10)
+	g.PlayerStep(DirE)
+	if g.Player != (Pos{2, 1}) {
+		t.Errorf("a blinded walker blunders into water (C move_creature), player at %v", g.Player)
+	}
+}
+
+func TestStandingInWaterDrains1HPPerTurn(t *testing.T) {
+	g := waterGame()
+	g.AddEffect("blind", 2) // long enough to stumble in, short enough to expire
+	g.PlayerStep(DirE)      // into the water; passTurn runs the first swim check
+	if g.PlayerHP != 19 {
+		t.Fatalf("first turn in water already exceeds swimming 0: want HP 19, got %d", g.PlayerHP)
+	}
+	g.advanceWorld() // treading water another turn
+	if g.PlayerHP != 18 {
+		t.Errorf("each turn under water costs 1 HP: want 18, got %d", g.PlayerHP)
+	}
+}
+
+func TestWadingOutResetsSwimFatigue(t *testing.T) {
+	g := waterGame()
+	g.AddEffect("blind", 2)
+	g.PlayerStep(DirE) // in: HP 19, fatigue 1
+	g.PlayerStep(DirW) // back onto floor: fatigue resets, no further damage
+	if g.PlayerHP != 19 {
+		t.Fatalf("dry land stops the drain: want HP 19, got %d", g.PlayerHP)
+	}
+	if g.swimFatigue != 0 {
+		t.Errorf("fatigue resets on land (C swim()), got %d", g.swimFatigue)
+	}
+}
+
+func TestPlayerDrowns(t *testing.T) {
+	g := waterGame()
+	g.PlayerHP = 1
+	g.AddEffect("blind", 10)
+	g.PlayerStep(DirE)
+	if !g.Dead {
+		t.Fatal("at 1 HP the first turn under water drowns the player")
+	}
+	if g.DeathCause != "drowned" {
+		t.Errorf("morgue cause should be %q, got %q", "drowned", g.DeathCause)
+	}
+	if !hasMessage(g, "You drown...") {
+		t.Errorf("expected the C drowning message, got %v", g.Messages)
+	}
+}

--- a/go/internal/gen/gen.go
+++ b/go/internal/gen/gen.go
@@ -222,10 +222,85 @@ func LevelFromDef(r *rng.MT, c *content.Content, def *content.LevelDef) (*game.L
 	}
 	placeSpawnMonsters(r, c, lvl, rooms, def)
 	placeItems(r, c, lvl, rooms, lvl.Start)
+	if def.Water > 0 {
+		if err := placePools(r, c, lvl, rooms, def.Water); err != nil {
+			return nil, err
+		}
+	}
 	if def.Traps > 0 {
 		placeTraps(r, c, lvl, rooms, def.Traps)
 	}
 	return lvl, nil
+}
+
+// placePools carves n water pools (the C add_pools/area_cloud: blobs of 5-24
+// tiles) into room floors. Water is impassable, so any pool that would cut the
+// start off from a portal is reverted — the C instead rejects whole unsolvable
+// levels; reverting one pool keeps generation deterministic and cheap.
+func placePools(r *rng.MT, c *content.Content, lvl *game.Level, rooms []rect, n int) error {
+	water := c.Tiles["water"]
+	if water == nil {
+		return fmt.Errorf("gen: level wants water pools but no \"water\" tile defined")
+	}
+	floor := c.Tiles["floor"]
+	for k := 0; k < n; k++ {
+		room := rooms[r.Intn(len(rooms))]
+		seed := game.Pos{X: room.x + r.Intn(room.w), Y: room.y + r.Intn(room.h)}
+		if !poolable(lvl, seed) {
+			continue
+		}
+		// Grow a cloud: each added tile is a random neighbour of the pool so far.
+		size := 5 + r.Intn(20)
+		pool := []game.Pos{seed}
+		lvl.Set(seed, water)
+		// Bounded tries: a pool hemmed in by walls simply stays small.
+		for tries := 0; len(pool) < size && tries < 200; tries++ {
+			from := pool[r.Intn(len(pool))]
+			next := game.Pos{X: from.X + r.Intn(3) - 1, Y: from.Y + r.Intn(3) - 1}
+			if !poolable(lvl, next) {
+				continue
+			}
+			lvl.Set(next, water)
+			pool = append(pool, next)
+		}
+		if cutsOff(lvl) {
+			for _, p := range pool {
+				lvl.Set(p, floor)
+			}
+		}
+	}
+	return nil
+}
+
+// poolable reports whether p is plain floor a pool may flood: never the start,
+// a portal, or any special tile.
+func poolable(lvl *game.Level, p game.Pos) bool {
+	return lvl.InBounds(p) && lvl.At(p).Def.ID == "floor" && p != lvl.Start && lvl.PortalAt(p) == nil
+}
+
+// cutsOff reports whether any portal is no longer walkable from the start.
+func cutsOff(lvl *game.Level) bool {
+	seen := map[game.Pos]bool{lvl.Start: true}
+	frontier := []game.Pos{lvl.Start}
+	for len(frontier) > 0 {
+		p := frontier[len(frontier)-1]
+		frontier = frontier[:len(frontier)-1]
+		for dy := -1; dy <= 1; dy++ {
+			for dx := -1; dx <= 1; dx++ {
+				q := game.Pos{X: p.X + dx, Y: p.Y + dy}
+				if !seen[q] && lvl.Passable(q) {
+					seen[q] = true
+					frontier = append(frontier, q)
+				}
+			}
+		}
+	}
+	for _, portal := range lvl.Portals {
+		if !seen[portal.Pos] {
+			return true
+		}
+	}
+	return false
 }
 
 // placeDoors converts each room's doorways — single-tile passages where a

--- a/go/internal/gen/gen_test.go
+++ b/go/internal/gen/gen_test.go
@@ -338,3 +338,73 @@ func TestRoomsPlacesMonsters(t *testing.T) {
 		}
 	}
 }
+
+// reachable floods passable tiles from start and reports whether goal is reached
+// (orthogonal+diagonal, matching player movement).
+func reachable(lvl *game.Level, start, goal game.Pos) bool {
+	seen := map[game.Pos]bool{start: true}
+	frontier := []game.Pos{start}
+	for len(frontier) > 0 {
+		p := frontier[len(frontier)-1]
+		frontier = frontier[:len(frontier)-1]
+		if p == goal {
+			return true
+		}
+		for dy := -1; dy <= 1; dy++ {
+			for dx := -1; dx <= 1; dx++ {
+				n := game.Pos{X: p.X + dx, Y: p.Y + dy}
+				if !seen[n] && lvl.Passable(n) {
+					seen[n] = true
+					frontier = append(frontier, n)
+				}
+			}
+		}
+	}
+	return false
+}
+
+func TestLevelFromDefCarvesWaterPools(t *testing.T) {
+	c := levelDefContent()
+	c.Tiles["water"] = &content.TileDef{ID: "water", Glyph: "_", Color: content.ColorBlue, Transparent: true, Water: true}
+	def := &content.LevelDef{ID: "x", Name: "X", W: 60, H: 24, Links: []string{"y"}, Water: 3}
+	for seed := uint32(1); seed <= 8; seed++ {
+		lvl, err := LevelFromDef(rng.NewWithSeed(seed), c, def)
+		if err != nil {
+			t.Fatal(err)
+		}
+		water := 0
+		for y := 0; y < lvl.H; y++ {
+			for x := 0; x < lvl.W; x++ {
+				if lvl.At(game.Pos{X: x, Y: y}).Def.Water {
+					water++
+				}
+			}
+		}
+		if water < 5 {
+			t.Errorf("seed %d: 3 pools of >=5 tiles each should leave some water, got %d tiles", seed, water)
+		}
+		// Pools must never wall off the stairs (the C validates solvability).
+		for _, p := range lvl.Portals {
+			if !reachable(lvl, lvl.Start, p.Pos) {
+				t.Errorf("seed %d: portal at %v unreachable after pool carving", seed, p.Pos)
+			}
+		}
+	}
+}
+
+func TestLevelFromDefNoWaterByDefault(t *testing.T) {
+	c := levelDefContent()
+	c.Tiles["water"] = &content.TileDef{ID: "water", Glyph: "_", Color: content.ColorBlue, Transparent: true, Water: true}
+	def := &content.LevelDef{ID: "x", Name: "X", W: 60, H: 24, Links: []string{"y"}}
+	lvl, err := LevelFromDef(rng.NewWithSeed(3), c, def)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for y := 0; y < lvl.H; y++ {
+		for x := 0; x < lvl.W; x++ {
+			if lvl.At(game.Pos{X: x, Y: y}).Def.Water {
+				t.Fatal("water=0 level must stay dry")
+			}
+		}
+	}
+}


### PR DESCRIPTION
## Summary
First PR of the swimming arc (plan 18a), porting `swimming.c` + the water rules of `creature.c`/`content.c`:

- **Water tile** (`_`, impassable, transparent — C `tiles.c`/`glyph.c`). Key 0.40 finding: water is *not walkable* — `move_creature` only admits free-swim/permaswim creatures, floaters, the **blinded**, or forced pushes. So a sighted bump is a no-turn wall-bump, while a blinded player blunders straight in.
- **Swim clock** (`swimming.c swim()`, run right after each player turn): each turn in deep water adds fatigue; past the swimming skill (base 0, like the C player) it costs 1 HP per turn; dry land resets; at 0 HP — "You drown...", morgue cause "drowned".
- **Pools in gen** (C `add_pools`/`area_cloud`): cloud blobs of 5–24 tiles on room floors; the Dungeon gets 1 (C `rnd%2`), the Underpass 3, the Drowned City 4. A pool that would cut the start off from any portal is reverted (the C validates whole-level solvability instead; reverting one pool is deterministic and cheap) — covered by an 8-seed connectivity test.
- Next in the arc: **potion of levitation** (float over water/lava, the player's real way across; 0.40 potion table case 7), then the **Lurker pool encounter** (lurker + 8 tentacles, free-swim monsters).

## Test plan
- Sighted step into water = blocked, no turn; blind step enters.
- 1 HP/turn drain in water; wading out resets the fatigue clock; drowning sets cause + C message.
- Gen: 8 seeds × 3 pools always leave ≥5 water tiles with all portals still reachable; water-free defs stay dry.
- Golden data test (water tile flags + per-level pool counts).
- gofmt + go vet + full `go test ./...` green (10/10 packages).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Deep water tiles added that block normal movement; blinded players may stumble into water.
  * Players accumulate swim fatigue, lose 1 HP per turn in deep water, and can drown.
  * Water pools generated on multiple dungeon areas including a drowned city.

* **Documentation**
  * Added design/implementation plan for the water & drowning arc.

* **Tests**
  * Added tests covering water placement, movement rules, swim fatigue, and drowning.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->