### PR TITLE
Potion of levitation (swimming arc 2/3)

### DIFF
--- a/docs/superpowers/plans/2026-06-10-potion-levitation-18b.md
+++ b/docs/superpowers/plans/2026-06-10-potion-levitation-18b.md
@@ -1,0 +1,52 @@
+# Potion of levitation (18b) Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Swimming arc 2/3: the **potion of levitation** (0.40
+`item_table_potion` case 7) — the player's legitimate way across the water of
+18a. Floating crosses deep water and skips floor traps; the danger is the
+clock: when it runs out you land on whatever is below. Advances #18 + #15.
+
+## C grounding
+- `potions.c treasure_p_levitation` → `levitate()`: float for `LEVITATE_TIME`
+  (20, `rules.h:129`); "You soar into the air!" (`altitude.c:58`).
+- `creature.c move_creature`: `is_floating` admits water (and lava) tiles.
+- `swimming.c swim()`: early-returns for floaters — no fatigue while airborne
+  (the counter freezes; it neither accrues nor resets).
+- `traps.c activate_trap:325`: floaters skip traps — except `trap_win`, so the
+  ascension altar still works mid-float.
+- `game.c decrement_levitation` → `altitude.c change_altitude` on expiry:
+  land in water → "You plunge into water!" (the swim clock takes over);
+  land on a trap → it springs; otherwise "You land on the ground.".
+
+## Design
+- Effect `levitate` (HUD "Floating"); behavior `levitate`:
+  `AddEffect("levitate", Power)` + the C soar message. Data:
+  `potion_levitation`, use `levitate`, power 20.
+- `PlayerStep`: the water-entry branch admits `blind` **or** `levitate`; the
+  trap branch (`tile.Effect`) is skipped while floating; `Win` still fires.
+- `swimCheck`: early return while floating (fatigue frozen, like the C).
+- Landing (`tickEffects`, on levitate expiry — like sleep's wake message):
+  on water → "You plunge into water!"; on an effect tile → "You land on the
+  ground." + the trap's effect; else the ground message.
+
+## Task 1: levitate effect + movement/trap/landing rules (TDD)
+**Files:** `internal/game/{combat,effects}.go`, `internal/game/swim_test.go`
+(extend).
+- Tests first: a floating player crosses water unharmed (no HP loss, full
+  pass); floating over a dart trap doesn't poison; expiry over water plunges
+  (message + drowning clock resumes next turn); expiry over a trap springs it;
+  expiry on floor logs the ground message.
+- Commit: `feat(game): levitation — float over water/traps, landing rules`
+
+## Task 2: behavior + data + ship
+**Files:** `internal/behaviors/behaviors.go` + test, `data/items.toml`,
+`data/data_test.go`.
+- Tests first: `levitate` behavior + golden data (potion/levitate/20).
+- Commit: `feat(content): potion of levitation`
+- Full gate; push, PR, CodeRabbit loop → merge.
+
+## Done when
+Quaff, soar, drift over the Drowned City's pools and the traps between — and
+time the crossing right, because landing in deep water starts the drowning
+clock. Suite green.

--- a/go/data/data_test.go
+++ b/go/data/data_test.go
@@ -592,3 +592,15 @@ func TestEmbeddedWaterLevels(t *testing.T) {
 		t.Errorf("drowned_city should have 4 water pools, got %+v", l)
 	}
 }
+
+// TestEmbeddedLevitationPotion checks the float potion loaded (18b): 20 turns,
+// the C LEVITATE_TIME.
+func TestEmbeddedLevitationPotion(t *testing.T) {
+	c, err := content.Load(Files)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if p := c.Items["potion_levitation"]; p == nil || p.Kind != "potion" || p.Use != "levitate" || p.Power != 20 {
+		t.Errorf("potion_levitation def unexpected: %+v", p)
+	}
+}

--- a/go/data/items.toml
+++ b/go/data/items.toml
@@ -192,6 +192,16 @@ kind = "potion"
 use = "slowness"
 power = 20
 
+# Float potion (18b): 20 turns airborne (C rules.h LEVITATE_TIME) — cross
+# water and skip traps, but mind where the clock runs out.
+[item.potion_levitation]
+name = "potion of levitation"
+glyph = "!"
+color = "green"
+kind = "potion"
+use = "levitate"
+power = 20
+
 # Knockout potion (16c): 25 lost turns (C rules.h SLEEP_DURATION) unless
 # something hits you awake first.
 [item.potion_sleep]

--- a/go/internal/behaviors/behaviors.go
+++ b/go/internal/behaviors/behaviors.go
@@ -31,7 +31,16 @@ func Registry() map[string]game.Behavior {
 		"haste":           haste,
 		"slowness":        slowness,
 		"tranquilize":     tranquilize,
+		"levitate":        levitate,
 	}
+}
+
+// levitate lifts the player off the ground for Power turns (C potions.c
+// treasure_p_levitation → altitude.c): water and floor traps pass harmlessly
+// below until the landing.
+func levitate(g *game.Game, it *game.Item) []string {
+	g.AddEffect("levitate", it.Def.Power)
+	return []string{"You soar into the air!"}
 }
 
 // tranquilize knocks the player out for Power turns (C sleep.c tranquilize via

--- a/go/internal/behaviors/behaviors_test.go
+++ b/go/internal/behaviors/behaviors_test.go
@@ -301,3 +301,18 @@ func TestTranquilizePutsPlayerToSleep(t *testing.T) {
 		t.Errorf("expected the C message, got %v", msgs)
 	}
 }
+
+func TestLevitatePotionLiftsPlayer(t *testing.T) {
+	lev, ok := Registry()["levitate"]
+	if !ok {
+		t.Fatal("levitate not registered")
+	}
+	g := &game.Game{PlayerHP: 10, PlayerMax: 10}
+	msgs := lev(g, &game.Item{Def: &content.ItemDef{Name: "potion of levitation", Power: 20}})
+	if !g.HasEffect("levitate") {
+		t.Error("expected a levitate effect from the potion")
+	}
+	if len(msgs) == 0 || msgs[0] != "You soar into the air!" {
+		t.Errorf("expected the C message, got %v", msgs)
+	}
+}

--- a/go/internal/game/combat.go
+++ b/go/internal/game/combat.go
@@ -68,16 +68,19 @@ func (g *Game) PlayerStep(d Direction) {
 			g.log("You ascend to demigodhood. You win!")
 			return // winning ends the turn immediately
 		}
-		if tile.Effect != "" {
+		if tile.Effect != "" && !g.HasEffect("levitate") {
+			// A floater glides over floor traps (C activate_trap); Win above
+			// already fired regardless, the C's trap_win exception.
 			g.AddEffect(tile.Effect, tile.EffectTurns)
 			g.log("You trigger a trap!")
 		}
 	} else if g.openDoor(dst) { // blocked by a closed door: open it (costs the turn)
 		g.log("You open the door.")
 		acted = true
-	} else if g.Level.InBounds(dst) && g.Level.At(dst).Def.Water && g.HasEffect("blind") {
-		// Deep water turns away a sighted walker, but the blinded blunder
-		// straight in (C move_creature).
+	} else if g.Level.InBounds(dst) && g.Level.At(dst).Def.Water &&
+		(g.HasEffect("blind") || g.HasEffect("levitate")) {
+		// Deep water turns away a sighted walker; the blinded blunder in and
+		// floaters drift across (C move_creature).
 		g.Player = dst
 		acted = true
 	}
@@ -269,6 +272,9 @@ const playerSwimming = 0
 // action: a turn spent in deep water adds fatigue, and past the swimming skill
 // each turn costs 1 HP until the swimmer drowns; dry land resets the count.
 func (g *Game) swimCheck() {
+	if g.HasEffect("levitate") {
+		return // airborne: the fatigue counter freezes (C swim() skips floaters)
+	}
 	if !g.Level.At(g.Player).Def.Water {
 		g.swimFatigue = 0
 		return

--- a/go/internal/game/effects.go
+++ b/go/internal/game/effects.go
@@ -10,14 +10,15 @@ type Effect struct {
 
 // effectLabels maps effect kinds to their HUD labels.
 var effectLabels = map[string]string{
-	"poison":  "Poisoned",
-	"regen":   "Regenerating",
-	"slow":    "Slowed",
-	"haste":   "Hastened",
-	"blind":   "Blinded",
-	"confuse": "Confused",
-	"fear":    "Afraid",
-	"sleep":   "Asleep",
+	"poison":   "Poisoned",
+	"regen":    "Regenerating",
+	"slow":     "Slowed",
+	"haste":    "Hastened",
+	"blind":    "Blinded",
+	"confuse":  "Confused",
+	"fear":     "Afraid",
+	"sleep":    "Asleep",
+	"levitate": "Floating",
 }
 
 // HasEffect reports whether a timed effect of the given kind is active on the
@@ -115,6 +116,7 @@ func (g *Game) tickEffects() {
 	if len(g.Effects) == 0 {
 		return
 	}
+	landed := false
 	kept := g.Effects[:0]
 	for _, e := range g.Effects {
 		switch e.Kind {
@@ -130,9 +132,14 @@ func (g *Game) tickEffects() {
 			kept = append(kept, e)
 		} else if e.Kind == "sleep" {
 			g.log("You wake up!") // sleep ran its course (C creature_sleep)
+		} else if e.Kind == "levitate" {
+			landed = true // resolved below, once the effects slice is settled
 		}
 	}
 	g.Effects = kept
+	if landed {
+		g.land()
+	}
 	// Resolve death once, after the net HP change of this turn, so a regen can
 	// offset poison instead of leaving Dead set while HP is still positive.
 	if g.PlayerHP <= 0 && !g.Dead {
@@ -140,6 +147,22 @@ func (g *Game) tickEffects() {
 		g.Dead = true
 		g.DeathCause = "poison"
 		g.log("The poison overcomes you. You die.")
+	}
+}
+
+// land resolves the end of levitation (C change_altitude): into deep water the
+// swim clock takes over; a trap below springs on touchdown; otherwise it's
+// just solid ground.
+func (g *Game) land() {
+	tile := g.Level.At(g.Player).Def
+	if tile.Water {
+		g.log("You plunge into water!")
+		return
+	}
+	g.log("You land on the ground.")
+	if tile.Effect != "" {
+		g.AddEffect(tile.Effect, tile.EffectTurns)
+		g.log("You trigger a trap!")
 	}
 }
 

--- a/go/internal/game/swim_test.go
+++ b/go/internal/game/swim_test.go
@@ -72,3 +72,66 @@ func TestPlayerDrowns(t *testing.T) {
 		t.Errorf("expected the C drowning message, got %v", g.Messages)
 	}
 }
+
+func TestFloatingPlayerCrossesWaterUnharmed(t *testing.T) {
+	g := waterGame()
+	g.AddEffect("levitate", 20)
+	g.PlayerStep(DirE) // onto the water, airborne
+	if g.Player != (Pos{2, 1}) {
+		t.Fatalf("a floating player crosses deep water (C move_creature), at %v", g.Player)
+	}
+	if g.PlayerHP != 20 {
+		t.Errorf("no swim fatigue while airborne (C swim() skips floaters): HP %d", g.PlayerHP)
+	}
+	g.PlayerStep(DirE) // and off the far side
+	if g.Player != (Pos{3, 1}) || g.PlayerHP != 20 {
+		t.Errorf("crossing should finish dry: at %v with HP %d", g.Player, g.PlayerHP)
+	}
+}
+
+func TestFloatingPlayerSkipsTraps(t *testing.T) {
+	g := combatGame()
+	trap := &content.TileDef{ID: "dart_trap", Glyph: "^", Passable: true, Transparent: true, Effect: "poison", EffectTurns: 5}
+	g.Level.Set(Pos{2, 1}, trap)
+	g.AddEffect("levitate", 20)
+	g.PlayerStep(DirE)
+	if g.HasEffect("poison") {
+		t.Error("a floater glides over floor traps (C activate_trap)")
+	}
+}
+
+func TestLandingInWaterPlunges(t *testing.T) {
+	g := waterGame()
+	g.AddEffect("levitate", 2) // expires right above the pool
+	g.PlayerStep(DirE)         // onto the water (levitate 2->1 this turn)
+	g.advanceWorld()           // levitate 1->0: the landing
+	if !hasMessage(g, "You plunge into water!") {
+		t.Fatalf("expected the C plunge message, got %v", g.Messages)
+	}
+	hp := g.PlayerHP
+	g.advanceWorld() // now swimming: the drowning clock runs
+	if g.PlayerHP != hp-1 {
+		t.Errorf("after plunging the swim clock resumes: want HP %d, got %d", hp-1, g.PlayerHP)
+	}
+}
+
+func TestLandingOnGround(t *testing.T) {
+	g := combatGame()
+	g.AddEffect("levitate", 1)
+	g.PlayerStep(DirE) // levitate expires over plain floor
+	if !hasMessage(g, "You land on the ground.") {
+		t.Errorf("expected the C ground message, got %v", g.Messages)
+	}
+}
+
+func TestLandingOnTrapSpringsIt(t *testing.T) {
+	g := combatGame()
+	trap := &content.TileDef{ID: "dart_trap", Glyph: "^", Passable: true, Transparent: true, Effect: "poison", EffectTurns: 5}
+	g.Level.Set(Pos{2, 1}, trap)
+	g.AddEffect("levitate", 2)
+	g.PlayerStep(DirE) // float onto the trap (no trigger; levitate 2->1)
+	g.advanceWorld()   // expiry: land right on it
+	if !g.HasEffect("poison") {
+		t.Error("landing on a trap springs it (C change_altitude)")
+	}
+}


### PR DESCRIPTION
## Summary
Plan 18b, building on #57: the **potion of levitation** (0.40 `item_table_potion` case 7) — the player's legitimate way across deep water, with the C's landing rules when the clock runs out.

- **`levitate` effect** (20 turns, C `LEVITATE_TIME`; HUD "Floating"; "You soar into the air!"). While it runs:
  - deep water is crossable (`creature.c move_creature` admits floaters);
  - the swim-fatigue counter **freezes** — it neither accrues nor resets (`swimming.c swim()` early-returns for floaters);
  - floor traps don't spring (`traps.c activate_trap`) — but the **win tile still fires**, the C's explicit `trap_win` exception.
- **Landing on expiry** (`game.c decrement_levitation` → `altitude.c change_altitude`): over water → "You plunge into water!" and the drowning clock takes over; over a trap → it springs on touchdown; otherwise "You land on the ground.". Landing resolves after the effects pass settles, so a sprung trap's effect can't corrupt the in-place slice compaction.
- Remaining in the arc: the **Lurker pool encounter** (lurker + 8 free-swim tentacles, 18c).

## Test plan
- Float across the pool: no HP loss either side; floating over a dart trap: no poison.
- Expiry over water plunges (C message) and the swim clock resumes the very next turn; expiry over a trap springs it; expiry on floor logs the ground message.
- `levitate` behavior + golden data test (potion/levitate/20).
- gofmt + go vet + full `go test ./...` green (10/10 packages).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Potion of Levitation, enabling players to float above terrain.
  * Levitating players safely cross water without damage and avoid trap activation.
  * Drowning effects pause while airborne; landing resolves based on tile type (water plunge, ground touch, or trap trigger).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->