### PR TITLE
Swimming monsters & the Lurker (swimming arc 3/3)

### DIFF
--- a/docs/superpowers/plans/2026-06-10-lurker-swimmers-18c.md
+++ b/docs/superpowers/plans/2026-06-10-lurker-swimmers-18c.md
@@ -1,0 +1,61 @@
+# Swimming monsters & the Lurker (18c) Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Swimming arc 3/3: monsters that swim, and the first unique — **the
+Lurker** — coiled in a Drowned City pool ringed by tentacles. Advances #18 +
+#13 (uniques).
+
+## C grounding
+- `creature.c move_creature`: `attr_free_swim` admits water; `attr_permaswim`
+  refuses anything *but* water ("we'd rather not get out").
+- `monster.c`: the merman (already in our roster) has `free_swim`; the
+  tentacle has `free_swim` + `permaswim` (a tentacle out of water is stuck —
+  it can flail but not move).
+- `swimming.c swim()`: free-swimmers never drown.
+- `unique.c:149` the Lurker: glyph `L` (`glyph.c:107`), HP 22, attack 95,
+  dodge 0, speed 120, free_swim + permaswim + sleep-immune, unarmed
+  `virtual_poison_fangs` (~2d6, damage_poison, "bites").
+- `content.c encounter_lurker`: **force the spot to water** ("Reset the
+  lurkers pool"), place the Lurker, then 8 tentacles at the nearest free
+  spots.
+- Out of scope: noxious breath for the Lurker (our ranged AI is single-target
+  bolts; revisit with the breath/explode subsystem), sleep immunity (nothing
+  can sleep a monster yet).
+
+## Design
+- `MonsterDef`: `swim` (may enter water), `permaswim` (water only), and
+  on-hit `effect`/`effect_turns` (poison fangs; mirrors wand/tile fields,
+  validated the same way). `monsterAttacks` applies the effect when the
+  player survives the bite.
+- Movement: one `creatureCanEnter(m, dst)` shared by
+  stepToward/stepAway/stepRandom — permaswim → only water tiles; swim →
+  passable or water; otherwise passable. (stepToward keeps its door-opening
+  fallback for walkers.)
+- Data: `lurker` (L, 22/95/0, speed 120, "2d6" + poison 5, nospawn-by-table:
+  placed as a boss), merman `swim = true`, tentacle `swim` + `permaswim`.
+- Gen: a permaswim boss gets its tile **forced to water** (the C's pool
+  reset); new `retinue`/`retinue_count` on LevelDef spawns escorts at the
+  nearest free tiles around the boss (water first). The Drowned City gets
+  `boss = "lurker"`, retinue 8 tentacles.
+
+## Task 1: swim flags + movement + poison fangs (TDD)
+**Files:** `internal/content/content.go`, `internal/game/combat.go`,
+`internal/game/swim_test.go` (extend).
+- Tests first: a swim-flagged monster pursues the player straight through a
+  pool (non-swimmer detours/stalls at the bank); a permaswim creature never
+  steps onto floor; a fanged monster's hit poisons.
+- Commit: `feat(game): swimming monsters (free_swim/permaswim) + on-hit effects`
+
+## Task 2: the Lurker + retinue placement + ship
+**Files:** `data/monsters.toml`, `data/levels.toml`, `data/data_test.go`,
+`internal/gen/gen.go` + tests.
+- Tests first: gen forces water under a permaswim boss and rings it with the
+  retinue; golden data for the lurker def and Drowned City wiring.
+- Commit: `feat(content): the Lurker — pool boss with tentacle retinue`
+- Full gate; push, PR, CodeRabbit loop → merge.
+
+## Done when
+Mermen cut straight across the Drowned City's pools while you detour; one pool
+holds something far worse — an `L` that never leaves the water, ringed by
+tentacles, whose bite leaves poison in your veins. Suite green.

--- a/go/data/data_test.go
+++ b/go/data/data_test.go
@@ -604,3 +604,29 @@ func TestEmbeddedLevitationPotion(t *testing.T) {
 		t.Errorf("potion_levitation def unexpected: %+v", p)
 	}
 }
+
+// TestEmbeddedLurker checks the Drowned City's pool boss loaded (18c): the
+// Lurker per C unique.c, with its tentacle retinue wiring.
+func TestEmbeddedLurker(t *testing.T) {
+	c, err := content.Load(Files)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	l := c.Monsters["lurker"]
+	if l == nil || l.Glyph != "L" || l.HP != 22 || l.Attack != 95 || l.Speed != 120 {
+		t.Fatalf("lurker def unexpected: %+v", l)
+	}
+	if !l.Swim || !l.Permaswim || l.Effect != "poison" {
+		t.Errorf("lurker should be a pool-bound venomous swimmer: %+v", l)
+	}
+	if m := c.Monsters["merman"]; m == nil || !m.Swim || m.Permaswim {
+		t.Errorf("merman should free-swim but walk ashore too: %+v", m)
+	}
+	if tn := c.Monsters["tentacle"]; tn == nil || !tn.Swim || !tn.Permaswim {
+		t.Errorf("tentacle should never leave the water: %+v", tn)
+	}
+	d := c.Levels["drowned_city"]
+	if d == nil || d.Boss != "lurker" || d.Retinue != "tentacle" || d.RetinueCount != 8 {
+		t.Errorf("drowned_city should host the Lurker with 8 tentacles: %+v", d)
+	}
+}

--- a/go/data/levels.toml
+++ b/go/data/levels.toml
@@ -198,6 +198,9 @@ height = 24
 links = ["laboratory", "dragons_lair", "underpass"]
 monsters = 12
 water = 4
+boss = "lurker"
+retinue = "tentacle"
+retinue_count = 8
 [[level.drowned_city.spawn]]
 monster = "merman"
 weight = 4

--- a/go/data/monsters.toml
+++ b/go/data/monsters.toml
@@ -67,6 +67,7 @@ attack = 4
 dodge = 2
 damage = "1d4"
 speed = 65
+swim = true
 corpse = "corpse"
 
 # Depth-gated tanks (no corpse — straw/ooze isn't edible). See #16 depth scaling.
@@ -294,6 +295,8 @@ attack = 5
 dodge = 1
 damage = "1d6"
 speed = 70
+swim = true
+permaswim = true
 min_depth = 3
 
 # A second ranged caster (after the imp) — flings gloom across a lit room
@@ -417,3 +420,21 @@ dodge = 3
 damage = "1d10"
 speed = 110
 ranged = 4
+
+# The Lurker (#18c/#13 uniques, C unique.c): a pool-bound horror — free_swim +
+# permaswim, poison fangs (C virtual_poison_fangs), speed 120. Placed only as
+# the Drowned City's boss, ringed by tentacles (C encounter_lurker).
+[monster.lurker]
+name = "Lurker"
+glyph = "L"
+color = "green"
+hp = 22
+attack = 95
+dodge = 0
+damage = "2d6"
+speed = 120
+swim = true
+permaswim = true
+effect = "poison"
+effect_turns = 5
+min_depth = 99 # never in random spawn tables: boss placement only

--- a/go/internal/content/content.go
+++ b/go/internal/content/content.go
@@ -312,6 +312,9 @@ func validateLevels(c *Content) error {
 				return fmt.Errorf("level %q: retinue set without a boss to escort", id)
 			}
 		}
+		if l.RetinueCount > 0 && l.Retinue == "" {
+			return fmt.Errorf("level %q: retinue_count > 0 without a retinue monster", id)
+		}
 		if l.Altar {
 			if t, ok := c.Tiles["altar"]; !ok || !t.Win {
 				return fmt.Errorf("level %q: altar set but no win tile %q is defined", id, "altar")

--- a/go/internal/content/content.go
+++ b/go/internal/content/content.go
@@ -54,18 +54,22 @@ func (t *TileDef) Rune() rune {
 
 // MonsterDef defines a kind of monster.
 type MonsterDef struct {
-	ID       string `toml:"-"`
-	Name     string `toml:"name"`
-	Glyph    string `toml:"glyph"`
-	Color    Color  `toml:"color"`
-	HP       int    `toml:"hp"`
-	Attack   int    `toml:"attack"`
-	Dodge    int    `toml:"dodge"`
-	Damage   string `toml:"damage"`    // dice spec, e.g. "1d4"
-	Speed    int    `toml:"speed"`     // energy gained per turn; <= 0 defaults to 100
-	Corpse   string `toml:"corpse"`    // item id dropped on death ("" = none); must be a food item
-	MinDepth int    `toml:"min_depth"` // earliest depth this monster spawns (0/1 = from depth 1)
-	Ranged   int    `toml:"ranged"`    // ranged attack distance in tiles (0 = melee only)
+	ID          string `toml:"-"`
+	Name        string `toml:"name"`
+	Glyph       string `toml:"glyph"`
+	Color       Color  `toml:"color"`
+	HP          int    `toml:"hp"`
+	Attack      int    `toml:"attack"`
+	Dodge       int    `toml:"dodge"`
+	Damage      string `toml:"damage"`       // dice spec, e.g. "1d4"
+	Speed       int    `toml:"speed"`        // energy gained per turn; <= 0 defaults to 100
+	Corpse      string `toml:"corpse"`       // item id dropped on death ("" = none); must be a food item
+	MinDepth    int    `toml:"min_depth"`    // earliest depth this monster spawns (0/1 = from depth 1)
+	Ranged      int    `toml:"ranged"`       // ranged attack distance in tiles (0 = melee only)
+	Swim        bool   `toml:"swim"`         // free_swim: may enter deep water (#18)
+	Permaswim   bool   `toml:"permaswim"`    // water only — it won't leave its pool (implies swim)
+	Effect      string `toml:"effect"`       // status effect a landed melee hit applies ("" = none)
+	EffectTurns int    `toml:"effect_turns"` // duration of Effect
 }
 
 // Rune returns the monster's glyph as a rune.
@@ -386,6 +390,12 @@ func validateMonster(m *MonsterDef) error {
 	}
 	if m.Ranged < 0 {
 		return fmt.Errorf("ranged must be >= 0, got %d", m.Ranged)
+	}
+	if m.Permaswim && !m.Swim {
+		return fmt.Errorf("permaswim requires swim")
+	}
+	if m.Effect != "" && m.EffectTurns <= 0 {
+		return fmt.Errorf("melee effect %q needs effect_turns > 0", m.Effect)
 	}
 	return nil
 }

--- a/go/internal/content/content.go
+++ b/go/internal/content/content.go
@@ -115,20 +115,22 @@ type SpawnEntry struct {
 
 // LevelDef defines a named dungeon level and its place in the graph.
 type LevelDef struct {
-	ID       string       `toml:"-"`
-	Name     string       `toml:"name"`
-	W        int          `toml:"width"`
-	H        int          `toml:"height"`
-	Start    bool         `toml:"start"` // the single entry level
-	Links    []string     `toml:"links"` // ids of connected levels
-	Monsters int          `toml:"monsters"`
-	Spawn    []SpawnEntry `toml:"spawn"`
-	Altar    bool         `toml:"altar"` // place an ascension altar (a win tile)
-	Boss     string       `toml:"boss"`  // a guaranteed monster placed once on the level
-	Traps    int          `toml:"traps"` // number of dart_trap tiles to scatter
-	Water    int          `toml:"water"` // number of water pools to carve (C level->water)
-	Doors    bool         `toml:"doors"` // place closed doors in room doorways
-	Dark     bool         `toml:"dark"`  // unlit level: the player sees only a small radius
+	ID           string       `toml:"-"`
+	Name         string       `toml:"name"`
+	W            int          `toml:"width"`
+	H            int          `toml:"height"`
+	Start        bool         `toml:"start"` // the single entry level
+	Links        []string     `toml:"links"` // ids of connected levels
+	Monsters     int          `toml:"monsters"`
+	Spawn        []SpawnEntry `toml:"spawn"`
+	Altar        bool         `toml:"altar"`         // place an ascension altar (a win tile)
+	Boss         string       `toml:"boss"`          // a guaranteed monster placed once on the level
+	Retinue      string       `toml:"retinue"`       // escort monster spawned around the boss ("" = none)
+	RetinueCount int          `toml:"retinue_count"` // how many escorts (C encounter_lurker spawns 8)
+	Traps        int          `toml:"traps"`         // number of dart_trap tiles to scatter
+	Water        int          `toml:"water"`         // number of water pools to carve (C level->water)
+	Doors        bool         `toml:"doors"`         // place closed doors in room doorways
+	Dark         bool         `toml:"dark"`          // unlit level: the player sees only a small radius
 }
 
 // Content is the fully-loaded, validated game content.
@@ -297,6 +299,17 @@ func validateLevels(c *Content) error {
 		if l.Boss != "" {
 			if _, ok := c.Monsters[l.Boss]; !ok {
 				return fmt.Errorf("level %q: boss %q is not a defined monster", id, l.Boss)
+			}
+		}
+		if l.RetinueCount < 0 {
+			return fmt.Errorf("level %q: retinue_count must be >= 0, got %d", id, l.RetinueCount)
+		}
+		if l.Retinue != "" {
+			if _, ok := c.Monsters[l.Retinue]; !ok {
+				return fmt.Errorf("level %q: retinue %q is not a defined monster", id, l.Retinue)
+			}
+			if l.Boss == "" {
+				return fmt.Errorf("level %q: retinue set without a boss to escort", id)
 			}
 		}
 		if l.Altar {

--- a/go/internal/game/combat.go
+++ b/go/internal/game/combat.go
@@ -193,6 +193,10 @@ func (g *Game) monsterAttacks(m *Creature) {
 	dmg := g.RNG.RollSpec(m.Def.Damage)
 	g.log("The %s hits you for %d.", m.Def.Name, dmg)
 	g.HurtPlayer(dmg, m.Def.Name)
+	if !g.Dead && m.Def.Effect != "" { // venomous bites etc. (C virtual weapons)
+		g.AddEffect(m.Def.Effect, m.Def.EffectTurns)
+		g.log("The %s %s you.", m.Def.Name, effectVerb(m.Def.Effect))
+	}
 }
 
 // rangedAttack fires a bolt at the player from a distance, using the same
@@ -362,12 +366,28 @@ func (g *Game) monsterAct(m *Creature) {
 	}
 }
 
+// creatureCanEnter is the terrain half of a monster's move (C move_creature):
+// a permaswimmer refuses anything but water, a free-swimmer takes water or
+// land, and everyone else needs walkable ground.
+func (g *Game) creatureCanEnter(m *Creature, dst Pos) bool {
+	if !g.Level.InBounds(dst) {
+		return false
+	}
+	if m.Def.Permaswim {
+		return g.Level.At(dst).Def.Water
+	}
+	if m.Def.Swim && g.Level.At(dst).Def.Water {
+		return true
+	}
+	return g.Level.Passable(dst)
+}
+
 func (g *Game) stepToward(m *Creature, target Pos) {
 	dst := Pos{m.Pos.X + signOf(target.X-m.Pos.X), m.Pos.Y + signOf(target.Y-m.Pos.Y)}
 	if dst == g.Player || g.Level.CreatureAt(dst) != nil {
 		return
 	}
-	if !g.Level.Passable(dst) {
+	if !g.creatureCanEnter(m, dst) {
 		g.openDoor(dst) // open a door in the way (spends this move); a plain wall is a no-op
 		return
 	}
@@ -383,7 +403,7 @@ func (g *Game) stepAway(m *Creature, from Pos) {
 		return // on top of the player (shouldn't happen): nowhere to flee
 	}
 	dst := Pos{m.Pos.X + dx, m.Pos.Y + dy}
-	if dst == g.Player || g.Level.CreatureAt(dst) != nil || !g.Level.Passable(dst) {
+	if dst == g.Player || g.Level.CreatureAt(dst) != nil || !g.creatureCanEnter(m, dst) {
 		return
 	}
 	m.Pos = dst
@@ -398,7 +418,7 @@ func (g *Game) stepRandom(m *Creature) {
 		return // stumbles in place
 	}
 	dst := Pos{m.Pos.X + dx, m.Pos.Y + dy}
-	if dst == g.Player || g.Level.CreatureAt(dst) != nil || !g.Level.Passable(dst) {
+	if dst == g.Player || g.Level.CreatureAt(dst) != nil || !g.creatureCanEnter(m, dst) {
 		return
 	}
 	m.Pos = dst

--- a/go/internal/game/swim_test.go
+++ b/go/internal/game/swim_test.go
@@ -135,3 +135,51 @@ func TestLandingOnTrapSpringsIt(t *testing.T) {
 		t.Error("landing on a trap springs it (C change_altitude)")
 	}
 }
+
+func TestSwimmerPursuesThroughWater(t *testing.T) {
+	g := waterGame() // water at (2,1); player at (1,1)
+	merman := &Creature{Def: &content.MonsterDef{ID: "merman", Name: "merman", Glyph: "m", HP: 8, Attack: 0, Dodge: 1, Damage: "1d4", Swim: true}, Pos: Pos{3, 1}, HP: 8}
+	g.Level.Creatures = append(g.Level.Creatures, merman)
+	g.worldTick()
+	if merman.Pos != (Pos{2, 1}) {
+		t.Errorf("a free-swimmer crosses the pool toward the player (C move_creature), at %v", merman.Pos)
+	}
+}
+
+func TestWalkerStallsAtTheBank(t *testing.T) {
+	g := combatGame()
+	// A pool wall straight across the corridor: x=2, all three rows.
+	water := &content.TileDef{ID: "water", Glyph: "_", Transparent: true, Water: true}
+	for y := 0; y < 3; y++ {
+		g.Level.Set(Pos{2, y}, water)
+	}
+	rat := &Creature{Def: &content.MonsterDef{ID: "rat", Name: "rat", Glyph: "r", HP: 3, Attack: 0, Dodge: 1, Damage: "1d1"}, Pos: Pos{3, 1}, HP: 3}
+	g.Level.Creatures = append(g.Level.Creatures, rat)
+	g.worldTick()
+	if g.Level.At(rat.Pos).Def.Water {
+		t.Errorf("a walker must not step into deep water, at %v", rat.Pos)
+	}
+}
+
+func TestPermaswimmerStaysInTheWater(t *testing.T) {
+	g := waterGame() // single water tile at (2,1), player adjacent at (1,1)
+	tentacle := &Creature{Def: &content.MonsterDef{ID: "tentacle", Name: "tentacle", Glyph: "l", HP: 12, Attack: 0, Dodge: 0, Damage: "1d6", Swim: true, Permaswim: true}, Pos: Pos{2, 1}, HP: 12}
+	g.Level.Creatures = append(g.Level.Creatures, tentacle)
+	g.Player = Pos{5, 1} // out of melee range: it would pursue if it could
+	for i := 0; i < 5; i++ {
+		g.worldTick()
+	}
+	if tentacle.Pos != (Pos{2, 1}) {
+		t.Errorf("a permaswimmer never leaves its pool (C move_creature), at %v", tentacle.Pos)
+	}
+}
+
+func TestPoisonFangsEnvenomOnHit(t *testing.T) {
+	g := combatGame()
+	lurker := &Creature{Def: &content.MonsterDef{ID: "lurker", Name: "the Lurker", Glyph: "L", HP: 22, Attack: 1000, Dodge: 0, Damage: "1d2", Effect: "poison", EffectTurns: 5}, Pos: Pos{2, 1}, HP: 22}
+	g.Level.Creatures = append(g.Level.Creatures, lurker)
+	g.worldTick()
+	if !g.HasEffect("poison") {
+		t.Error("a landed bite should envenom the player (C virtual_poison_fangs)")
+	}
+}

--- a/go/internal/gen/gen.go
+++ b/go/internal/gen/gen.go
@@ -214,7 +214,17 @@ func LevelFromDef(r *rng.MT, c *content.Content, def *content.LevelDef) (*game.L
 			return nil, fmt.Errorf("gen: level %q boss %q is not a defined monster", def.ID, def.Boss)
 		}
 		if pos, ok := bossSpot(r, lvl, rooms[len(rooms)-1]); ok {
+			if bdef.Permaswim {
+				// "Reset the lurkers pool" (C encounter_lurker): a water-bound
+				// boss gets water forced under it, wherever it lands.
+				water := c.Tiles["water"]
+				if water == nil {
+					return nil, fmt.Errorf("gen: level %q boss %q is permaswim but no \"water\" tile defined", def.ID, def.Boss)
+				}
+				lvl.Set(pos, water)
+			}
 			lvl.Creatures = append(lvl.Creatures, &game.Creature{Def: bdef, Pos: pos, HP: bdef.HP})
+			placeRetinue(c, lvl, def, pos)
 		}
 	}
 	if def.Doors {
@@ -231,6 +241,48 @@ func LevelFromDef(r *rng.MT, c *content.Content, def *content.LevelDef) (*game.L
 		placeTraps(r, c, lvl, rooms, def.Traps)
 	}
 	return lvl, nil
+}
+
+// placeRetinue rings the boss with def.Retinue escorts at the nearest free
+// tiles (C encounter_lurker: 8 tentacles at the nearest free spots), water
+// before land so swimmers start wet.
+func placeRetinue(c *content.Content, lvl *game.Level, def *content.LevelDef, boss game.Pos) {
+	if def.Retinue == "" || def.RetinueCount <= 0 {
+		return
+	}
+	rdef := c.Monsters[def.Retinue]
+	if rdef == nil {
+		return
+	}
+	placed := 0
+	for _, wantWater := range []bool{true, false} {
+		for radius := 1; radius <= 5 && placed < def.RetinueCount; radius++ {
+			for dy := -radius; dy <= radius && placed < def.RetinueCount; dy++ {
+				for dx := -radius; dx <= radius && placed < def.RetinueCount; dx++ {
+					if max(abs(dx), abs(dy)) != radius {
+						continue // ring only: nearest spots first
+					}
+					p := game.Pos{X: boss.X + dx, Y: boss.Y + dy}
+					if !lvl.InBounds(p) || lvl.CreatureAt(p) != nil || p == lvl.Start || lvl.PortalAt(p) != nil {
+						continue
+					}
+					tile := lvl.At(p).Def
+					if tile.Water != wantWater || (!tile.Water && !tile.Passable) {
+						continue
+					}
+					lvl.Creatures = append(lvl.Creatures, &game.Creature{Def: rdef, Pos: p, HP: rdef.HP})
+					placed++
+				}
+			}
+		}
+	}
+}
+
+func abs(n int) int {
+	if n < 0 {
+		return -n
+	}
+	return n
 }
 
 // placePools carves n water pools (the C add_pools/area_cloud: blobs of 5-24

--- a/go/internal/gen/gen_test.go
+++ b/go/internal/gen/gen_test.go
@@ -408,3 +408,54 @@ func TestLevelFromDefNoWaterByDefault(t *testing.T) {
 		}
 	}
 }
+
+func TestPermaswimBossGetsPoolAndRetinue(t *testing.T) {
+	c := levelDefContent()
+	c.Tiles["water"] = &content.TileDef{ID: "water", Glyph: "_", Color: content.ColorBlue, Transparent: true, Water: true}
+	c.Monsters["lurker"] = &content.MonsterDef{ID: "lurker", Name: "the Lurker", Glyph: "L", HP: 22, Attack: 95, Damage: "2d6", Speed: 120, Swim: true, Permaswim: true}
+	c.Monsters["tentacle"] = &content.MonsterDef{ID: "tentacle", Name: "tentacle", Glyph: "l", HP: 12, Attack: 5, Damage: "1d6", Swim: true, Permaswim: true}
+	def := &content.LevelDef{ID: "x", Name: "X", W: 60, H: 24, Links: []string{"y"}, Water: 4,
+		Boss: "lurker", Retinue: "tentacle", RetinueCount: 8}
+	lvl, err := LevelFromDef(rng.NewWithSeed(5), c, def)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var lurker *game.Creature
+	tentacles := 0
+	for _, m := range lvl.Creatures {
+		switch m.Def.ID {
+		case "lurker":
+			lurker = m
+		case "tentacle":
+			tentacles++
+		}
+	}
+	if lurker == nil {
+		t.Fatal("the Lurker should be placed")
+	}
+	if !lvl.At(lurker.Pos).Def.Water {
+		t.Errorf("the Lurker's tile is forced to water (C encounter_lurker), tile %q", lvl.At(lurker.Pos).Def.ID)
+	}
+	if tentacles == 0 {
+		t.Errorf("expected a tentacle retinue around the pool, got %d", tentacles)
+	}
+	for _, m := range lvl.Creatures {
+		if m.Def.ID == "tentacle" && chebyshevDist(m.Pos, lurker.Pos) > 6 {
+			t.Errorf("retinue should ring the boss: tentacle at %v, lurker at %v", m.Pos, lurker.Pos)
+		}
+	}
+}
+
+func chebyshevDist(a, b game.Pos) int {
+	dx, dy := a.X-b.X, a.Y-b.Y
+	if dx < 0 {
+		dx = -dx
+	}
+	if dy < 0 {
+		dy = -dy
+	}
+	if dx > dy {
+		return dx
+	}
+	return dy
+}


### PR DESCRIPTION
## Summary
Plan 18c — the swimming arc closes with monsters in the water and the port's first unique, all from the C:

- **`swim` / `permaswim` monster flags** (`creature.c move_creature`): one shared `creatureCanEnter` drives all three AI steps — permaswimmers refuse anything but water ("we'd rather not get out"), free-swimmers take water or land, walkers stall at the bank. The merman (which has `free_swim` in `monster.c`) now cuts straight across pools mid-pursuit.
- **On-hit melee effects** (C virtual weapons): a landed bite can apply a status effect — the Lurker's `virtual_poison_fangs` poisons through `monsterAttacks`, reusing the wand/tile `effect`/`effect_turns` schema + validation.
- **The Lurker** (`unique.c:149`): glyph `L`, HP 22, attack 95, speed 120, pool-bound, 2d6 poison bite. Placed as the Drowned City's boss with the C's "Reset the lurkers pool" rule — **water is forced under it** wherever it lands — and ringed by up to 8 permaswim tentacles via a new `retinue`/`retinue_count` level field (`content.c encounter_lurker`'s nearest-free-spots, water first).
- Noted out of scope: the Lurker's noxious breath (needs the breath subsystem) and sleep immunity (nothing can sleep a monster yet).

## Test plan
- A swim-flagged merman crosses the pool toward the player; a walker rat stalls at the bank; a tentacle never leaves its single water tile even with the player in sense range; a fanged hit envenoms.
- Gen: the permaswim boss sits on forced water with tentacles ringed nearby (seeded).
- Golden data: lurker stats/flags, merman/tentacle flags, Drowned City boss + retinue wiring; load-time validation for the new fields (permaswim⇒swim, retinue⇒boss, effect⇒turns).
- gofmt + go vet + full `go test ./...` green (10/10 packages).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced the Lurker boss monster with water-only movement and poison bite
  * Added swim and permanent-swim movement mechanics for aquatic creatures
  * Added boss retinue support for escorted boss encounters

* **Tests**
  * Added tests covering swim/permaswim movement, poison-on-hit, and the Lurker boss + retinue setup

* **Documentation**
  * Added an implementation plan detailing goals, tasks, and acceptance criteria
<!-- end of auto-generated comment: release notes by coderabbit.ai -->