### PR TITLE
Roster batch 6: electric snake, sludge dweller, severed hand, floating brain, flame spirit

### DIFF
--- a/docs/superpowers/plans/2026-06-10-roster-batch6-13g.md
+++ b/docs/superpowers/plans/2026-06-10-roster-batch6-13g.md
@@ -1,0 +1,44 @@
+# Roster batch 6 (13g) Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Five more canonical 0.40 monsters (batch 6): **electric snake,
+sludge dweller, severed hand, floating brain, flame spirit** — all from
+`common/monster.c`, glyphs from `common/glyph.c`, spawn levels from
+`common/places.c` `std_enemy` tables. Advances #13. (The **mimic** waits: its
+essence is the item-disguise `ai_mimic` machinery, its own increment.)
+
+## C grounding (stats `monster.c`, glyph `glyph.c`, levels `places.c`)
+- **electric snake** `S` cyan: HP 3, speed 35, fangs; Dungeon/Ominous
+  Cave/Underpass. (m_shock/m_recharge abilities out of scope.)
+- **sludge dweller** `s` brown: HP 2, speed 60, **mudball caster** → ranged;
+  everywhere mid-game (Dungeon, Ominous Cave, Laboratory, Comm Hub,
+  Underpass, Drowned City).
+- **severed hand** `p` normal: HP 4, speed 80, fast strangler; Catacombs.
+  (0.40 itself reuses `p` — goatman also wears it; colors differ.)
+- **floating brain** `b` magenta: HP 15, speed 70, **force-bolt caster** →
+  ranged; the Frozen Vault. (blink out of scope.)
+- **flame spirit** `j` red: HP 20, speed 60, burning melee; the Dragons Lair.
+- Glyph note: `b/j/s/S` are currently worn by bat/jackal/skeleton/cave_snake —
+  pre-parity filler absent from 0.40 (no `monster.c`/`glyph.c` entries).
+  Batch 6 takes the canonical glyphs with distinct colors; filler retirement
+  is flagged as its own follow-up task.
+
+## Design
+Data-only, the batch-1..5 pattern: five `[monster.*]` defs (attack/dodge/
+damage scaled like prior batches since the C's attack sequences don't map
+1:1), spawn-table entries on the C-faithful levels, `min_depth` tiering for
+generic generation, golden data test.
+
+## Task: defs + spawns + golden (TDD)
+**Files:** `data/monsters.toml`, `data/levels.toml`, `data/data_test.go`.
+- Golden test first (red): five defs with canonical glyph/HP/speed (+ranged
+  for sludge dweller and floating brain); spawn entries present.
+- Fill TOML (green); full gate; push, PR, CodeRabbit loop → merge.
+- Commit: `feat(content): roster batch 6 (electric snake, sludge dweller, severed hand, floating brain, flame spirit)`
+
+## Done when
+The Dungeon hisses with slow electric snakes, sludge dwellers lob mud across
+half the game, severed hands scuttle the Catacombs, a floating brain hurls
+bolts in the Frozen Vault, and a flame spirit guards the Dragons Lair. Suite
+green.

--- a/go/data/data_test.go
+++ b/go/data/data_test.go
@@ -630,3 +630,52 @@ func TestEmbeddedLurker(t *testing.T) {
 		t.Errorf("drowned_city should host the Lurker with 8 tentacles: %+v", d)
 	}
 }
+
+// TestEmbeddedRosterBatch6 checks batch 6 loaded with canonical 0.40 glyphs
+// (13g): electric snake, sludge dweller, severed hand, floating brain, flame
+// spirit (monster.c stats, glyph.c glyphs).
+func TestEmbeddedRosterBatch6(t *testing.T) {
+	c, err := content.Load(Files)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	checks := []struct {
+		id     string
+		glyph  string
+		hp     int
+		speed  int
+		ranged bool
+	}{
+		{"electric_snake", "S", 3, 35, false},
+		{"sludge_dweller", "s", 2, 60, true},
+		{"severed_hand", "p", 4, 80, false},
+		{"floating_brain", "b", 15, 70, true},
+		{"flame_spirit", "j", 20, 60, false},
+	}
+	for _, want := range checks {
+		m := c.Monsters[want.id]
+		if m == nil {
+			t.Errorf("%s missing", want.id)
+			continue
+		}
+		if m.Glyph != want.glyph || m.HP != want.hp || m.Speed != want.speed {
+			t.Errorf("%s: glyph/hp/speed = %q/%d/%d, want %q/%d/%d", want.id, m.Glyph, m.HP, m.Speed, want.glyph, want.hp, want.speed)
+		}
+		if (m.Ranged > 0) != want.ranged {
+			t.Errorf("%s: ranged = %d, want caster=%v", want.id, m.Ranged, want.ranged)
+		}
+	}
+	// Spot-check the C-faithful spawn homes (places.c std_enemy).
+	spawns := map[string]string{"dungeon": "electric_snake", "catacombs": "severed_hand", "frozen_vault": "floating_brain", "dragons_lair": "flame_spirit", "laboratory": "sludge_dweller"}
+	for lvl, mon := range spawns {
+		found := false
+		for _, s := range c.Levels[lvl].Spawn {
+			if s.Monster == mon {
+				found = true
+			}
+		}
+		if !found {
+			t.Errorf("%s should spawn %s (C places.c)", lvl, mon)
+		}
+	}
+}

--- a/go/data/levels.toml
+++ b/go/data/levels.toml
@@ -34,6 +34,12 @@ weight = 2
 [[level.dungeon.spawn]]
 monster = "jackal"
 weight = 2
+[[level.dungeon.spawn]]
+monster = "electric_snake"
+weight = 2
+[[level.dungeon.spawn]]
+monster = "sludge_dweller"
+weight = 1
 
 [level.catacombs]
 name = "the Catacombs"
@@ -66,6 +72,9 @@ weight = 2
 [[level.catacombs.spawn]]
 monster = "hellhound"
 weight = 1
+[[level.catacombs.spawn]]
+monster = "severed_hand"
+weight = 2
 
 [level.ominous_cave]
 name = "the Ominous Cave"
@@ -92,6 +101,12 @@ weight = 2
 [[level.ominous_cave.spawn]]
 monster = "cave_snake"
 weight = 2
+[[level.ominous_cave.spawn]]
+monster = "sludge_dweller"
+weight = 2
+[[level.ominous_cave.spawn]]
+monster = "electric_snake"
+weight = 1
 
 [level.laboratory]
 name = "the Laboratory"
@@ -128,6 +143,9 @@ weight = 2
 [[level.laboratory.spawn]]
 monster = "technician"
 weight = 2
+[[level.laboratory.spawn]]
+monster = "sludge_dweller"
+weight = 2
 
 [level.comm_hub]
 name = "the Communications Hub"
@@ -160,6 +178,9 @@ weight = 2
 [[level.comm_hub.spawn]]
 monster = "technician"
 weight = 1
+[[level.comm_hub.spawn]]
+monster = "sludge_dweller"
+weight = 1
 
 [level.underpass]
 name = "the Underpass"
@@ -189,6 +210,12 @@ monster = "dire_wolf"
 weight = 2
 [[level.underpass.spawn]]
 monster = "tentacle"
+weight = 1
+[[level.underpass.spawn]]
+monster = "sludge_dweller"
+weight = 1
+[[level.underpass.spawn]]
+monster = "electric_snake"
 weight = 1
 
 [level.drowned_city]
@@ -222,6 +249,9 @@ weight = 2
 [[level.drowned_city.spawn]]
 monster = "giant_slimy_toad"
 weight = 2
+[[level.drowned_city.spawn]]
+monster = "sludge_dweller"
+weight = 1
 
 [level.frozen_vault]
 name = "the Vault of the Frozen Saint"
@@ -255,6 +285,9 @@ weight = 2
 [[level.frozen_vault.spawn]]
 monster = "gaoler"
 weight = 1
+[[level.frozen_vault.spawn]]
+monster = "floating_brain"
+weight = 2
 
 [level.dragons_lair]
 name = "the Dragons Lair"
@@ -291,6 +324,9 @@ weight = 2
 [[level.dragons_lair.spawn]]
 monster = "chrome_angel"
 weight = 1
+[[level.dragons_lair.spawn]]
+monster = "flame_spirit"
+weight = 2
 
 [level.chapel]
 name = "the Chapel of Fallen Stars"

--- a/go/data/monsters.toml
+++ b/go/data/monsters.toml
@@ -438,3 +438,68 @@ permaswim = true
 effect = "poison"
 effect_turns = 5
 min_depth = 99 # never in random spawn tables: boss placement only
+
+# Roster batch 6 (13g) — canonical 0.40 foes (monster.c / glyph.c / places.c).
+# A slow, weak shock-eel of the early Dungeon (m_shock ability out of scope).
+[monster.electric_snake]
+name = "electric snake"
+glyph = "S"
+color = "cyan"
+hp = 3
+attack = 3
+dodge = 2
+damage = "1d3"
+speed = 35
+corpse = "corpse"
+min_depth = 1
+
+# Flings mudballs across half the mid-game (C m_mudball -> ranged).
+[monster.sludge_dweller]
+name = "sludge dweller"
+glyph = "s"
+color = "brown"
+hp = 2
+attack = 4
+dodge = 1
+damage = "1d3"
+speed = 60
+ranged = 4
+min_depth = 1
+
+# A fast strangler scuttling the Catacombs ('p' is shared with the goatman in
+# 0.40 itself; colors tell them apart).
+[monster.severed_hand]
+name = "severed hand"
+glyph = "p"
+color = "normal"
+hp = 4
+attack = 6
+dodge = 3
+damage = "1d4"
+speed = 80
+min_depth = 2
+
+# A force-bolt caster drifting the Frozen Vault (blink out of scope).
+[monster.floating_brain]
+name = "floating brain"
+glyph = "b"
+color = "magenta"
+hp = 15
+attack = 7
+dodge = 2
+damage = "1d6"
+speed = 70
+ranged = 6
+min_depth = 7
+
+# A burning guardian of the Dragons Lair.
+[monster.flame_spirit]
+name = "flame spirit"
+glyph = "j"
+color = "red"
+hp = 20
+attack = 8
+dodge = 3
+damage = "2d4"
+speed = 60
+min_depth = 8


### PR DESCRIPTION
## Summary
Plan 13g — five more canonical 0.40 monsters, data-only in the established batch pattern (stats `monster.c`, glyphs `glyph.c`, spawn homes `places.c` `std_enemy` tables):

| Monster | Glyph | HP/Spd | Role | Home (per C) |
|---|---|---|---|---|
| electric snake | `S` cyan | 3/35 | slow early-game fang | Dungeon, Ominous Cave, Underpass |
| sludge dweller | `s` brown | 2/60 | **mudball caster** (ranged 4) | six mid-game levels |
| severed hand | `p` normal | 4/80 | fast strangler | Catacombs |
| floating brain | `b` magenta | 15/70 | **force-bolt caster** (ranged 6) | Frozen Vault |
| flame spirit | `j` red | 20/60 | burning bruiser | Dragons Lair |

Notes: 0.40 itself shares `p` between goatman and severed hand (colors differ here). `b/j/s/S` are also worn by bat/jackal/skeleton/cave_snake — those four are pre-parity filler absent from 0.40 entirely; their retirement is flagged as a separate follow-up. Out of scope: electric snake's m_shock/m_recharge, floating brain's blink, and the mimic (its item-disguise AI is its own increment).

## Test plan
- Golden data test: all five defs (glyph/hp/speed/ranged) + C-faithful spawn-table spot checks per level.
- gofmt + go vet + full `go test ./...` green (10/10 packages).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added five new monsters: electric snake, sludge dweller, severed hand, floating brain, and flame spirit. Each features unique combat statistics and abilities, spawning strategically across multiple dungeon levels for increased gameplay variety and challenge.

* **Tests**
  * Added validation tests for the new monster roster.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->