### PR TITLE
The Necromancer — boss of the Catacombs

### DIFF
--- a/docs/superpowers/plans/2026-06-10-necromancer-13h.md
+++ b/docs/superpowers/plans/2026-06-10-necromancer-13h.md
@@ -4,7 +4,7 @@
 
 **Goal:** The second unique: **the Necromancer**, boss of the Catacombs
 (`places.c:130 temp->boss = encounter_necromancer`). Advances #13 (uniques).
-Data-only — every mechanic he needs shipped in earlier increments.
+Data-only — every mechanic he needs already shipped in earlier increments.
 
 ## C grounding
 - `unique.c:78`: HP 30, **speed 10** (glacial — roughly one action per ten

--- a/docs/superpowers/plans/2026-06-10-necromancer-13h.md
+++ b/docs/superpowers/plans/2026-06-10-necromancer-13h.md
@@ -1,0 +1,38 @@
+# The Necromancer (13h) Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** The second unique: **the Necromancer**, boss of the Catacombs
+(`places.c:130 temp->boss = encounter_necromancer`). Advances #13 (uniques).
+Data-only — every mechanic he needs shipped in earlier increments.
+
+## C grounding
+- `unique.c:78`: HP 30, **speed 10** (glacial — roughly one action per ten
+  player turns under the energy scheduler, a stationary-turret flavor the C
+  shares), EP 200 with force bolt / frost ray / fireball / bone crush —
+  approximated as a strong ranged caster (our casters are single-target
+  bolts); `virtual_cold_touch` melee — mapped to the shipped on-hit effect
+  machinery as a chilling touch (slow), the same mapping the wand of slowing
+  uses.
+- Glyph `N` (`glyph.c:109`, free in our roster), bestiary "NECROMANCER, THE (N)".
+- His two random scrolls at build are rolled-and-discarded in the C
+  (`del_item(attach_item_to_creature(...))`) — nothing to port.
+- The King of Worms was considered and deferred: he's an interaction NPC
+  ("the password that you want", `actions.c:876`) and needs the talk verb /
+  quest subsystem, not a stat block.
+
+## Design
+`[monster.necromancer]`: N, normal color (C A_NORMAL), hp 30, attack 9,
+dodge 2, damage "2d6", speed 10, ranged 7, effect "slow" 3 (cold touch),
+min_depth 99 (boss-only). Catacombs gets `boss = "necromancer"`.
+
+## Task: def + boss wiring + golden (TDD)
+**Files:** `data/monsters.toml`, `data/levels.toml`, `data/data_test.go`.
+- Golden test first (red): def stats/flags + catacombs boss wiring.
+- Fill TOML (green); full gate; push, PR, CodeRabbit loop → merge.
+- Commit: `feat(content): the Necromancer — boss of the Catacombs`
+
+## Done when
+An `N` waits deep in the Catacombs: almost motionless, hurling bolts from
+across the room, its rare touch draining the speed from your limbs. Suite
+green.

--- a/go/data/data_test.go
+++ b/go/data/data_test.go
@@ -679,3 +679,22 @@ func TestEmbeddedRosterBatch6(t *testing.T) {
 		}
 	}
 }
+
+// TestEmbeddedNecromancer checks the Catacombs boss loaded (13h): the
+// Necromancer per C unique.c — glacial, ranged, with a chilling touch.
+func TestEmbeddedNecromancer(t *testing.T) {
+	c, err := content.Load(Files)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	n := c.Monsters["necromancer"]
+	if n == nil || n.Glyph != "N" || n.HP != 30 || n.Speed != 10 || n.Ranged <= 0 {
+		t.Fatalf("necromancer def unexpected: %+v", n)
+	}
+	if n.Effect != "slow" {
+		t.Errorf("the Necromancer's cold touch should chill (slow on hit): %+v", n)
+	}
+	if l := c.Levels["catacombs"]; l == nil || l.Boss != "necromancer" {
+		t.Errorf("catacombs should host the Necromancer (C places.c), got %+v", l)
+	}
+}

--- a/go/data/levels.toml
+++ b/go/data/levels.toml
@@ -47,6 +47,7 @@ width = 60
 height = 24
 links = ["dungeon", "laboratory"]
 monsters = 10
+boss = "necromancer"
 traps = 3
 [[level.catacombs.spawn]]
 monster = "ghoul"

--- a/go/data/monsters.toml
+++ b/go/data/monsters.toml
@@ -503,3 +503,21 @@ dodge = 3
 damage = "2d4"
 speed = 60
 min_depth = 8
+
+# The Necromancer (13h, C unique.c:78): boss of the Catacombs. Glacial
+# (speed 10 — one move in ten player turns) but hurls bolts from afar
+# (force bolt/frost ray/fireball approximated as ranged) and his rare
+# cold touch drains your speed (virtual_cold_touch -> slow on hit).
+[monster.necromancer]
+name = "Necromancer"
+glyph = "N"
+color = "normal"
+hp = 30
+attack = 9
+dodge = 2
+damage = "2d6"
+speed = 10
+ranged = 7
+effect = "slow"
+effect_turns = 3
+min_depth = 99 # boss placement only


### PR DESCRIPTION
## Summary
Plan 13h — the port's second unique, data-only (every mechanic shipped in earlier increments):

- **The Necromancer** (`unique.c:78`, glyph `N` per `glyph.c:109`): HP 30, **speed 10** — under the energy scheduler that's one action per ~ten player turns, the C's stationary-turret flavor — `ranged = 7` approximating his force bolt/frost ray/fireball kit, and `virtual_cold_touch` mapped to the shipped on-hit machinery as **slow on hit** (the wand-of-slowing mapping).
- Placed as the **Catacombs** boss (`places.c:130`).
- Considered and deferred: **the King of Worms** — in 0.40 he's an interaction NPC ("He keeps the wisdom that you need, the password that you want", `actions.c:876`), so he belongs with a talk-verb/quest increment, not a stat block. His rolled-then-discarded scrolls (`del_item(attach_item_to_creature(...))`) have nothing to port.

## Test plan
- Golden data test: def stats (N/30/speed 10/ranged/slow-touch) + Catacombs boss wiring.
- gofmt + go vet + full `go test ./...` green (10/10 packages).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the Necromancer boss to the Catacombs with ranged attacks and an on-hit slow effect.

* **Tests**
  * Added content validation tests to verify Necromancer combat stats and placement.

* **Documentation**
  * Added an implementation plan detailing Necromancer design, parameters, and acceptance criteria.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->