### PR TITLE
Potions of yuck & elixir (potion table complete sans polymorph)

### DIFF
--- a/docs/superpowers/plans/2026-06-10-potions-yuck-elixir-15r.md
+++ b/docs/superpowers/plans/2026-06-10-potions-yuck-elixir-15r.md
@@ -1,0 +1,49 @@
+# Potions of yuck & elixir (15r) Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** The last two portable entries of 0.40's `item_table_potion`
+(`treasure.c` cases 10 and 12): the **potion of yuck** and the **elixir**.
+With these, the potion table is complete except polymorph (waits on the
+shapeshift subsystem). Advances #15.
+
+## C grounding
+- `potions.c treasure_p_yuck` (case 10): pure flavor — a 1d4 taste roll
+  ("This tastes like ratman urine." 1/4, "...gnoblin blood." 2/4,
+  "...liquified maggots." 1/4), identifies, no mechanical effect. (The
+  gnoblin's "Yum!" needs monster quaffing — out of scope.)
+- `potions.c treasure_elixir` (case 12): "Removes all status effects, even
+  good ones" — expires poison/haste/slow/healing(regen)/stun/wound/blindness,
+  zeroes levitation, then `change_altitude` (an airborne drinker lands!);
+  "You feel perfectly normal." Effects we have that the C does *not* expire
+  (confuse, fear, sleep) stay untouched.
+- Names: "potion of yuck", "elixir" (plural "elixirs" — note: no "potion of"
+  prefix in 0.40), both in the random-appearance pool.
+
+## Design
+- `Game.DispelLevitation()` — exported: if floating, drop the effect and run
+  the landing (the C's `set_attr(levitate,0)` + `change_altitude`); behaviors
+  can't reach the unexported `land`.
+- Behavior `yuck`: roll the taste line via `g.RNG`, nothing else. Behavior
+  `elixir`: `RemoveEffect` poison/haste/slow/regen/blind, then
+  `DispelLevitation()`, return the C message.
+- Data: `potion_yuck` (use `yuck`), `elixir` (kind potion, name "elixir",
+  use `elixir`). Both spawn + join the appearance shuffle automatically.
+
+## Task 1: DispelLevitation + behaviors (TDD)
+**Files:** `internal/game/effects.go` + test, `internal/behaviors/behaviors.go`
++ test.
+- Tests first: DispelLevitation over water plunges (landing runs);
+  elixir strips poison+haste+blind but leaves fear; yuck logs a taste line
+  and nothing else.
+- Commit: `feat(game): DispelLevitation + yuck/elixir behaviors`
+
+## Task 2: data + golden + ship
+- Golden: both defs load; elixir is named "elixir" (no "potion of" prefix).
+- Commit: `feat(content): potion of yuck + elixir (potion table complete sans polymorph)`
+- Full gate; push, PR, CodeRabbit loop → merge.
+
+## Done when
+One unidentified bottle tastes like liquified maggots and does nothing; the
+other strips every effect you have — poison cured, haste wasted, and if you
+were floating over a pool, enjoy the swim. Suite green.

--- a/go/data/data_test.go
+++ b/go/data/data_test.go
@@ -698,3 +698,18 @@ func TestEmbeddedNecromancer(t *testing.T) {
 		t.Errorf("catacombs should host the Necromancer (C places.c), got %+v", l)
 	}
 }
+
+// TestEmbeddedYuckAndElixir checks the last two portable potion-table entries
+// loaded (15r). Note the elixir's 0.40 name has no "potion of" prefix.
+func TestEmbeddedYuckAndElixir(t *testing.T) {
+	c, err := content.Load(Files)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if p := c.Items["potion_yuck"]; p == nil || p.Kind != "potion" || p.Use != "yuck" {
+		t.Errorf("potion_yuck def unexpected: %+v", p)
+	}
+	if p := c.Items["elixir"]; p == nil || p.Kind != "potion" || p.Use != "elixir" || p.Name != "elixir" {
+		t.Errorf("elixir def unexpected (0.40 name is just \"elixir\"): %+v", p)
+	}
+}

--- a/go/data/items.toml
+++ b/go/data/items.toml
@@ -401,3 +401,19 @@ glyph = "\""
 color = "magenta"
 kind = "amulet"
 dodge = 3
+
+# The table's dregs (15r): one bottle is pure vile flavor, the other strips
+# every status effect, even the ones you wanted (C treasure_p_yuck/elixir).
+[item.potion_yuck]
+name = "potion of yuck"
+glyph = "!"
+color = "brown"
+kind = "potion"
+use = "yuck"
+
+[item.elixir]
+name = "elixir"
+glyph = "!"
+color = "normal"
+kind = "potion"
+use = "elixir"

--- a/go/internal/behaviors/behaviors.go
+++ b/go/internal/behaviors/behaviors.go
@@ -32,6 +32,32 @@ func Registry() map[string]game.Behavior {
 		"slowness":        slowness,
 		"tranquilize":     tranquilize,
 		"levitate":        levitate,
+		"elixir":          elixir,
+		"yuck":            yuck,
+	}
+}
+
+// elixir strips every status the C expires — poison, haste, slow, regen,
+// blindness — and cuts levitation short, landing the drinker (C potions.c
+// treasure_elixir: "Removes all status effects, even good ones").
+func elixir(g *game.Game, it *game.Item) []string {
+	for _, kind := range []string{"poison", "haste", "slow", "regen", "blind"} {
+		g.RemoveEffect(kind)
+	}
+	g.DispelLevitation()
+	return []string{"You feel perfectly normal."}
+}
+
+// yuck is pure flavor — a vile taste and nothing else (C treasure_p_yuck's
+// 1d4 roll: gnoblin blood on 2-3).
+func yuck(g *game.Game, it *game.Item) []string {
+	switch g.RNG.Intn(4) {
+	case 0:
+		return []string{"This tastes like ratman urine."}
+	case 3:
+		return []string{"This tastes like liquified maggots."}
+	default:
+		return []string{"This tastes like gnoblin blood."}
 	}
 }
 

--- a/go/internal/behaviors/behaviors_test.go
+++ b/go/internal/behaviors/behaviors_test.go
@@ -1,6 +1,7 @@
 package behaviors
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/c0ze/tsl/internal/content"
@@ -314,5 +315,43 @@ func TestLevitatePotionLiftsPlayer(t *testing.T) {
 	}
 	if len(msgs) == 0 || msgs[0] != "You soar into the air!" {
 		t.Errorf("expected the C message, got %v", msgs)
+	}
+}
+
+func TestElixirStripsAllListedEffects(t *testing.T) {
+	elixir, ok := Registry()["elixir"]
+	if !ok {
+		t.Fatal("elixir not registered")
+	}
+	g := &game.Game{PlayerHP: 10, PlayerMax: 10}
+	for _, kind := range []string{"poison", "haste", "blind", "fear"} {
+		g.AddEffect(kind, 10)
+	}
+	msgs := elixir(g, &game.Item{Def: &content.ItemDef{Name: "elixir"}})
+	for _, gone := range []string{"poison", "haste", "blind"} {
+		if g.HasEffect(gone) {
+			t.Errorf("elixir should strip %s (C treasure_elixir)", gone)
+		}
+	}
+	if !g.HasEffect("fear") {
+		t.Error("fear is not in the C's expiry list and should survive")
+	}
+	if len(msgs) == 0 || msgs[0] != "You feel perfectly normal." {
+		t.Errorf("expected the C message, got %v", msgs)
+	}
+}
+
+func TestYuckIsAllFlavor(t *testing.T) {
+	yuck, ok := Registry()["yuck"]
+	if !ok {
+		t.Fatal("yuck not registered")
+	}
+	g := &game.Game{PlayerHP: 10, PlayerMax: 10, RNG: rng.NewWithSeed(7)}
+	msgs := yuck(g, &game.Item{Def: &content.ItemDef{Name: "potion of yuck"}})
+	if len(msgs) == 0 || !strings.Contains(msgs[0], "This tastes like") {
+		t.Errorf("expected a taste line, got %v", msgs)
+	}
+	if len(g.Effects) != 0 || g.PlayerHP != 10 {
+		t.Error("yuck is pure flavor: no effects, no damage")
 	}
 }

--- a/go/internal/game/effects.go
+++ b/go/internal/game/effects.go
@@ -166,6 +166,16 @@ func (g *Game) land() {
 	}
 }
 
+// DispelLevitation cuts levitation short and runs the landing (the C elixir's
+// set_attr(levitate,0) + change_altitude). A grounded player is a no-op.
+func (g *Game) DispelLevitation() {
+	if !g.HasEffect("levitate") {
+		return
+	}
+	g.RemoveEffect("levitate")
+	g.land()
+}
+
 // EffectsSummary is a comma-separated list of active effect labels for the HUD,
 // or "" when there are none.
 func (g *Game) EffectsSummary() string {

--- a/go/internal/game/swim_test.go
+++ b/go/internal/game/swim_test.go
@@ -1,6 +1,7 @@
 package game
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/c0ze/tsl/internal/content"
@@ -181,5 +182,22 @@ func TestPoisonFangsEnvenomOnHit(t *testing.T) {
 	g.worldTick()
 	if !g.HasEffect("poison") {
 		t.Error("a landed bite should envenom the player (C virtual_poison_fangs)")
+	}
+}
+
+func TestDispelLevitationLands(t *testing.T) {
+	g := waterGame()
+	g.AddEffect("levitate", 20)
+	g.PlayerStep(DirE) // float out over the pool
+	g.DispelLevitation()
+	if g.HasEffect("levitate") {
+		t.Fatal("DispelLevitation should drop the effect")
+	}
+	if !hasMessage(g, "You plunge into water!") {
+		t.Errorf("dispelling mid-air runs the landing (C change_altitude), got %v", g.Messages)
+	}
+	g.DispelLevitation() // grounded: a no-op, no second landing
+	if n := strings.Count(strings.Join(g.Messages, "\n"), "You plunge into water!"); n != 1 {
+		t.Errorf("no landing without levitation: %d plunge messages", n)
 	}
 }


### PR DESCRIPTION
## Summary
Plan 15r — the last two portable entries of 0.40's `item_table_potion` (`treasure.c` cases 10/12):

- **Potion of yuck** (`potions.c treasure_p_yuck`): pure flavor — the C's 1d4 taste roll (ratman urine 1/4, gnoblin blood 2/4, liquified maggots 1/4), identifies on quaff, zero mechanics. (The gnoblin's "Yum!" needs monster quaffing — out of scope.)
- **Elixir** (`treasure_elixir`, 0.40 name has no "potion of" prefix): "Removes all status effects, even good ones" — strips poison/haste/slow/regen/blind and **cuts levitation short with a real landing** (the C's `change_altitude`: dispel it over a pool and you plunge straight into the drowning clock). Effects the C does *not* expire (confuse/fear/sleep) survive. "You feel perfectly normal."
- New exported `Game.DispelLevitation()` — drop-and-land in one hook, since behaviors can't reach the unexported landing.
- The potion table is now **complete except polymorph**, which waits on the shapeshift subsystem.

## Test plan
- DispelLevitation over water plunges exactly once; grounded dispel is a no-op.
- Elixir strips poison+haste+blind, leaves fear; yuck logs a taste line with no effects and no damage.
- Golden data: both defs, including the prefix-less "elixir" name.
- gofmt + go vet + full `go test ./...` green (10/10 packages).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced two new potions: **potion of yuck** and **elixir**.
  * Elixir removes multiple status effects and dispels active levitation, returning the player to normal ground state.
  * Potion of yuck delivers randomized flavor outcomes with taste-based feedback and no stat changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->