### PR TITLE
Player burden: carried weight halves your speed

### DIFF
--- a/docs/superpowers/plans/2026-06-10-burden-16d.md
+++ b/docs/superpowers/plans/2026-06-10-burden-16d.md
@@ -1,0 +1,53 @@
+# Player burden (16d) Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** The burden model (`burdened.c`) — the third and last speed modifier
+the 16a scheduler was built for (after haste and slow): carry too much and the
+world moves twice for every step you take. Advances #14/#16.
+
+## C grounding
+- `burdened.c is_burdened`: carried weight > allowance;
+  `get_weight_allowance` = `attr_carrying_capacity`
+  (`DEFAULT_CARRYING_CAPACITY` 400, `rules.h:148`); carried = Σ item weights
+  over the whole inventory (equipped gear stays in the C's item list — ours
+  too).
+- `game.c increment_counters`: burdened → `speed = MAX(1, speed * 0.5)`
+  (`BURDENED_FACTOR`), stacking after effect mods (our haste/slow), same
+  order here.
+- Messages (`burdened.c`): crossing over — "You stagger under your load!";
+  dropping back under — "You are no longer burdened.". HUD flag "Burdened".
+- Weights (`rules.h` WEIGHT_*): potion 7, scroll 4, wand 21, food 8,
+  tool/torch 12, **corpse 599** (heavier than the whole allowance — the C's
+  anti-hoarding rule: hauling any corpse burdens you), dagger 18, small sword
+  22, large sword 28, club 26, bow 20, cloak 25, light armor 40, heavy
+  armor 80.
+
+## Design
+- `ItemDef.Weight` + loader defaults by kind (potion 7 / scroll 4 / wand 21 /
+  food 8 / light 12 / spellbook 12 / ring & amulet 5 / weapon 22 / armor 40),
+  explicit TOML weights where the C differs: corpse 599, dagger & machete 18,
+  shortbow 20, quarterstaff 26, doomblade 28, filthy rags 25, chainmail &
+  rune armor 80.
+- `Game.carriedWeight()` / `burdened()` (capacity const 400); `playerSpeed()`
+  halves (floor 1) when burdened, after haste/slow like the C.
+- Messages: `PlayerPickup` staggers on crossing over; `removeInventory`
+  announces relief on dropping under. `EffectsSummary` appends "Burdened".
+
+## Task 1: burden mechanics (TDD)
+**Files:** `internal/content/content.go`, `internal/game/{game,combat,use,effects}.go`,
+new `internal/game/burden_test.go`.
+- Tests first: overloaded player gives monsters two ticks per action (the
+  scheduler observable); stagger message fires once on crossing; quaffing
+  below the line announces relief; HUD label; loader kind-defaults + corpse
+  599 golden.
+- Commit: `feat(game): burden — carried weight halves player speed (C burdened.c)`
+
+## Task 2: data weights + ship
+- Explicit weights in items.toml; golden checks; full gate; PR; CodeRabbit
+  loop → merge.
+- Commit: `feat(content): C item weights (corpses weigh 599 for a reason)`
+
+## Done when
+Greed has a cost: scoop up one corpse too many and every monster on the level
+takes two steps for your one until you drop the load. Suite green.

--- a/go/data/data_test.go
+++ b/go/data/data_test.go
@@ -713,3 +713,28 @@ func TestEmbeddedYuckAndElixir(t *testing.T) {
 		t.Errorf("elixir def unexpected (0.40 name is just \"elixir\"): %+v", p)
 	}
 }
+
+// TestEmbeddedWeights checks the C weight table loaded (16d): kind defaults
+// fill unset items, explicit gear weights override, and a corpse outweighs
+// the whole 400 allowance (rules.h WEIGHT_CORPSE 599 — the anti-hoarding rule).
+func TestEmbeddedWeights(t *testing.T) {
+	c, err := content.Load(Files)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if w := c.Items["healing_potion"].Weight; w != 7 {
+		t.Errorf("potions default to WEIGHT_POTION 7, got %d", w)
+	}
+	if w := c.Items["scroll_identify"].Weight; w != 4 {
+		t.Errorf("scrolls default to WEIGHT_SCROLL 4, got %d", w)
+	}
+	if w := c.Items["corpse"].Weight; w != 599 {
+		t.Errorf("a corpse weighs 599 (more than the allowance), got %d", w)
+	}
+	if w := c.Items["rune_armor"].Weight; w != 80 {
+		t.Errorf("rune armor is WEIGHT_HEAVY_ARMOR 80, got %d", w)
+	}
+	if w := c.Items["dagger"].Weight; w != 18 {
+		t.Errorf("dagger is WEIGHT_DAGGER 18, got %d", w)
+	}
+}

--- a/go/data/items.toml
+++ b/go/data/items.toml
@@ -14,6 +14,7 @@ color = "normal"
 kind = "weapon"
 attack = 2
 damage = "1d4"
+weight = 18
 
 [item.leather_armor]
 name = "leather armor"
@@ -30,6 +31,7 @@ color = "normal"
 kind = "weapon"
 attack = 3
 damage = "1d6"
+weight = 18
 
 [item.quarterstaff]
 name = "quarterstaff"
@@ -38,6 +40,7 @@ color = "brown"
 kind = "weapon"
 attack = 2
 damage = "1d6"
+weight = 26
 
 [item.cleaver]
 name = "cleaver"
@@ -62,6 +65,7 @@ color = "red"
 kind = "weapon"
 attack = 5
 damage = "2d6"
+weight = 28
 
 # Ranged weapon (#14) — wield it, then fire (f) at a target in line of sight.
 # Weak in melee; its strength is reach. power/ammo are infinite for now.
@@ -73,6 +77,7 @@ kind = "weapon"
 attack = 1
 damage = "1d6"
 ranged = 6
+weight = 20
 
 # Body armor (dodge bonus).
 [item.filthy_rags]
@@ -81,6 +86,7 @@ glyph = "["
 color = "brown"
 kind = "armor"
 dodge = 1
+weight = 25
 
 [item.fish_scale_armor]
 name = "fish-scale armor"
@@ -95,6 +101,7 @@ glyph = "["
 color = "normal"
 kind = "armor"
 dodge = 4
+weight = 80
 
 [item.rune_armor]
 name = "rune armor"
@@ -102,6 +109,7 @@ glyph = "["
 color = "magenta"
 kind = "armor"
 dodge = 5
+weight = 80
 
 # Food. Eaten with `e` to restore HP. Corpses are nospawn (drops only).
 [item.ration]
@@ -121,6 +129,7 @@ kind = "food"
 use = "eat"
 power = 2
 nospawn = true
+weight = 599
 
 [item.carcass]
 name = "carcass"

--- a/go/internal/content/content.go
+++ b/go/internal/content/content.go
@@ -97,6 +97,14 @@ type ItemDef struct {
 	Cost        int    `toml:"cost"`         // EP cost to cast (spellbooks)
 	Beam        bool   `toml:"beam"`         // a spell that strikes every creature in a line
 	NoSpawn     bool   `toml:"nospawn"`      // exclude from random floor loot (e.g. corpses)
+	Weight      int    `toml:"weight"`       // carry weight (0 = kind default, C rules.h WEIGHT_*)
+}
+
+// kindWeights are the C's per-kind WEIGHT_* defaults (rules.h); an item with
+// no explicit weight inherits its kind's.
+var kindWeights = map[string]int{
+	"potion": 7, "scroll": 4, "wand": 21, "food": 8, "light": 12,
+	"spellbook": 12, "ring": 5, "amulet": 5, "weapon": 22, "armor": 40,
 }
 
 // Rune returns the item's glyph as a rune.
@@ -206,6 +214,9 @@ func Load(fsys fs.FS) (*Content, error) {
 			def.ID = id
 			if err := validateItem(def); err != nil {
 				return nil, fmt.Errorf("item %q: %w", id, err)
+			}
+			if def.Weight == 0 {
+				def.Weight = kindWeights[def.Kind]
 			}
 			c.Items[id] = def
 		}
@@ -479,6 +490,9 @@ func validateItem(i *ItemDef) error {
 	}
 	if i.Ranged < 0 {
 		return fmt.Errorf("ranged must be >= 0, got %d", i.Ranged)
+	}
+	if i.Weight < 0 {
+		return fmt.Errorf("weight must be >= 0, got %d", i.Weight)
 	}
 	if i.Light < 0 {
 		return fmt.Errorf("light must be >= 0, got %d", i.Light)

--- a/go/internal/game/burden_test.go
+++ b/go/internal/game/burden_test.go
@@ -1,0 +1,54 @@
+package game
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/c0ze/tsl/internal/content"
+)
+
+// loadedGame is a combat corridor with a pursuing rat and a heavy lump in the
+// player's pack (one C corpse outweighs the whole 400 allowance by itself).
+func loadedGame() (*Game, *Creature) {
+	g, rat := schedulerGame()
+	g.Inventory = append(g.Inventory, &Item{Def: &content.ItemDef{ID: "corpse", Name: "corpse", Kind: "food", Weight: 599}})
+	return g, rat
+}
+
+func TestBurdenedPlayerGivesMonstersTwoTicks(t *testing.T) {
+	g, rat := loadedGame()
+	g.advanceWorld()
+	if rat.Pos.X != 6 {
+		t.Errorf("a burdened player moves at half speed (C BURDENED_FACTOR): rat should be at x=6, got x=%d", rat.Pos.X)
+	}
+}
+
+func TestStaggerOnPickupAndReliefOnUse(t *testing.T) {
+	g := combatGame()
+	corpse := &Item{Def: &content.ItemDef{ID: "corpse", Name: "corpse", Kind: "food", Weight: 599, Use: "eat"}, Pos: g.Player}
+	g.Level.Items = append(g.Level.Items, corpse)
+	g.PlayerPickup()
+	if !hasMessage(g, "You stagger under your load!") {
+		t.Fatalf("crossing the allowance staggers (C burdened.c), got %v", g.Messages)
+	}
+	if got := g.EffectsSummary(); !strings.Contains(got, "Burdened") {
+		t.Errorf("HUD should flag the burden, got %q", got)
+	}
+	g.Behaviors = map[string]Behavior{"eat": func(g *Game, it *Item) []string { return nil }}
+	g.PlayerUse(corpse) // consuming it drops the weight
+	if !hasMessage(g, "You are no longer burdened.") {
+		t.Errorf("dropping under the allowance announces relief, got %v", g.Messages)
+	}
+	if strings.Contains(g.EffectsSummary(), "Burdened") {
+		t.Error("HUD flag should clear with the load")
+	}
+}
+
+func TestLightPackNoBurden(t *testing.T) {
+	g, rat := schedulerGame()
+	g.Inventory = append(g.Inventory, &Item{Def: &content.ItemDef{ID: "healing_potion", Kind: "potion", Weight: 7}})
+	g.advanceWorld()
+	if rat.Pos.X != 7 {
+		t.Errorf("a light pack costs nothing: rat should be at x=7, got x=%d", rat.Pos.X)
+	}
+}

--- a/go/internal/game/combat.go
+++ b/go/internal/game/combat.go
@@ -26,15 +26,40 @@ func speedOf(m *Creature) int {
 	return defaultSpeed
 }
 
+// carryCapacity is how much the player can haul comfortably
+// (C rules.h DEFAULT_CARRYING_CAPACITY).
+const carryCapacity = 400
+
+// carriedWeight sums the pack, equipped gear included — worn items stay in
+// the inventory list, as in the C.
+func (g *Game) carriedWeight() int {
+	total := 0
+	for _, it := range g.Inventory {
+		if it != nil && it.Def != nil {
+			total += it.Def.Weight
+		}
+	}
+	return total
+}
+
+// burdened reports whether the player carries more than the allowance
+// (C burdened.c is_burdened).
+func (g *Game) burdened() bool { return g.carriedWeight() > carryCapacity }
+
 // playerSpeed is the player's energy gain per world tick (the C's attr_speed,
 // base BASE_SPEED): haste adds a flat bonus, slow halves — the same rule
-// monsters use (the C's literal -1 for slow is vestigial on a 100 scale).
+// monsters use (the C's literal -1 for slow is vestigial on a 100 scale) —
+// and a heavy pack halves what's left (C BURDENED_FACTOR, applied after the
+// effect mods as in increment_counters).
 func (g *Game) playerSpeed() int {
 	speed := defaultSpeed
 	if g.HasEffect("haste") {
 		speed += hasteBonus
 	}
 	if g.HasEffect("slow") {
+		speed /= 2
+	}
+	if g.burdened() {
 		speed /= 2
 	}
 	if speed < 1 {

--- a/go/internal/game/effects.go
+++ b/go/internal/game/effects.go
@@ -176,19 +176,20 @@ func (g *Game) DispelLevitation() {
 	g.land()
 }
 
-// EffectsSummary is a comma-separated list of active effect labels for the HUD,
-// or "" when there are none.
+// EffectsSummary is a comma-separated list of active effect labels for the HUD
+// — plus the burden flag, which is carried state rather than a timed effect —
+// or "" when there is nothing to show.
 func (g *Game) EffectsSummary() string {
-	if len(g.Effects) == 0 {
-		return ""
-	}
-	labels := make([]string, 0, len(g.Effects))
+	labels := make([]string, 0, len(g.Effects)+1)
 	for _, e := range g.Effects {
 		if l := effectLabels[e.Kind]; l != "" {
 			labels = append(labels, l)
 		} else {
 			labels = append(labels, e.Kind)
 		}
+	}
+	if g.burdened() {
+		labels = append(labels, "Burdened")
 	}
 	return strings.Join(labels, ", ")
 }

--- a/go/internal/game/use.go
+++ b/go/internal/game/use.go
@@ -10,9 +10,13 @@ func (g *Game) PlayerPickup() {
 		g.log("There is nothing here to pick up.")
 		return
 	}
+	wasBurdened := g.burdened()
 	g.Level.RemoveItem(it)
 	g.Inventory = append(g.Inventory, it)
 	g.log("You pick up the %s.", it.Def.Name)
+	if !wasBurdened && g.burdened() {
+		g.log("You stagger under your load!")
+	}
 	g.autoEquip(it)
 	g.advanceWorld()
 }
@@ -89,11 +93,15 @@ func (g *Game) hasInventoryItem(it *Item) bool {
 }
 
 func (g *Game) removeInventory(it *Item) {
+	wasBurdened := g.burdened()
 	for i, x := range g.Inventory {
 		if x == it {
 			g.Inventory = append(g.Inventory[:i], g.Inventory[i+1:]...)
-			return
+			break
 		}
+	}
+	if wasBurdened && !g.burdened() {
+		g.log("You are no longer burdened.")
 	}
 }
 


### PR DESCRIPTION
## Summary
Plan 16d — the third and final speed modifier the #54 scheduler was built for (after haste and slow), ported from `burdened.c`:

- **Burden rule**: carried weight (whole inventory, equipped gear included — same as the C's item list) above `DEFAULT_CARRYING_CAPACITY` 400 halves `playerSpeed()` (`BURDENED_FACTOR`), applied **after** the effect mods exactly like `increment_counters`. Burdened means every monster gets two ticks per step you take.
- **Messages on the threshold** (`burdened.c`): "You stagger under your load!" on picking up past the line; "You are no longer burdened." when the load drops back under. The HUD effects line gains a "Burdened" flag.
- **C weight table** (`rules.h WEIGHT_*`): per-kind defaults filled at load (potion 7, scroll 4, wand 21, food 8…), explicit gear weights where the C differs (dagger 18, doomblade 28, heavy armor 80…). And the original's quiet masterpiece, ported intact: **a corpse weighs 599** — hauling even one burdens you, so loot the floor, not the morgue.

## Test plan
- An overloaded player gives a pursuing rat two tiles per action (the scheduler observable); a light pack costs nothing.
- Stagger fires exactly on crossing; relief on consuming the weight; HUD flag appears and clears.
- Golden data: kind defaults + explicit overrides + the 599 corpse.
- gofmt + go vet + full `go test ./...` green (10/10 packages).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added item weight system with carrying capacity limits
  * Player movement speed is reduced when overencumbered
  * HUD displays "Burdened" status indicator when carrying capacity is exceeded
  * Contextual feedback messages when picking up heavy items and when burden is relieved

* **Documentation**
  * Added implementation plan documentation for burden mechanics

* **Tests**
  * Added tests for burden behavior, item weight handling, and speed calculations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->