### PR TITLE
Blink scroll (0.40's true name) + scroll of amnesia

### DIFF
--- a/docs/superpowers/plans/2026-06-10-blink-amnesia-15t.md
+++ b/docs/superpowers/plans/2026-06-10-blink-amnesia-15t.md
@@ -1,0 +1,48 @@
+# Blink scroll rename + scroll of amnesia (15t) Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Two scroll-kit fixes from the 0.40 source. First, a faithfulness
+correction: 0.40 has **no teleportation scroll** — its random-relocation
+scroll is the **blink scroll** (`treasure.h` scroll list; `treasure.c:1178`),
+which is exactly the mechanic our mislabeled "scroll of teleportation"
+shipped. Second, the **scroll of amnesia** — the map-eraser, the inverse of
+magic mapping. Advances #15.
+
+## C grounding
+- `treasure.h:119-129` is the whole 0.40 scroll list: identify, magic mapping,
+  trap detection, recharge, **blink**, familiar, mark, recall, **amnesia**,
+  magic weapon. No teleportation scroll exists; the C's controlled
+  `cast_teleport` is spell-side and "computer controlled teleport works just
+  like blink" (`teleport.c:261`).
+- `teleport.c cast_blink`: move to a random free spot; "You blink away..." /
+  "Suddenly, you are somewhere else."; springs any trap at the destination.
+- `magic.c amnesia`: wipe the automap (`memory[y][x] = gent_blank`);
+  "You suddenly feel very forgetful.".
+- `treasure.c:1178`: the item is named "blink scroll" (not "scroll of blink").
+
+## Design
+- Rename `scroll_teleport` → `scroll_blink`, name "blink scroll"; the
+  behavior key stays `teleport` internally but the read messages become the
+  C's blink lines, and the landing applies the destination tile's trap
+  effect (cast_blink's `activate_trap`). Tests referencing the old id move.
+- New `Game.ForgetMap()` (inverse of the reveal used by magic mapping:
+  Seen=false everywhere); behavior `amnesia` returns the C line;
+  `scroll_amnesia` joins the scroll appearance pool — an unidentified read
+  can now cost you your map.
+
+## Task 1: rename + landing trap + ForgetMap (TDD)
+**Files:** `internal/game/teleport.go` + tests, `internal/behaviors/behaviors.go`
++ tests, `data/items.toml`, `data/data_test.go`.
+- Tests first: blink onto a trap tile springs it; ForgetMap clears Seen;
+  amnesia behavior wipes the map with the C message; golden defs
+  (`scroll_blink` named "blink scroll", `scroll_amnesia`).
+- Commit: `feat(content): blink scroll (0.40's true name) + scroll of amnesia`
+
+## Task 2: gate + ship
+- Full gate; push, PR, CodeRabbit loop → merge.
+
+## Done when
+The scroll kit matches `treasure.h`: the random hop is honestly called a blink
+scroll and lands you on whatever was waiting there, and one unlucky read wipes
+your hard-earned map. Suite green.

--- a/go/data/data_test.go
+++ b/go/data/data_test.go
@@ -469,8 +469,8 @@ func TestEmbeddedScrolls(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Load: %v", err)
 	}
-	if s := c.Items["scroll_teleport"]; s == nil || s.Kind != "scroll" || s.Use != "teleport" {
-		t.Errorf("scroll_teleport def unexpected: %+v", s)
+	if s := c.Items["scroll_blink"]; s == nil || s.Kind != "scroll" || s.Use != "teleport" || s.Name != "blink scroll" {
+		t.Errorf("scroll_blink def unexpected (0.40 treasure.c names it \"blink scroll\"): %+v", s)
 	}
 	if s := c.Items["scroll_magic_mapping"]; s == nil || s.Kind != "scroll" || s.Use != "reveal" {
 		t.Errorf("scroll_magic_mapping def unexpected: %+v", s)
@@ -736,5 +736,16 @@ func TestEmbeddedWeights(t *testing.T) {
 	}
 	if w := c.Items["dagger"].Weight; w != 18 {
 		t.Errorf("dagger is WEIGHT_DAGGER 18, got %d", w)
+	}
+}
+
+// TestEmbeddedAmnesiaScroll checks the map-eraser loaded (15t).
+func TestEmbeddedAmnesiaScroll(t *testing.T) {
+	c, err := content.Load(Files)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if s := c.Items["scroll_amnesia"]; s == nil || s.Kind != "scroll" || s.Use != "amnesia" {
+		t.Errorf("scroll_amnesia def unexpected: %+v", s)
 	}
 }

--- a/go/data/items.toml
+++ b/go/data/items.toml
@@ -303,8 +303,8 @@ effect_turns = 8
 power = 5
 
 # Scrolls (#15) — read (r) to invoke. Glyph ?.
-[item.scroll_teleport]
-name = "scroll of teleportation"
+[item.scroll_blink]
+name = "blink scroll"
 glyph = "?"
 color = "magenta"
 kind = "scroll"
@@ -426,3 +426,11 @@ glyph = "!"
 color = "normal"
 kind = "potion"
 use = "elixir"
+
+# The map-eraser (15t, C magic.c amnesia) — an unlucky unidentified read.
+[item.scroll_amnesia]
+name = "scroll of amnesia"
+glyph = "?"
+color = "magenta"
+kind = "scroll"
+use = "amnesia"

--- a/go/internal/behaviors/behaviors.go
+++ b/go/internal/behaviors/behaviors.go
@@ -34,7 +34,15 @@ func Registry() map[string]game.Behavior {
 		"levitate":        levitate,
 		"elixir":          elixir,
 		"yuck":            yuck,
+		"amnesia":         amnesia,
 	}
+}
+
+// amnesia wipes the automap (C magic.c amnesia) — the priciest thing an
+// unidentified scroll can cost you is what you already knew.
+func amnesia(g *game.Game, it *game.Item) []string {
+	g.ForgetMap()
+	return []string{"You suddenly feel very forgetful."}
 }
 
 // elixir strips every status the C expires — poison, haste, slow, regen,
@@ -149,7 +157,8 @@ func eatMushroom(g *game.Game, it *game.Item) []string {
 // teleport blinks the player to a random spot on the level (an escape hatch).
 func teleport(g *game.Game, it *game.Item) []string {
 	if g.Teleport() {
-		return []string{fmt.Sprintf("You read the %s and blink across the dungeon.", it.Def.Name)}
+		// The C's blink lines (teleport.c cast_blink).
+		return []string{"You blink away...", "Suddenly, you are somewhere else."}
 	}
 	return []string{fmt.Sprintf("You read the %s, but nothing happens.", it.Def.Name)}
 }

--- a/go/internal/behaviors/behaviors_test.go
+++ b/go/internal/behaviors/behaviors_test.go
@@ -355,3 +355,20 @@ func TestYuckIsAllFlavor(t *testing.T) {
 		t.Error("yuck is pure flavor: no effects, no damage")
 	}
 }
+
+func TestAmnesiaWipesTheMap(t *testing.T) {
+	amn, ok := Registry()["amnesia"]
+	if !ok {
+		t.Fatal("amnesia not registered")
+	}
+	floor := &content.TileDef{ID: "floor", Glyph: ".", Color: content.ColorNormal, Passable: true, Transparent: true}
+	g := &game.Game{Level: game.NewLevel(6, 3, floor), Player: game.Pos{X: 1, Y: 1}}
+	g.RevealMap()
+	msgs := amn(g, &game.Item{Def: &content.ItemDef{Name: "scroll of amnesia"}})
+	if g.Level.At(game.Pos{X: 4, Y: 1}).Seen {
+		t.Error("amnesia should wipe the automap (C magic.c)")
+	}
+	if len(msgs) == 0 || msgs[0] != "You suddenly feel very forgetful." {
+		t.Errorf("expected the C message, got %v", msgs)
+	}
+}

--- a/go/internal/game/teleport.go
+++ b/go/internal/game/teleport.go
@@ -18,6 +18,12 @@ func (g *Game) Teleport() bool {
 		return false
 	}
 	g.Player = candidates[g.RNG.Intn(len(candidates))]
+	// A blink springs whatever waits at the destination (C cast_blink's
+	// activate_trap) — unless the traveller is floating above it.
+	if tile := g.Level.At(g.Player).Def; tile.Effect != "" && !g.HasEffect("levitate") {
+		g.AddEffect(tile.Effect, tile.EffectTurns)
+		g.log("You trigger a trap!")
+	}
 	return true
 }
 
@@ -26,5 +32,13 @@ func (g *Game) Teleport() bool {
 func (g *Game) RevealMap() {
 	for i := range g.Level.tiles {
 		g.Level.tiles[i].Seen = true
+	}
+}
+
+// ForgetMap wipes the automap — every tile forgotten, the inverse of RevealMap
+// (C magic.c amnesia: memory[y][x] = gent_blank).
+func (g *Game) ForgetMap() {
+	for i := range g.Level.tiles {
+		g.Level.tiles[i].Seen = false
 	}
 }

--- a/go/internal/game/teleport_test.go
+++ b/go/internal/game/teleport_test.go
@@ -88,3 +88,54 @@ func TestPlayerUseScrollConsumesAndRuns(t *testing.T) {
 		t.Error("a read scroll should be consumed")
 	}
 }
+
+func TestBlinkLandingSpringsTrap(t *testing.T) {
+	g := combatGame()
+	trap := &content.TileDef{ID: "dart_trap", Glyph: "^", Passable: true, Transparent: true, Effect: "poison", EffectTurns: 5}
+	// Every tile the blink can land on is a trap, so the landing is certain.
+	for y := 0; y < g.Level.H; y++ {
+		for x := 0; x < g.Level.W; x++ {
+			p := Pos{X: x, Y: y}
+			if p != g.Player && g.Level.Passable(p) {
+				g.Level.Set(p, trap)
+			}
+		}
+	}
+	if !g.Teleport() {
+		t.Fatal("expected the blink to land somewhere")
+	}
+	if !g.HasEffect("poison") {
+		t.Error("a blink springs the trap it lands on (C cast_blink/activate_trap)")
+	}
+}
+
+func TestFloatingBlinkSkipsLandingTrap(t *testing.T) {
+	g := combatGame()
+	trap := &content.TileDef{ID: "dart_trap", Glyph: "^", Passable: true, Transparent: true, Effect: "poison", EffectTurns: 5}
+	for y := 0; y < g.Level.H; y++ {
+		for x := 0; x < g.Level.W; x++ {
+			p := Pos{X: x, Y: y}
+			if p != g.Player && g.Level.Passable(p) {
+				g.Level.Set(p, trap)
+			}
+		}
+	}
+	g.AddEffect("levitate", 10)
+	g.Teleport()
+	if g.HasEffect("poison") {
+		t.Error("a floater blinks over the trap below (C activate_trap is_floating)")
+	}
+}
+
+func TestForgetMapClearsSeen(t *testing.T) {
+	g := combatGame()
+	g.RevealMap()
+	g.ForgetMap()
+	for y := 0; y < g.Level.H; y++ {
+		for x := 0; x < g.Level.W; x++ {
+			if g.Level.At(Pos{X: x, Y: y}).Seen {
+				t.Fatal("ForgetMap should wipe the automap (C magic.c amnesia)")
+			}
+		}
+	}
+}


### PR DESCRIPTION
## Summary
Plan 15t — two scroll-kit corrections straight from `treasure.h`'s scroll list (identify, magic mapping, trap detection, recharge, **blink**, familiar, mark, recall, **amnesia**, magic weapon):

- **Faithfulness fix**: 0.40 has **no teleportation scroll**. The random-relocation scroll is the **"blink scroll"** (`treasure.c:1178` — that exact name, no "scroll of" prefix), which is precisely the mechanic our mislabeled "scroll of teleportation" shipped. Renamed id + name, the read now uses the C's lines ("You blink away..." / "Suddenly, you are somewhere else."), and the landing **springs whatever trap waits at the destination** (`cast_blink`'s `activate_trap`) — unless you're floating over it, the C's `is_floating` guard.
- **Scroll of amnesia** (`magic.c amnesia`): new `Game.ForgetMap()` (the exact inverse of magic mapping's reveal) wipes the automap; "You suddenly feel very forgetful." It joins the scroll appearance pool, so an unidentified read can now cost you your map.

## Test plan
- A blink onto an all-trap floor springs the landing trap; a floating blink doesn't.
- ForgetMap clears every Seen flag; the amnesia behavior wipes and returns the C line.
- Goldens: `scroll_blink` named "blink scroll", `scroll_amnesia` wired.
- gofmt + go vet + full `go test ./...` green (10/10 packages).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "amnesia scroll" — instantly wipes your entire automap, removing all explored tile knowledge.

* **Updates**
  * "Blink scroll" (redesigned teleport scroll) now activates destination tile effects when you land, including springing traps, unless you're floating.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->