### PR TITLE
Mark & recall scrolls (cross-level teleport home)

### DIFF
--- a/docs/superpowers/plans/2026-06-10-mark-recall-15u.md
+++ b/docs/superpowers/plans/2026-06-10-mark-recall-15u.md
@@ -1,0 +1,44 @@
+# Mark & recall scrolls (15u) Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** The teleport-home pair from 0.40's scroll list: the **mark scroll**
+pins a spot (level + position), the **recall scroll** snaps you back to it —
+across levels. Advances #15.
+
+## C grounding
+- `teleport.c cast_mark`: store `recall_location/recall_y/recall_x`
+  (level + coordinates); "Destination marked.".
+- `teleport.c cast_recall`: `change_level` + place the caster at the mark;
+  "You find yourself back in <level name>.". The C's unmarked recall would
+  land at its zero-initialized location — we fizzle instead ("nothing
+  happens"), the deliberate divergence here.
+- Names (`treasure.c:1192/1199`): "mark scroll" / "recall scroll" — like the
+  blink scroll, no "scroll of" prefix.
+
+## Design
+- `Game.recallLevel string` / `recallPos Pos`; `MarkRecall()` records
+  `Level.ID` + position; `Recall() bool` re-enters the marked level through
+  the Dungeon (persisted cache — same machinery as stairs Travel) and places
+  the player at the mark, nudging one ring outward if a creature now stands
+  there (the C stacks creatures; we don't). Unmarked or no-dungeon → false.
+- Behaviors `mark` / `recall` with the C messages; recall names the level via
+  `LocationName()`. Items `scroll_mark` / `scroll_recall` join the pool.
+
+## Task 1: MarkRecall/Recall engine (TDD)
+**Files:** `internal/game/teleport.go` + tests.
+- Tests first: mark here, walk away, recall returns exactly here (same
+  level); recall across levels via a real two-level dungeon (mark, take
+  stairs, recall → back on the original level at the mark); unmarked recall
+  reports false; an occupied mark nudges to an adjacent tile.
+- Commit: `feat(game): mark/recall — cross-level return to a pinned spot`
+
+## Task 2: behaviors + data + ship
+- Behaviors with C messages; goldens for both defs; full gate; PR; CodeRabbit
+  loop → merge.
+- Commit: `feat(content): mark & recall scrolls`
+
+## Done when
+Read the mark scroll beside the shop-quality loot you can't carry (you're
+burdened, after all), dive deeper, then recall straight back to it from three
+levels down. Suite green.

--- a/go/data/data_test.go
+++ b/go/data/data_test.go
@@ -749,3 +749,18 @@ func TestEmbeddedAmnesiaScroll(t *testing.T) {
 		t.Errorf("scroll_amnesia def unexpected: %+v", s)
 	}
 }
+
+// TestEmbeddedMarkRecall checks the teleport-home pair loaded (15u) — like the
+// blink scroll, 0.40 names them without the "scroll of" prefix.
+func TestEmbeddedMarkRecall(t *testing.T) {
+	c, err := content.Load(Files)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if s := c.Items["scroll_mark"]; s == nil || s.Kind != "scroll" || s.Use != "mark" || s.Name != "mark scroll" {
+		t.Errorf("scroll_mark def unexpected: %+v", s)
+	}
+	if s := c.Items["scroll_recall"]; s == nil || s.Kind != "scroll" || s.Use != "recall" || s.Name != "recall scroll" {
+		t.Errorf("scroll_recall def unexpected: %+v", s)
+	}
+}

--- a/go/data/items.toml
+++ b/go/data/items.toml
@@ -434,3 +434,18 @@ glyph = "?"
 color = "magenta"
 kind = "scroll"
 use = "amnesia"
+
+# The teleport-home pair (15u, C teleport.c cast_mark/cast_recall).
+[item.scroll_mark]
+name = "mark scroll"
+glyph = "?"
+color = "green"
+kind = "scroll"
+use = "mark"
+
+[item.scroll_recall]
+name = "recall scroll"
+glyph = "?"
+color = "brown"
+kind = "scroll"
+use = "recall"

--- a/go/internal/behaviors/behaviors.go
+++ b/go/internal/behaviors/behaviors.go
@@ -35,7 +35,32 @@ func Registry() map[string]game.Behavior {
 		"elixir":          elixir,
 		"yuck":            yuck,
 		"amnesia":         amnesia,
+		"mark":            mark,
+		"recall":          recall,
 	}
+}
+
+// mark pins the spot a recall scroll will return to (C teleport.c cast_mark).
+func mark(g *game.Game, it *game.Item) []string {
+	g.MarkRecall()
+	return []string{"Destination marked."}
+}
+
+// recall snaps the reader back to the mark, across levels (C cast_recall).
+func recall(g *game.Game, it *game.Item) []string {
+	if g.Recall() {
+		return []string{fmt.Sprintf("You find yourself back in %s.", recallPlace(g))}
+	}
+	return []string{fmt.Sprintf("You read the %s, but nothing happens.", it.Def.Name)}
+}
+
+// recallPlace names the arrival level, with a fallback for bare unit-test
+// games that have no dungeon wired.
+func recallPlace(g *game.Game) string {
+	if name := g.LocationName(); name != "" {
+		return name
+	}
+	return "familiar surroundings"
 }
 
 // amnesia wipes the automap (C magic.c amnesia) — the priciest thing an

--- a/go/internal/behaviors/behaviors_test.go
+++ b/go/internal/behaviors/behaviors_test.go
@@ -372,3 +372,39 @@ func TestAmnesiaWipesTheMap(t *testing.T) {
 		t.Errorf("expected the C message, got %v", msgs)
 	}
 }
+
+func TestMarkAndRecallBehaviors(t *testing.T) {
+	mark, ok := Registry()["mark"]
+	if !ok {
+		t.Fatal("mark not registered")
+	}
+	recall, ok := Registry()["recall"]
+	if !ok {
+		t.Fatal("recall not registered")
+	}
+	floor := &content.TileDef{ID: "floor", Glyph: ".", Color: content.ColorNormal, Passable: true, Transparent: true}
+	g := &game.Game{Level: game.NewLevel(8, 3, floor), Player: game.Pos{X: 1, Y: 1}}
+	msgs := mark(g, &game.Item{Def: &content.ItemDef{Name: "mark scroll"}})
+	if len(msgs) == 0 || msgs[0] != "Destination marked." {
+		t.Errorf("expected the C mark message, got %v", msgs)
+	}
+	home := g.Player
+	g.Player = game.Pos{X: 5, Y: 1}
+	msgs = recall(g, &game.Item{Def: &content.ItemDef{Name: "recall scroll"}})
+	if g.Player != home {
+		t.Errorf("recall should return to the mark, at %v", g.Player)
+	}
+	if len(msgs) == 0 || !strings.Contains(msgs[0], "You find yourself back") {
+		t.Errorf("expected the C recall message, got %v", msgs)
+	}
+}
+
+func TestUnmarkedRecallBehaviorFizzles(t *testing.T) {
+	recall := Registry()["recall"]
+	floor := &content.TileDef{ID: "floor", Glyph: ".", Color: content.ColorNormal, Passable: true, Transparent: true}
+	g := &game.Game{Level: game.NewLevel(8, 3, floor), Player: game.Pos{X: 1, Y: 1}}
+	msgs := recall(g, &game.Item{Def: &content.ItemDef{Name: "recall scroll"}})
+	if len(msgs) == 0 || !strings.Contains(msgs[0], "nothing happens") {
+		t.Errorf("unmarked recall should fizzle, got %v", msgs)
+	}
+}

--- a/go/internal/behaviors/behaviors_test.go
+++ b/go/internal/behaviors/behaviors_test.go
@@ -400,7 +400,10 @@ func TestMarkAndRecallBehaviors(t *testing.T) {
 }
 
 func TestUnmarkedRecallBehaviorFizzles(t *testing.T) {
-	recall := Registry()["recall"]
+	recall, ok := Registry()["recall"]
+	if !ok {
+		t.Fatal("recall not registered")
+	}
 	floor := &content.TileDef{ID: "floor", Glyph: ".", Color: content.ColorNormal, Passable: true, Transparent: true}
 	g := &game.Game{Level: game.NewLevel(8, 3, floor), Player: game.Pos{X: 1, Y: 1}}
 	msgs := recall(g, &game.Item{Def: &content.ItemDef{Name: "recall scroll"}})

--- a/go/internal/game/game.go
+++ b/go/internal/game/game.go
@@ -98,9 +98,12 @@ type Game struct {
 	PlayerMax    int
 	EP           int // energy points: the spellcasting resource
 	EPMax        int
-	epTurn       int // counter for slow EP regeneration
-	playerEnergy int // turn-energy surplus banked toward the next action (see advanceWorld)
-	swimFatigue  int // consecutive turns spent in deep water (see swimCheck)
+	epTurn       int    // counter for slow EP regeneration
+	playerEnergy int    // turn-energy surplus banked toward the next action (see advanceWorld)
+	swimFatigue  int    // consecutive turns spent in deep water (see swimCheck)
+	recallLevel  string // level id pinned by a mark scroll (see MarkRecall/Recall)
+	recallPos    Pos
+	recallSet    bool
 	Messages     []string
 	Dead         bool
 	Inventory    []*Item

--- a/go/internal/game/teleport.go
+++ b/go/internal/game/teleport.go
@@ -60,7 +60,9 @@ func (g *Game) Recall() bool {
 	if !g.recallSet {
 		return false
 	}
-	if g.recallLevel != g.Level.ID {
+	fromID := g.Level.ID
+	switched := false
+	if g.recallLevel != fromID {
 		if g.Dungeon == nil {
 			return false
 		}
@@ -70,22 +72,36 @@ func (g *Game) Recall() bool {
 		}
 		g.Level = g.Dungeon.Current()
 		g.Level.entered = true
+		switched = true
 	}
-	dst := g.recallPos
-	if g.Level.CreatureAt(dst) != nil {
-		nudged := false
-		for dy := -1; dy <= 1 && !nudged; dy++ {
-			for dx := -1; dx <= 1 && !nudged; dx++ {
-				p := Pos{X: dst.X + dx, Y: dst.Y + dy}
-				if p != dst && g.Level.Passable(p) && g.Level.CreatureAt(p) == nil {
-					dst, nudged = p, true
-				}
-			}
+	dst, ok := g.freeSpotNear(g.recallPos)
+	if !ok {
+		// The mark is buried in bodies. A fizzle must leave no trace, so
+		// undo the level switch (re-entering a cached level cannot fail).
+		if switched {
+			g.Dungeon.enter(fromID)
+			g.Level = g.Dungeon.Current()
+			g.Player = g.Level.Return
 		}
-		if !nudged {
-			return false // the mark is buried in bodies; nowhere to appear
-		}
+		return false
 	}
 	g.Player = dst
 	return true
+}
+
+// freeSpotNear returns p itself when unoccupied, else a free passable tile one
+// ring outward; ok is false when every candidate is taken.
+func (g *Game) freeSpotNear(p Pos) (Pos, bool) {
+	if g.Level.CreatureAt(p) == nil {
+		return p, true
+	}
+	for dy := -1; dy <= 1; dy++ {
+		for dx := -1; dx <= 1; dx++ {
+			q := Pos{X: p.X + dx, Y: p.Y + dy}
+			if q != p && g.Level.Passable(q) && g.Level.CreatureAt(q) == nil {
+				return q, true
+			}
+		}
+	}
+	return Pos{}, false
 }

--- a/go/internal/game/teleport.go
+++ b/go/internal/game/teleport.go
@@ -42,3 +42,50 @@ func (g *Game) ForgetMap() {
 		g.Level.tiles[i].Seen = false
 	}
 }
+
+// MarkRecall pins the player's current level and position as the recall
+// destination (C teleport.c cast_mark).
+func (g *Game) MarkRecall() {
+	g.recallLevel = g.Level.ID
+	g.recallPos = g.Player
+	g.recallSet = true
+}
+
+// Recall snaps the player back to the pinned mark, crossing levels through the
+// Dungeon's persisted cache like stairs do (C cast_recall's change_level). It
+// reports whether the recall happened: with no mark set it fizzles — the C
+// would land at its zero-initialized location; we decline instead. If a
+// creature now stands on the mark, the player lands one ring outward.
+func (g *Game) Recall() bool {
+	if !g.recallSet {
+		return false
+	}
+	if g.recallLevel != g.Level.ID {
+		if g.Dungeon == nil {
+			return false
+		}
+		g.Level.Return = g.Player
+		if err := g.Dungeon.enter(g.recallLevel); err != nil {
+			return false
+		}
+		g.Level = g.Dungeon.Current()
+		g.Level.entered = true
+	}
+	dst := g.recallPos
+	if g.Level.CreatureAt(dst) != nil {
+		nudged := false
+		for dy := -1; dy <= 1 && !nudged; dy++ {
+			for dx := -1; dx <= 1 && !nudged; dx++ {
+				p := Pos{X: dst.X + dx, Y: dst.Y + dy}
+				if p != dst && g.Level.Passable(p) && g.Level.CreatureAt(p) == nil {
+					dst, nudged = p, true
+				}
+			}
+		}
+		if !nudged {
+			return false // the mark is buried in bodies; nowhere to appear
+		}
+	}
+	g.Player = dst
+	return true
+}

--- a/go/internal/game/teleport_test.go
+++ b/go/internal/game/teleport_test.go
@@ -139,3 +139,58 @@ func TestForgetMapClearsSeen(t *testing.T) {
 		}
 	}
 }
+
+func TestMarkAndRecallSameLevel(t *testing.T) {
+	g := fakeDungeon(t)
+	g.MarkRecall()
+	mark := g.Player
+	g.Player = Pos{2, 1} // wander off
+	if !g.Recall() {
+		t.Fatal("a marked recall should succeed")
+	}
+	if g.Player != mark {
+		t.Errorf("recall should return to the mark %v, got %v", mark, g.Player)
+	}
+}
+
+func TestRecallAcrossLevels(t *testing.T) {
+	g := fakeDungeon(t)
+	mark := g.Player
+	g.MarkRecall()
+	g.Player = Pos{3, 1}
+	g.Travel() // descend to B
+	if g.Dungeon.current != "b" {
+		t.Fatal("setup: expected to be on B")
+	}
+	if !g.Recall() {
+		t.Fatal("recall should pull the player back across levels (C change_level)")
+	}
+	if g.Dungeon.current != "a" || g.Player != mark {
+		t.Errorf("recall should land on A at %v, got level %q at %v", mark, g.Dungeon.current, g.Player)
+	}
+}
+
+func TestUnmarkedRecallFizzles(t *testing.T) {
+	g := fakeDungeon(t)
+	if g.Recall() {
+		t.Error("recall with no mark set must fizzle (we diverge from the C's zero-init landing)")
+	}
+}
+
+func TestRecallNudgesOffOccupiedMark(t *testing.T) {
+	g := fakeDungeon(t)
+	g.MarkRecall()
+	mark := g.Player
+	g.Player = Pos{3, 1}
+	squatter := &Creature{Def: &content.MonsterDef{ID: "rat", Name: "rat", Glyph: "r", HP: 3}, Pos: mark, HP: 3}
+	g.Level.Creatures = append(g.Level.Creatures, squatter)
+	if !g.Recall() {
+		t.Fatal("an occupied mark should still recall, one tile off")
+	}
+	if g.Player == mark {
+		t.Error("the player must not land inside the squatter")
+	}
+	if d := chebyshev(g.Player, mark); d != 1 {
+		t.Errorf("expected a one-ring nudge, landed %d away", d)
+	}
+}

--- a/go/internal/game/teleport_test.go
+++ b/go/internal/game/teleport_test.go
@@ -194,3 +194,25 @@ func TestRecallNudgesOffOccupiedMark(t *testing.T) {
 		t.Errorf("expected a one-ring nudge, landed %d away", d)
 	}
 }
+
+func TestBuriedMarkRollsBackLevelSwitch(t *testing.T) {
+	g := fakeDungeon(t)
+	g.MarkRecall()
+	mark := g.Player
+	// Bury the mark and its whole ring in bodies on level A.
+	for dy := -1; dy <= 1; dy++ {
+		for dx := -1; dx <= 1; dx++ {
+			p := Pos{X: mark.X + dx, Y: mark.Y + dy}
+			g.Level.Creatures = append(g.Level.Creatures, &Creature{Def: &content.MonsterDef{ID: "rat", Glyph: "r", HP: 1}, Pos: p, HP: 1})
+		}
+	}
+	g.Player = Pos{3, 1}
+	g.Travel() // over to B
+	before := g.Player
+	if g.Recall() {
+		t.Fatal("a fully buried mark must fizzle")
+	}
+	if g.Dungeon.current != "b" || g.Player != before {
+		t.Errorf("a fizzled recall must leave no trace: on %q at %v", g.Dungeon.current, g.Player)
+	}
+}


### PR DESCRIPTION
## Summary
Plan 15u — the teleport-home pair from 0.40's scroll list (`teleport.c`):

- **Mark scroll** (`cast_mark`): pins the current level + position ("Destination marked.").
- **Recall scroll** (`cast_recall`): snaps the reader back to the pin — **across levels**, re-entering through the Dungeon's persisted cache exactly like stairs Travel, so the marked level's state (dead monsters, dropped loot) is intact on arrival. "You find yourself back in <level>."
- Deliberate divergences, documented in the plan: an **unmarked recall fizzles** (the C would land at its zero-initialized location); a mark **occupied by a creature nudges** the player one ring outward (the C stacks creatures on one tile).
- Names per `treasure.c:1192/1199`: "mark scroll" / "recall scroll" — no "scroll of" prefix, same as blink.

## Test plan
- Same-level mark→wander→recall returns exactly to the pin; cross-level via a real two-level dungeon (mark on A, stairs to B, recall lands on A at the pin).
- Unmarked recall returns false / "nothing happens"; an occupied pin lands the player exactly one tile off.
- Behavior messages match the C; goldens for both prefix-less names.
- gofmt + go vet + full `go test ./...` green (10/10 packages).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added mark and recall scrolls; players can mark a location and teleport back, including across dungeon levels.
  * Recall will nudge you if the marked tile is occupied and fails gracefully if unmarked or fully blocked.

* **Documentation**
  * Added implementation plan for mark-and-recall mechanics.

* **Tests**
  * Added unit and integration coverage for mark/recall behaviors and edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->