### PR TITLE
Hidden traps + trap detection scroll

### DIFF
--- a/docs/superpowers/plans/2026-06-10-hidden-traps-18d.md
+++ b/docs/superpowers/plans/2026-06-10-hidden-traps-18d.md
@@ -1,0 +1,53 @@
+# Hidden traps + trap detection scroll (18d) Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Port 0.40's trap concealment: traps start **unrevealed** and render
+as plain floor until they spring, are spotted, or a **trap detection scroll**
+exposes them. Fixes a known divergence (our traps were always visible) and
+ships scroll 8 of 10. Advances #18 + #15.
+
+## C grounding
+- `traps.c`: a trap starts `revealed = false` with `difficulty = roll(2,6)`;
+  activating reveals it (`traps.c:330`).
+- `game.c try_to_detect_traps` (passive, per turn): a *visible* unrevealed
+  trap is spotted when `perception + s_trap_detection > difficulty`; the
+  player's perception is 3 (`player.c:1265`), so only the flimsiest traps
+  betray themselves on sight.
+- `magic.c reveal_traps` (the scroll): every unrevealed trap on the level is
+  exposed and written to the automap; "You sense the presence of traps.".
+- `treasure.c:1164`: named "trap detection scroll" (prefix-less, like blink/
+  mark/recall).
+
+## Design
+- `game.Tile` gains `Disguise *content.TileDef`, `Revealed bool`, and
+  `TrapDifficulty int` (instance state alongside Visible/Seen). New
+  `Tile.Appears()` returns the Disguise while unrevealed, else the real def;
+  `ui.BuildView` renders `Appears()` — the seam also fits future secret
+  doors. Zero values keep every existing tile untouched.
+- gen `placeTraps`: traps go down disguised as floor with difficulty 2d6.
+- A shared `g.springTrapAt(p)` (reveal + effect + "You trigger a trap!")
+  replaces the three duplicated trigger sites (step, landing, blink).
+- Passive spotting in `passTurn`: visible disguised tiles reveal when
+  `playerPerception (3) > TrapDifficulty`, the C's strict inequality.
+- `Game.RevealTraps() int` exposes (and maps) every disguised tile; behavior
+  `detect_traps` + `scroll_trap_detection` with the C message.
+
+## Task 1: disguise/reveal engine + passive spotting (TDD)
+**Files:** `internal/game/{game,combat,effects,teleport,fov}.go` + tests,
+`internal/ui/ui.go` + test.
+- Tests first: a disguised trap renders as floor and springs+reveals on step
+  (then renders as itself); difficulty 12 stays unseen while visible,
+  difficulty 2 is spotted on sight; landing and blink reveal too;
+  `RevealTraps` exposes all and returns the count.
+- Commit: `feat(game): hidden traps — disguise, spring-reveal, passive spotting`
+
+## Task 2: gen difficulty + scroll + ship
+**Files:** `internal/gen/gen.go` + test, behaviors + data + goldens.
+- gen rolls 2d6 per trap and disguises it; scroll behavior + def.
+- Commit: `feat(content): trap detection scroll`
+- Full gate; push, PR, CodeRabbit loop → merge.
+
+## Done when
+The floor ahead looks innocent — until your boot finds the plate, your landing
+springs it, or one scroll lights up every needle on the level. Suite green.

--- a/go/data/data_test.go
+++ b/go/data/data_test.go
@@ -764,3 +764,15 @@ func TestEmbeddedMarkRecall(t *testing.T) {
 		t.Errorf("scroll_recall def unexpected: %+v", s)
 	}
 }
+
+// TestEmbeddedTrapDetection checks scroll 8 of 10 loaded (18d) — prefix-less
+// 0.40 name, like blink/mark/recall.
+func TestEmbeddedTrapDetection(t *testing.T) {
+	c, err := content.Load(Files)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if s := c.Items["scroll_trap_detection"]; s == nil || s.Kind != "scroll" || s.Use != "detect_traps" || s.Name != "trap detection scroll" {
+		t.Errorf("scroll_trap_detection def unexpected: %+v", s)
+	}
+}

--- a/go/data/items.toml
+++ b/go/data/items.toml
@@ -449,3 +449,12 @@ glyph = "?"
 color = "brown"
 kind = "scroll"
 use = "recall"
+
+# Scroll 8 of 10 (18d, C magic.c reveal_traps): every needle on the level,
+# lit up at once.
+[item.scroll_trap_detection]
+name = "trap detection scroll"
+glyph = "?"
+color = "red"
+kind = "scroll"
+use = "detect_traps"

--- a/go/internal/behaviors/behaviors.go
+++ b/go/internal/behaviors/behaviors.go
@@ -37,7 +37,15 @@ func Registry() map[string]game.Behavior {
 		"amnesia":         amnesia,
 		"mark":            mark,
 		"recall":          recall,
+		"detect_traps":    detectTraps,
 	}
+}
+
+// detectTraps lights up every hidden trap on the level (C magic.c
+// reveal_traps; the C queues its message whether or not anything was found).
+func detectTraps(g *game.Game, it *game.Item) []string {
+	g.RevealTraps()
+	return []string{"You sense the presence of traps."}
 }
 
 // mark pins the spot a recall scroll will return to (C teleport.c cast_mark).

--- a/go/internal/behaviors/behaviors_test.go
+++ b/go/internal/behaviors/behaviors_test.go
@@ -411,3 +411,24 @@ func TestUnmarkedRecallBehaviorFizzles(t *testing.T) {
 		t.Errorf("unmarked recall should fizzle, got %v", msgs)
 	}
 }
+
+func TestDetectTrapsBehaviorRevealsAll(t *testing.T) {
+	detect, ok := Registry()["detect_traps"]
+	if !ok {
+		t.Fatal("detect_traps not registered")
+	}
+	floor := &content.TileDef{ID: "floor", Glyph: ".", Color: content.ColorNormal, Passable: true, Transparent: true}
+	trap := &content.TileDef{ID: "dart_trap", Glyph: "^", Color: content.ColorRed, Passable: true, Transparent: true, Effect: "poison", EffectTurns: 5}
+	g := &game.Game{Level: game.NewLevel(6, 3, floor), Player: game.Pos{X: 1, Y: 1}}
+	g.Level.Set(game.Pos{X: 4, Y: 1}, trap)
+	tile := g.Level.At(game.Pos{X: 4, Y: 1})
+	tile.Disguise = floor
+	tile.TrapDifficulty = 12
+	msgs := detect(g, &game.Item{Def: &content.ItemDef{Name: "trap detection scroll"}})
+	if !tile.Revealed {
+		t.Error("the scroll exposes every trap on the level (C reveal_traps)")
+	}
+	if len(msgs) == 0 || msgs[0] != "You sense the presence of traps." {
+		t.Errorf("expected the C message, got %v", msgs)
+	}
+}

--- a/go/internal/game/combat.go
+++ b/go/internal/game/combat.go
@@ -96,8 +96,7 @@ func (g *Game) PlayerStep(d Direction) {
 		if tile.Effect != "" && !g.HasEffect("levitate") {
 			// A floater glides over floor traps (C activate_trap); Win above
 			// already fired regardless, the C's trap_win exception.
-			g.AddEffect(tile.Effect, tile.EffectTurns)
-			g.log("You trigger a trap!")
+			g.springTrapAt(g.Player)
 		}
 	} else if g.openDoor(dst) { // blocked by a closed door: open it (costs the turn)
 		g.log("You open the door.")
@@ -272,11 +271,38 @@ func (g *Game) advanceWorld() {
 // playerEnergy holds the player's surplus beyond the turn just taken (the C's
 // move_counter minus TURN_TIME), so at base speed exactly one tick passes; a
 // slowed player owes two, and a hasted player sometimes none (a free action).
+// playerPerception is the player's trap-spotting sense (C player.c:1265):
+// only traps flimsier than it betray themselves on sight.
+const playerPerception = 3
+
+// springTrapAt reveals the trap at p and inflicts its effect — the one
+// trigger path shared by stepping, landing, and blinking (C activate_trap).
+func (g *Game) springTrapAt(p Pos) {
+	tile := g.Level.At(p)
+	tile.Revealed = true
+	if tile.Def.Effect != "" {
+		g.AddEffect(tile.Def.Effect, tile.Def.EffectTurns)
+		g.log("You trigger a trap!")
+	}
+}
+
+// spotTraps is the C's try_to_detect_traps: each turn, a visible unrevealed
+// trap is spotted when the player's perception beats its difficulty.
+func (g *Game) spotTraps() {
+	for i := range g.Level.tiles {
+		t := &g.Level.tiles[i]
+		if t.Disguise != nil && !t.Revealed && t.Visible && playerPerception > t.TrapDifficulty {
+			t.Revealed = true
+		}
+	}
+}
+
 func (g *Game) passTurn() {
 	g.swimCheck()
 	if g.Dead {
 		return // drowned
 	}
+	g.spotTraps()
 	g.tickEffects()
 	if g.Dead {
 		return // status effects (e.g. poison) killed the player

--- a/go/internal/game/effects.go
+++ b/go/internal/game/effects.go
@@ -161,8 +161,7 @@ func (g *Game) land() {
 	}
 	g.log("You land on the ground.")
 	if tile.Effect != "" {
-		g.AddEffect(tile.Effect, tile.EffectTurns)
-		g.log("You trigger a trap!")
+		g.springTrapAt(g.Player)
 	}
 }
 

--- a/go/internal/game/game.go
+++ b/go/internal/game/game.go
@@ -51,10 +51,25 @@ func (d Direction) Delta() (int, int) {
 
 // Tile is a single map cell. Visible is true when currently in the player's
 // FOV; Seen is true once it has ever been visible (remembered/dimmed).
+// A tile with a Disguise renders as that def until Revealed — 0.40's hidden
+// traps (and a ready seam for secret doors); TrapDifficulty is the 2d6 score
+// passive spotting must beat (C traps.c).
 type Tile struct {
-	Def     *content.TileDef
-	Visible bool
-	Seen    bool
+	Def            *content.TileDef
+	Visible        bool
+	Seen           bool
+	Disguise       *content.TileDef
+	Revealed       bool
+	TrapDifficulty int
+}
+
+// Appears returns the def this tile shows: the Disguise while unrevealed,
+// otherwise the real thing.
+func (t *Tile) Appears() *content.TileDef {
+	if t.Disguise != nil && !t.Revealed {
+		return t.Disguise
+	}
+	return t.Def
 }
 
 // Level is a rectangular grid of tiles stored row-major.

--- a/go/internal/game/hidden_trap_test.go
+++ b/go/internal/game/hidden_trap_test.go
@@ -1,0 +1,96 @@
+package game
+
+import (
+	"testing"
+
+	"github.com/c0ze/tsl/internal/content"
+)
+
+var testTrapDef = &content.TileDef{ID: "dart_trap", Glyph: "^", Passable: true, Transparent: true, Effect: "poison", EffectTurns: 5}
+var testFloorDef = &content.TileDef{ID: "floor", Glyph: ".", Passable: true, Transparent: true}
+
+// hideTrap plants a disguised trap of the given difficulty at p.
+func hideTrap(g *Game, p Pos, difficulty int) *Tile {
+	g.Level.Set(p, testTrapDef)
+	t := g.Level.At(p)
+	t.Disguise = testFloorDef
+	t.TrapDifficulty = difficulty
+	return t
+}
+
+func TestDisguisedTrapAppearsAsFloor(t *testing.T) {
+	g := combatGame()
+	tile := hideTrap(g, Pos{2, 1}, 8)
+	if tile.Appears() != testFloorDef {
+		t.Error("an unrevealed trap wears the floor's face (C: traps render only once revealed)")
+	}
+	tile.Revealed = true
+	if tile.Appears() != testTrapDef {
+		t.Error("a revealed trap shows itself")
+	}
+}
+
+func TestSteppingSpringsAndReveals(t *testing.T) {
+	g := combatGame()
+	tile := hideTrap(g, Pos{2, 1}, 8)
+	g.PlayerStep(DirE)
+	if !g.HasEffect("poison") {
+		t.Error("stepping on the hidden trap springs it")
+	}
+	if !tile.Revealed {
+		t.Error("springing reveals the trap (C traps.c:330)")
+	}
+}
+
+func TestPassiveSpottingRespectsDifficulty(t *testing.T) {
+	g := combatGame()
+	easy := hideTrap(g, Pos{4, 1}, 2)  // perception 3 > 2: spotted on sight
+	hard := hideTrap(g, Pos{6, 1}, 12) // 3 > 12 never holds
+	easy.Visible, hard.Visible = true, true
+	g.advanceWorld()
+	if !easy.Revealed {
+		t.Error("a flimsy visible trap is spotted (C try_to_detect_traps)")
+	}
+	if hard.Revealed {
+		t.Error("a well-made trap stays hidden in plain sight")
+	}
+}
+
+func TestUnseenTrapNotSpotted(t *testing.T) {
+	g := combatGame()
+	easy := hideTrap(g, Pos{4, 1}, 2)
+	easy.Visible = false // out of the FOV
+	g.advanceWorld()
+	if easy.Revealed {
+		t.Error("spotting requires line of sight (C: can_see gate)")
+	}
+}
+
+func TestRevealTrapsExposesAll(t *testing.T) {
+	g := combatGame()
+	a := hideTrap(g, Pos{4, 1}, 12)
+	b := hideTrap(g, Pos{6, 1}, 12)
+	b.Revealed = true // already known: not counted again
+	if n := g.RevealTraps(); n != 1 {
+		t.Errorf("RevealTraps should count newly exposed traps, got %d", n)
+	}
+	if !a.Revealed || !a.Seen {
+		t.Error("the scroll exposes and maps every trap (C reveal_traps writes to memory)")
+	}
+}
+
+func TestBlinkLandingRevealsTrap(t *testing.T) {
+	g := combatGame()
+	for y := 0; y < g.Level.H; y++ {
+		for x := 0; x < g.Level.W; x++ {
+			p := Pos{X: x, Y: y}
+			if p != g.Player && g.Level.Passable(p) {
+				hideTrap(g, p, 12)
+			}
+		}
+	}
+	g.Teleport()
+	if !g.Level.At(g.Player).Revealed {
+		t.Error("a blink landing springs and reveals the trap under it")
+	}
+}

--- a/go/internal/game/teleport.go
+++ b/go/internal/game/teleport.go
@@ -21,8 +21,7 @@ func (g *Game) Teleport() bool {
 	// A blink springs whatever waits at the destination (C cast_blink's
 	// activate_trap) — unless the traveller is floating above it.
 	if tile := g.Level.At(g.Player).Def; tile.Effect != "" && !g.HasEffect("levitate") {
-		g.AddEffect(tile.Effect, tile.EffectTurns)
-		g.log("You trigger a trap!")
+		g.springTrapAt(g.Player)
 	}
 	return true
 }
@@ -41,6 +40,21 @@ func (g *Game) ForgetMap() {
 	for i := range g.Level.tiles {
 		g.Level.tiles[i].Seen = false
 	}
+}
+
+// RevealTraps exposes every disguised, unrevealed trap on the level and puts
+// it on the automap (C magic.c reveal_traps), returning how many were found.
+func (g *Game) RevealTraps() int {
+	found := 0
+	for i := range g.Level.tiles {
+		t := &g.Level.tiles[i]
+		if t.Disguise != nil && !t.Revealed {
+			t.Revealed = true
+			t.Seen = true
+			found++
+		}
+	}
+	return found
 }
 
 // MarkRecall pins the player's current level and position as the recall

--- a/go/internal/gen/gen.go
+++ b/go/internal/gen/gen.go
@@ -425,7 +425,13 @@ func placeTraps(r *rng.MT, c *content.Content, lvl *game.Level, rooms []rect, n 
 		if lvl.At(pos).Def.ID != "floor" {
 			continue // don't overwrite stairs, the altar, etc.
 		}
+		floor := lvl.At(pos).Def
 		lvl.Set(pos, trap)
+		// Traps go down hidden, disguised as the floor they replaced, with a
+		// 2d6 difficulty for passive spotting (C traps.c roll(2,6)).
+		t := lvl.At(pos)
+		t.Disguise = floor
+		t.TrapDifficulty = 2 + r.Intn(6) + r.Intn(6)
 	}
 }
 

--- a/go/internal/gen/gen_test.go
+++ b/go/internal/gen/gen_test.go
@@ -459,3 +459,32 @@ func chebyshevDist(a, b game.Pos) int {
 	}
 	return dy
 }
+
+func TestPlacedTrapsAreDisguised(t *testing.T) {
+	c := levelDefContent()
+	c.Tiles["dart_trap"] = &content.TileDef{ID: "dart_trap", Glyph: "^", Color: content.ColorRed, Passable: true, Transparent: true, Effect: "poison", EffectTurns: 5}
+	def := &content.LevelDef{ID: "x", Name: "X", W: 60, H: 24, Links: []string{"y"}, Traps: 8}
+	lvl, err := LevelFromDef(rng.NewWithSeed(3), c, def)
+	if err != nil {
+		t.Fatal(err)
+	}
+	traps := 0
+	for y := 0; y < lvl.H; y++ {
+		for x := 0; x < lvl.W; x++ {
+			tile := lvl.At(game.Pos{X: x, Y: y})
+			if tile.Def.Effect == "" {
+				continue
+			}
+			traps++
+			if tile.Disguise == nil || tile.Revealed {
+				t.Errorf("trap at %d,%d should be placed hidden", x, y)
+			}
+			if tile.TrapDifficulty < 2 || tile.TrapDifficulty > 12 {
+				t.Errorf("trap difficulty should be 2d6, got %d", tile.TrapDifficulty)
+			}
+		}
+	}
+	if traps == 0 {
+		t.Fatal("expected traps placed")
+	}
+}

--- a/go/internal/ui/ui.go
+++ b/go/internal/ui/ui.go
@@ -85,11 +85,12 @@ func BuildView(g *game.Game) View {
 	for y := 0; y < l.H; y++ {
 		for x := 0; x < l.W; x++ {
 			t := l.At(game.Pos{X: x, Y: y})
+			def := t.Appears() // an unrevealed trap wears its disguise
 			switch {
 			case t.Visible:
-				*v.At(x, y) = Cell{Glyph: t.Def.Rune(), Color: t.Def.Color}
+				*v.At(x, y) = Cell{Glyph: def.Rune(), Color: def.Color}
 			case t.Seen:
-				*v.At(x, y) = Cell{Glyph: t.Def.Rune(), Color: t.Def.Color, Dim: true}
+				*v.At(x, y) = Cell{Glyph: def.Rune(), Color: def.Color, Dim: true}
 			default:
 				*v.At(x, y) = Cell{Glyph: ' ', Color: content.ColorNormal}
 			}

--- a/go/internal/ui/ui_test.go
+++ b/go/internal/ui/ui_test.go
@@ -448,3 +448,23 @@ func TestRunEatWithNoFoodReports(t *testing.T) {
 		t.Errorf("expected a 'nothing to eat' message, got %v", g.Messages)
 	}
 }
+
+func TestBuildViewHidesDisguisedTraps(t *testing.T) {
+	g := testGame(t, []string{".@."})
+	trap := &content.TileDef{ID: "dart_trap", Glyph: "^", Color: content.ColorRed, Passable: true, Transparent: true, Effect: "poison", EffectTurns: 5}
+	floor := &content.TileDef{ID: "floor", Glyph: ".", Color: content.ColorNormal, Passable: true, Transparent: true}
+	pos := game.Pos{X: 2, Y: 0}
+	g.Level.Set(pos, trap)
+	tile := g.Level.At(pos)
+	tile.Disguise = floor
+	tile.Visible = true
+	v := BuildView(g)
+	if got := v.At(2, 0).Glyph; got != '.' {
+		t.Errorf("an unrevealed trap should render as floor, got %q", got)
+	}
+	tile.Revealed = true
+	v = BuildView(g)
+	if got := v.At(2, 0).Glyph; got != '^' {
+		t.Errorf("a revealed trap should show itself, got %q", got)
+	}
+}


### PR DESCRIPTION
## Summary
Plan 18d — ports 0.40's trap concealment, fixing a known divergence (our traps were always visible) and shipping scroll 8 of 10:

- **Tile disguises**: tiles gain `Disguise`/`Revealed`/`TrapDifficulty` instance state; `Tile.Appears()` returns the disguise until revealed and `ui.BuildView` renders through it — an unrevealed dart trap looks like the floor it replaced. (The same seam will serve secret doors.)
- **One trigger path**: `springTrapAt` (reveal + effect) now serves stepping, levitation landings, and blink arrivals — all reveal, per `traps.c:330`.
- **Passive spotting** (`game.c try_to_detect_traps`): each turn, a *visible* unrevealed trap is spotted when the player's perception (3, `player.c:1265`) beats its difficulty — rolled 2d6 at generation (`traps.c roll(2,6)`), so only the flimsiest traps betray themselves on sight.
- **Trap detection scroll** (`magic.c reveal_traps`, name per `treasure.c:1164` — prefix-less like blink/mark/recall): exposes and maps every trap on the level; "You sense the presence of traps." (queued unconditionally, as in the C).

## Test plan
- Disguised trap renders as floor and as itself once revealed (ui test); stepping/landing/blinking each spring **and** reveal.
- Difficulty 2 is spotted on sight, 12 never; spotting requires visibility.
- `RevealTraps` counts only newly exposed traps and maps them; gen test: all placed traps hidden with 2d6 difficulties.
- gofmt + go vet + full `go test ./...` green (10/10 packages).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Traps now start hidden and appear as regular floor tiles until detected
  * Trap Detection Scroll item added—use it to instantly reveal all traps on the current level
  * Passive trap spotting: your character's perception can automatically reveal nearby hidden traps based on their difficulty
  * Traps are revealed when you step on them or successfully detect them

* **Documentation**
  * Added implementation planning for trap concealment mechanics

<!-- end of auto-generated comment: release notes by coderabbit.ai -->