### PR TITLE
Lava (the hazard pair's second half)

### DIFF
--- a/docs/superpowers/plans/2026-06-10-lava-18e.md
+++ b/docs/superpowers/plans/2026-06-10-lava-18e.md
@@ -1,0 +1,49 @@
+# Lava (18e) Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** The hazard-terrain pair's second half: **lava** — water's machinery
+(impassable pools, blind stumbles, levitation crossings, landing rules) with
+fire instead of fatigue. Advances #18.
+
+## C grounding
+- `tiles.c:43`: lava is `walkable=false`, transparent; glyph `^`
+  (`glyph.c:58`) — 0.40 renders lava *and every trap* as `^` (`glyph.c:65-73`);
+  our color layer tells them apart (trap red, lava brown).
+- `elements.c lava_bath`: standing in lava (not floating) burns `1d6+1`
+  (`LAVA_DAMAGE`, `rules.h:53`) — every turn, no fatigue grace; "You get
+  burned by lava!"; death "melted in a pool of lava" (our noun: "lava").
+- `altitude.c:71-78`: levitation expiring over lava lands you in it —
+  "You land in lava!" then the bath.
+- `creature.c move_creature`: same entry rules as water (blinded stumble in,
+  floaters cross, nobody walks in); no monster in our roster enters lava.
+- `places.c:352`: only the Dragons Lair has lava — `10 + rnd%10` pools of
+  `5 + rnd%9` tiles (`content.c`, the smaller cloud).
+
+## Design
+- `TileDef.Lava bool` + `[tile.lava]` (`^` brown, impassable, transparent).
+- `PlayerStep`'s stumble branch and `land()` extend to lava (the C messages);
+  a new `lavaCheck` beside `swimCheck` in `passTurn` burns 1d6+1 per turn,
+  cause "lava". Floaters are exempt everywhere, like the C.
+- `LevelDef.Lava int` + parallel validation (lava set ⇒ lava tile defined);
+  gen reuses `placePools` with the tile, count, and 5–13 blob size
+  parameterized; dragons_lair gets `lava = 12`.
+
+## Task 1: lava mechanics (TDD)
+**Files:** `internal/game/{combat,effects}.go`, `internal/game/swim_test.go`
+(extend), `internal/content/content.go`.
+- Tests first: blind stumble into lava starts burning 1d6+1 per turn (seeded);
+  floating crosses unburned; levitation expiry over lava logs the C landing
+  line and burns; death cause "lava".
+- Commit: `feat(game): lava — burn-per-turn terrain with the water entry rules`
+
+## Task 2: gen pools + data + ship
+**Files:** `internal/gen/gen.go` + test, `data/{tiles,levels}.toml`, goldens.
+- Parameterize the pool carver; dragons_lair 12 lava pools; validation.
+- Commit: `feat(content): lava pools in the Dragons Lair`
+- Full gate; push, PR, CodeRabbit loop → merge.
+
+## Done when
+The Dragons Lair floor is veined with `^` that ends careless blind steps and
+mistimed levitation in 1d6+1 per turn — and the dragon didn't need any of it
+to be dangerous. Suite green.

--- a/go/data/data_test.go
+++ b/go/data/data_test.go
@@ -776,3 +776,18 @@ func TestEmbeddedTrapDetection(t *testing.T) {
 		t.Errorf("scroll_trap_detection def unexpected: %+v", s)
 	}
 }
+
+// TestEmbeddedLava checks the molten half of the hazard pair loaded (18e):
+// only the Dragons Lair runs with lava (C places.c:352).
+func TestEmbeddedLava(t *testing.T) {
+	c, err := content.Load(Files)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if l := c.Tiles["lava"]; l == nil || !l.Lava || l.Passable || !l.Transparent {
+		t.Errorf("lava tile def unexpected: %+v", l)
+	}
+	if l := c.Levels["dragons_lair"]; l == nil || l.Lava != 12 {
+		t.Errorf("dragons_lair should run with 12 lava pools, got %+v", l)
+	}
+}

--- a/go/data/levels.toml
+++ b/go/data/levels.toml
@@ -296,6 +296,7 @@ width = 60
 height = 24
 links = ["chapel", "drowned_city", "frozen_vault"]
 monsters = 14
+lava = 12
 boss = "dragon"
 traps = 5
 [[level.dragons_lair.spawn]]

--- a/go/data/tiles.toml
+++ b/go/data/tiles.toml
@@ -58,3 +58,12 @@ color = "blue"
 passable = false
 transparent = true
 water = true
+
+# Molten rock (#18e, C tiles.c/elements.c): impassable on foot, burns 1d6+1
+# per turn. 0.40 renders lava and every trap as '^'; our colors differ them.
+[tile.lava]
+glyph = "^"
+color = "brown"
+passable = false
+transparent = true
+lava = true

--- a/go/internal/content/content.go
+++ b/go/internal/content/content.go
@@ -40,6 +40,7 @@ type TileDef struct {
 	Transparent bool   `toml:"transparent"`
 	Win         bool   `toml:"win"`          // stepping onto this tile wins (the ascension altar)
 	Water       bool   `toml:"water"`        // deep water: impassable on foot, drowns waders (#18)
+	Lava        bool   `toml:"lava"`         // molten rock: impassable on foot, burns per turn (#18)
 	Effect      string `toml:"effect"`       // status effect applied when stepped on ("" = none)
 	EffectTurns int    `toml:"effect_turns"` // duration of Effect
 	OpensTo     string `toml:"opens_to"`     // tile id this becomes when opened ("" = not a door)

--- a/go/internal/content/content.go
+++ b/go/internal/content/content.go
@@ -138,6 +138,7 @@ type LevelDef struct {
 	RetinueCount int          `toml:"retinue_count"` // how many escorts (C encounter_lurker spawns 8)
 	Traps        int          `toml:"traps"`         // number of dart_trap tiles to scatter
 	Water        int          `toml:"water"`         // number of water pools to carve (C level->water)
+	Lava         int          `toml:"lava"`          // number of lava pools to carve (C level->lava)
 	Doors        bool         `toml:"doors"`         // place closed doors in room doorways
 	Dark         bool         `toml:"dark"`          // unlit level: the player sees only a small radius
 }
@@ -346,6 +347,14 @@ func validateLevels(c *Content) error {
 		if l.Water > 0 {
 			if t, ok := c.Tiles["water"]; !ok || !t.Water {
 				return fmt.Errorf("level %q: water pools set but no water tile is defined", id)
+			}
+		}
+		if l.Lava < 0 {
+			return fmt.Errorf("level %q: lava must be >= 0, got %d", id, l.Lava)
+		}
+		if l.Lava > 0 {
+			if t, ok := c.Tiles["lava"]; !ok || !t.Lava {
+				return fmt.Errorf("level %q: lava pools set but no lava tile is defined", id)
 			}
 		}
 	}

--- a/go/internal/game/combat.go
+++ b/go/internal/game/combat.go
@@ -101,10 +101,10 @@ func (g *Game) PlayerStep(d Direction) {
 	} else if g.openDoor(dst) { // blocked by a closed door: open it (costs the turn)
 		g.log("You open the door.")
 		acted = true
-	} else if g.Level.InBounds(dst) && g.Level.At(dst).Def.Water &&
+	} else if g.Level.InBounds(dst) && (g.Level.At(dst).Def.Water || g.Level.At(dst).Def.Lava) &&
 		(g.HasEffect("blind") || g.HasEffect("levitate")) {
-		// Deep water turns away a sighted walker; the blinded blunder in and
-		// floaters drift across (C move_creature).
+		// Deep water and lava turn away a sighted walker; the blinded blunder
+		// in and floaters drift across (C move_creature).
 		g.Player = dst
 		acted = true
 	}
@@ -302,6 +302,10 @@ func (g *Game) passTurn() {
 	if g.Dead {
 		return // drowned
 	}
+	g.lavaCheck()
+	if g.Dead {
+		return // melted
+	}
 	g.spotTraps()
 	g.tickEffects()
 	if g.Dead {
@@ -315,6 +319,22 @@ func (g *Game) passTurn() {
 		if g.Dead {
 			return
 		}
+	}
+}
+
+// lavaCheck burns a non-floating player standing in lava for 1d6+1 every
+// turn (C elements.c lava_bath, LAVA_DAMAGE) — no fatigue grace, unlike water.
+func (g *Game) lavaCheck() {
+	if g.HasEffect("levitate") || !g.Level.At(g.Player).Def.Lava {
+		return
+	}
+	g.log("You get burned by lava!")
+	g.PlayerHP -= g.RNG.RollSpec("1d6+1")
+	if g.PlayerHP <= 0 {
+		g.PlayerHP = 0
+		g.Dead = true
+		g.DeathCause = "lava"
+		g.log("You die...")
 	}
 }
 

--- a/go/internal/game/effects.go
+++ b/go/internal/game/effects.go
@@ -159,6 +159,11 @@ func (g *Game) land() {
 		g.log("You plunge into water!")
 		return
 	}
+	if tile.Lava {
+		g.log("You land in lava!")
+		g.lavaCheck() // the bath is immediate (C altitude.c:78)
+		return
+	}
 	g.log("You land on the ground.")
 	if tile.Effect != "" {
 		g.springTrapAt(g.Player)

--- a/go/internal/game/swim_test.go
+++ b/go/internal/game/swim_test.go
@@ -201,3 +201,58 @@ func TestDispelLevitationLands(t *testing.T) {
 		t.Errorf("no landing without levitation: %d plunge messages", n)
 	}
 }
+
+// lavaGame is a corridor with a lava tile directly east of the player.
+func lavaGame() *Game {
+	g := combatGame()
+	lava := &content.TileDef{ID: "lava", Glyph: "^", Passable: false, Transparent: true, Lava: true}
+	g.Level.Set(Pos{2, 1}, lava)
+	return g
+}
+
+func TestBlindStumbleIntoLavaBurns(t *testing.T) {
+	g := lavaGame()
+	g.AddEffect("blind", 10)
+	g.PlayerStep(DirE)
+	if g.Player != (Pos{2, 1}) {
+		t.Fatalf("the blinded blunder into lava like water (C move_creature), at %v", g.Player)
+	}
+	if g.PlayerHP >= 20 {
+		t.Errorf("lava burns 1d6+1 from the first turn (C lava_bath), HP %d", g.PlayerHP)
+	}
+	if !hasMessage(g, "You get burned by lava!") {
+		t.Errorf("expected the C burn message, got %v", g.Messages)
+	}
+}
+
+func TestFloatingCrossesLavaUnburned(t *testing.T) {
+	g := lavaGame()
+	g.AddEffect("levitate", 20)
+	g.PlayerStep(DirE)
+	if g.Player != (Pos{2, 1}) || g.PlayerHP != 20 {
+		t.Errorf("a floater drifts over lava unburned: at %v with HP %d", g.Player, g.PlayerHP)
+	}
+}
+
+func TestLandingInLava(t *testing.T) {
+	g := lavaGame()
+	g.AddEffect("levitate", 2)
+	g.PlayerStep(DirE) // out over the lava (2->1)
+	g.advanceWorld()   // expiry: the landing
+	if !hasMessage(g, "You land in lava!") {
+		t.Fatalf("expected the C landing line, got %v", g.Messages)
+	}
+	if g.PlayerHP >= 20 {
+		t.Errorf("landing in lava burns immediately, HP %d", g.PlayerHP)
+	}
+}
+
+func TestLavaCanKill(t *testing.T) {
+	g := lavaGame()
+	g.PlayerHP = 1
+	g.AddEffect("blind", 10)
+	g.PlayerStep(DirE)
+	if !g.Dead || g.DeathCause != "lava" {
+		t.Errorf("dead=%v cause=%q, want death by lava", g.Dead, g.DeathCause)
+	}
+}

--- a/go/internal/gen/gen.go
+++ b/go/internal/gen/gen.go
@@ -233,7 +233,13 @@ func LevelFromDef(r *rng.MT, c *content.Content, def *content.LevelDef) (*game.L
 	placeSpawnMonsters(r, c, lvl, rooms, def)
 	placeItems(r, c, lvl, rooms, lvl.Start)
 	if def.Water > 0 {
-		if err := placePools(r, c, lvl, rooms, def.Water); err != nil {
+		if err := placePools(r, c, lvl, rooms, def.Water, "water", 20); err != nil {
+			return nil, err
+		}
+	}
+	if def.Lava > 0 {
+		// Lava clouds run smaller than water (C content.c: 5+rnd%9 vs 5+rnd%20).
+		if err := placePools(r, c, lvl, rooms, def.Lava, "lava", 9); err != nil {
 			return nil, err
 		}
 	}
@@ -285,14 +291,15 @@ func abs(n int) int {
 	return n
 }
 
-// placePools carves n water pools (the C add_pools/area_cloud: blobs of 5-24
-// tiles) into room floors. Water is impassable, so any pool that would cut the
-// start off from a portal is reverted — the C instead rejects whole unsolvable
-// levels; reverting one pool keeps generation deterministic and cheap.
-func placePools(r *rng.MT, c *content.Content, lvl *game.Level, rooms []rect, n int) error {
-	water := c.Tiles["water"]
-	if water == nil {
-		return fmt.Errorf("gen: level wants water pools but no \"water\" tile defined")
+// placePools carves n pools of the given tile (the C add_pools/area_cloud:
+// water blobs of 5-24 tiles, lava 5-13) into room floors. Pools are
+// impassable, so any one that would cut the start off from a portal is
+// reverted — the C instead rejects whole unsolvable levels; reverting one
+// pool keeps generation deterministic and cheap.
+func placePools(r *rng.MT, c *content.Content, lvl *game.Level, rooms []rect, n int, tileID string, sizeSpread int) error {
+	pool := c.Tiles[tileID]
+	if pool == nil {
+		return fmt.Errorf("gen: level wants %s pools but no %q tile defined", tileID, tileID)
 	}
 	floor := c.Tiles["floor"]
 	for k := 0; k < n; k++ {
@@ -302,21 +309,21 @@ func placePools(r *rng.MT, c *content.Content, lvl *game.Level, rooms []rect, n 
 			continue
 		}
 		// Grow a cloud: each added tile is a random neighbour of the pool so far.
-		size := 5 + r.Intn(20)
-		pool := []game.Pos{seed}
-		lvl.Set(seed, water)
+		size := 5 + r.Intn(sizeSpread)
+		grown := []game.Pos{seed}
+		lvl.Set(seed, pool)
 		// Bounded tries: a pool hemmed in by walls simply stays small.
-		for tries := 0; len(pool) < size && tries < 200; tries++ {
-			from := pool[r.Intn(len(pool))]
+		for tries := 0; len(grown) < size && tries < 200; tries++ {
+			from := grown[r.Intn(len(grown))]
 			next := game.Pos{X: from.X + r.Intn(3) - 1, Y: from.Y + r.Intn(3) - 1}
 			if !poolable(lvl, next) {
 				continue
 			}
-			lvl.Set(next, water)
-			pool = append(pool, next)
+			lvl.Set(next, pool)
+			grown = append(grown, next)
 		}
 		if cutsOff(lvl) {
-			for _, p := range pool {
+			for _, p := range grown {
 				lvl.Set(p, floor)
 			}
 		}

--- a/go/internal/gen/gen_test.go
+++ b/go/internal/gen/gen_test.go
@@ -488,3 +488,31 @@ func TestPlacedTrapsAreDisguised(t *testing.T) {
 		t.Fatal("expected traps placed")
 	}
 }
+
+func TestLevelFromDefCarvesLavaPools(t *testing.T) {
+	c := levelDefContent()
+	c.Tiles["lava"] = &content.TileDef{ID: "lava", Glyph: "^", Color: content.ColorBrown, Transparent: true, Lava: true}
+	def := &content.LevelDef{ID: "x", Name: "X", W: 60, H: 24, Links: []string{"y"}, Lava: 6}
+	for seed := uint32(1); seed <= 4; seed++ {
+		lvl, err := LevelFromDef(rng.NewWithSeed(seed), c, def)
+		if err != nil {
+			t.Fatal(err)
+		}
+		lava := 0
+		for y := 0; y < lvl.H; y++ {
+			for x := 0; x < lvl.W; x++ {
+				if lvl.At(game.Pos{X: x, Y: y}).Def.Lava {
+					lava++
+				}
+			}
+		}
+		if lava < 5 {
+			t.Errorf("seed %d: 6 lava pools should leave some lava, got %d tiles", seed, lava)
+		}
+		for _, p := range lvl.Portals {
+			if !reachable(lvl, lvl.Start, p.Pos) {
+				t.Errorf("seed %d: portal at %v unreachable after lava carving", seed, p.Pos)
+			}
+		}
+	}
+}


### PR DESCRIPTION
## Summary
Plan 18e — lava, reusing the water machinery shipped across the swimming arc:

- **Terrain** (`tiles.c:43`): `^` impassable, transparent — 0.40 renders lava *and every trap* as `^` (`glyph.c:58-73`); our color layer differentiates (trap red, lava brown).
- **The bath** (`elements.c lava_bath`): a non-floating player standing in lava burns **1d6+1 every turn** (`LAVA_DAMAGE`) — no fatigue grace, unlike water. "You get burned by lava!", death cause "lava" ("You die...").
- **Entry rules** = water's (`creature.c move_creature`): nobody walks in; the blinded stumble in; floaters cross unburned; **levitation expiring above it lands you in the bath** ("You land in lava!", `altitude.c:78`).
- **Generation**: `placePools` parameterized by tile + cloud size (water 5–24, lava 5–13 per `content.c`); the **Dragons Lair** runs with 12 pools (`places.c:352`: `10+rnd%10`), with the same cut-off-revert connectivity guard.

## Test plan
- Blind stumble burns from the first turn; floating crossing is free; expiry over lava logs the C landing line and burns immediately; 1 HP + lava = death with cause "lava".
- Gen: 4 seeds × 6 pools leave lava with all portals reachable; goldens for the tile def + the Lair's 12 pools; load-time validation (lava set ⇒ lava tile, negatives rejected).
- gofmt + go vet + full `go test ./...` green (10/10 packages).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Lava is now available as a new hazard terrain with unique burn damage mechanics.
  * Added 12 lava pools to the Dragons Lair level.
  * Players standing in lava without levitation status take burn damage each turn.
  * Levitation provides complete protection from lava burn effects.
  * Lava has been added as a possible death cause.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->