### PR TITLE
Scroll of magic weapon (flame hands)

### DIFF
--- a/docs/superpowers/plans/2026-06-10-magic-weapon-15v.md
+++ b/docs/superpowers/plans/2026-06-10-magic-weapon-15v.md
@@ -1,0 +1,33 @@
+# Scroll of magic weapon (15v) Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Scroll 9 of 10: **scroll of magic weapon** (`magic.c magic_weapon`)
+— your hands ignite for 22 turns, overriding whatever you wield. Only the
+familiar scroll (needs summons) remains after this. Advances #15.
+
+## C grounding
+- `magic.c:92`: `set_temp_weapon(caster, virtual_flame_hands,
+  MAGIC_WEAPON_LIFETIME)` (22, `rules.h:135`); "Your hands seem to be on
+  fire.". A temp weapon supersedes the wielded one while it lasts.
+- `vweapon.c:163`: flame hands deal fire damage in a 3/5/5/5 attack
+  sequence; our flat-dice model approximates that as **2d4+1**.
+- `treasure.c:1135`: named "scroll of magic weapon" (with the prefix,
+  unlike blink/mark/recall/trap-detection).
+
+## Design
+- Effect `flame_hands` (HUD "Flaming hands"), 22 turns.
+- `playerDamageSpec()`: while `flame_hands` is active, return the flame
+  spec — overriding the wielded weapon, like the C's temp weapon.
+- Behavior `magic_weapon` + `scroll_magic_weapon` def; joins the appearance
+  pool.
+
+## Task: effect + override + scroll (TDD)
+**Files:** `internal/game/combat.go` + test, behaviors + data + goldens.
+- Tests first: with a dagger wielded and flame hands active, the damage spec
+  is the flame spec; expired → the dagger's returns; behavior message; golden.
+- Commit: `feat(content): scroll of magic weapon (flame hands)`
+- Full gate; push, PR, CodeRabbit loop → merge.
+
+## Done when
+One read and your fists burn hotter than your blade for 22 turns. Suite green.

--- a/go/data/data_test.go
+++ b/go/data/data_test.go
@@ -791,3 +791,15 @@ func TestEmbeddedLava(t *testing.T) {
 		t.Errorf("dragons_lair should run with 12 lava pools, got %+v", l)
 	}
 }
+
+// TestEmbeddedMagicWeapon checks scroll 9 of 10 loaded (15v) — this one keeps
+// its "scroll of" prefix in 0.40 (treasure.c:1135).
+func TestEmbeddedMagicWeapon(t *testing.T) {
+	c, err := content.Load(Files)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if s := c.Items["scroll_magic_weapon"]; s == nil || s.Kind != "scroll" || s.Use != "magic_weapon" || s.Power != 22 {
+		t.Errorf("scroll_magic_weapon def unexpected: %+v", s)
+	}
+}

--- a/go/data/items.toml
+++ b/go/data/items.toml
@@ -458,3 +458,13 @@ glyph = "?"
 color = "red"
 kind = "scroll"
 use = "detect_traps"
+
+# Scroll 9 of 10 (15v, C magic.c magic_weapon): 22 turns of flame hands
+# (C MAGIC_WEAPON_LIFETIME), superseding whatever you wield.
+[item.scroll_magic_weapon]
+name = "scroll of magic weapon"
+glyph = "?"
+color = "cyan"
+kind = "scroll"
+use = "magic_weapon"
+power = 22

--- a/go/internal/behaviors/behaviors.go
+++ b/go/internal/behaviors/behaviors.go
@@ -38,7 +38,15 @@ func Registry() map[string]game.Behavior {
 		"mark":            mark,
 		"recall":          recall,
 		"detect_traps":    detectTraps,
+		"magic_weapon":    magicWeapon,
 	}
+}
+
+// magicWeapon ignites the reader's hands for Power turns, superseding any
+// wielded weapon (C magic.c magic_weapon / set_temp_weapon).
+func magicWeapon(g *game.Game, it *game.Item) []string {
+	g.AddEffect("flame_hands", it.Def.Power)
+	return []string{"Your hands seem to be on fire."}
 }
 
 // detectTraps lights up every hidden trap on the level (C magic.c

--- a/go/internal/behaviors/behaviors_test.go
+++ b/go/internal/behaviors/behaviors_test.go
@@ -432,3 +432,18 @@ func TestDetectTrapsBehaviorRevealsAll(t *testing.T) {
 		t.Errorf("expected the C message, got %v", msgs)
 	}
 }
+
+func TestMagicWeaponIgnitesHands(t *testing.T) {
+	mw, ok := Registry()["magic_weapon"]
+	if !ok {
+		t.Fatal("magic_weapon not registered")
+	}
+	g := &game.Game{PlayerHP: 10, PlayerMax: 10}
+	msgs := mw(g, &game.Item{Def: &content.ItemDef{Name: "scroll of magic weapon", Power: 22}})
+	if !g.HasEffect("flame_hands") {
+		t.Error("expected flaming hands from the scroll")
+	}
+	if len(msgs) == 0 || msgs[0] != "Your hands seem to be on fire." {
+		t.Errorf("expected the C message, got %v", msgs)
+	}
+}

--- a/go/internal/game/combat.go
+++ b/go/internal/game/combat.go
@@ -134,7 +134,15 @@ func (g *Game) playerAttackStat() int {
 	return atk
 }
 
+// flameHandsDamage approximates the C's virtual_flame_hands attack sequence
+// (vweapon.c: fire damage in a 3/5/5/5 chain) in our flat-dice model.
+const flameHandsDamage = "2d4+1"
+
 func (g *Game) playerDamageSpec() string {
+	if g.HasEffect("flame_hands") {
+		// A temp weapon supersedes the wielded one (C set_temp_weapon).
+		return flameHandsDamage
+	}
 	if g.Weapon != nil && g.Weapon.Def.Damage != "" {
 		return g.Weapon.Def.Damage
 	}

--- a/go/internal/game/combat.go
+++ b/go/internal/game/combat.go
@@ -135,8 +135,10 @@ func (g *Game) playerAttackStat() int {
 }
 
 // flameHandsDamage approximates the C's virtual_flame_hands attack sequence
-// (vweapon.c: fire damage in a 3/5/5/5 chain) in our flat-dice model.
-const flameHandsDamage = "2d4+1"
+// (vweapon.c: a deterministic 3/5/5/5 fire chain — avg 4.5, max 5) in our
+// flat-dice model: 1d2+3 matches both the average and the cap (min 4 vs the
+// C's occasional 3).
+const flameHandsDamage = "1d2+3"
 
 func (g *Game) playerDamageSpec() string {
 	if g.HasEffect("flame_hands") {

--- a/go/internal/game/combat_test.go
+++ b/go/internal/game/combat_test.go
@@ -276,3 +276,19 @@ func TestFearedMonsterFleesInsteadOfAttacking(t *testing.T) {
 		t.Errorf("a frightened creature should increase its distance from the player (%d -> %d)", before, got)
 	}
 }
+
+func TestFlameHandsOverrideWeapon(t *testing.T) {
+	g := combatGame()
+	g.Weapon = &Item{Def: &content.ItemDef{Name: "dagger", Kind: "weapon", Damage: "1d4"}}
+	if got := g.playerDamageSpec(); got != "1d4" {
+		t.Fatalf("setup: wielded spec should be 1d4, got %q", got)
+	}
+	g.AddEffect("flame_hands", 22)
+	if got := g.playerDamageSpec(); got != flameHandsDamage {
+		t.Errorf("flame hands supersede the wielded weapon (C set_temp_weapon), got %q", got)
+	}
+	g.RemoveEffect("flame_hands")
+	if got := g.playerDamageSpec(); got != "1d4" {
+		t.Errorf("the dagger returns when the fire dies, got %q", got)
+	}
+}

--- a/go/internal/game/effects.go
+++ b/go/internal/game/effects.go
@@ -10,15 +10,16 @@ type Effect struct {
 
 // effectLabels maps effect kinds to their HUD labels.
 var effectLabels = map[string]string{
-	"poison":   "Poisoned",
-	"regen":    "Regenerating",
-	"slow":     "Slowed",
-	"haste":    "Hastened",
-	"blind":    "Blinded",
-	"confuse":  "Confused",
-	"fear":     "Afraid",
-	"sleep":    "Asleep",
-	"levitate": "Floating",
+	"poison":      "Poisoned",
+	"regen":       "Regenerating",
+	"slow":        "Slowed",
+	"haste":       "Hastened",
+	"blind":       "Blinded",
+	"confuse":     "Confused",
+	"fear":        "Afraid",
+	"sleep":       "Asleep",
+	"levitate":    "Floating",
+	"flame_hands": "Flaming hands",
 }
 
 // HasEffect reports whether a timed effect of the given kind is active on the


### PR DESCRIPTION
## Summary
Plan 15v — scroll 9 of 10 from 0.40's list (`magic.c magic_weapon`):

- **Flame hands**: reading ignites your hands for **22 turns** (`MAGIC_WEAPON_LIFETIME`) — `set_temp_weapon(virtual_flame_hands)` supersedes the wielded weapon, so `playerDamageSpec()` returns the flame spec while the effect runs and your blade comes back when it dies. "Your hands seem to be on fire."
- The C's 3/5/5/5 fire attack sequence (`vweapon.c:170`) approximated as **2d4+1** in our flat-dice model (documented in code).
- Named with the prefix ("scroll of magic weapon", `treasure.c:1135`) unlike blink/mark/recall/trap-detection; HUD shows "Flaming hands".
- After this only the **familiar scroll** remains, gated on a summons/ally subsystem.

## Test plan
- With a dagger wielded: flame active → flame spec; expired → dagger spec returns.
- Behavior message + effect; golden def (scroll/magic_weapon/22).
- gofmt + go vet + full `go test ./...` green (10/10 packages).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "scroll of magic weapon" that grants a "Flaming hands" effect for 22 turns.
  * While active, "Flaming hands" overrides the player's equipped weapon damage.
  * "Flaming hands" status now appears in the HUD.

* **Documentation**
  * Added a design/plan doc describing the new scroll and acceptance criteria.

* **Tests**
  * Added tests validating the scroll is embedded, the effect applies, and damage override behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->