### PR TITLE
Scroll of Summon Familiar (the 0.40 scroll list complete)

### DIFF
--- a/docs/superpowers/plans/2026-06-10-summon-familiar-15w.md
+++ b/docs/superpowers/plans/2026-06-10-summon-familiar-15w.md
@@ -1,0 +1,52 @@
+# Scroll of Summon Familiar (15w) Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** The tenth and final 0.40 scroll: **scroll of Summon Familiar**
+(`magic.c summon_familiar`) — an imp ally that follows you and fights your
+enemies. Brings the port's first ally AI and monster-vs-monster combat.
+Completes the scroll list. Advances #15.
+
+## C grounding
+- `magic.c:585`: always an **imp** (the 1d4 switch has only a default),
+  `charm()`ed — `attr_player_ally = 1`, ai_offensive — with
+  `lifetime = DEFAULT_SUMMON_LIFETIME` (500, `rules.h:70`); placed at the
+  nearest free spot; "The imp has arrived.".
+- `game.c:123-146`: lifetime ticks down once per creature-turn; at 0 the
+  creature "disappears." (no corpse, no drops).
+- `ai.c basic_ai`: allies and hostiles target each other (the `enemies()`
+  split). Bounded port: an ally attacks an adjacent hostile, pursues the
+  nearest hostile in sense range, else heels to the player; a hostile
+  prefers an adjacent ally over a distant player. (Full mutual targeting at
+  range is out of scope — noted.)
+- `treasure.c:1171`: named "scroll of Summon Familiar" (capitals in 0.40).
+
+## Design
+- `Creature.Ally bool` + `Creature.Lifetime int` (0 = permanent). worldTick
+  decrements a positive lifetime each tick (≈ a creature-turn at base speed);
+  at 0 the creature disappears, corpse-free.
+- Ally turn in `monsterAct`: adjacent hostile → `monsterFights` (the first
+  creature-vs-creature swing: attack vs dodge, damage dice, `killCreature`);
+  nearest hostile within sense range → step toward it; otherwise follow the
+  player (step toward when more than 2 away).
+- Hostile turn: an adjacent ally is attacked before a distant player.
+- Behavior `summon_familiar`: clones the imp def into an Ally with the 500
+  lifetime at a free spot near the player; the C arrival message. Item
+  `scroll_familiar`, the C's capitalized name.
+
+## Task 1: ally AI + lifetime + creature combat (TDD)
+**Files:** `internal/game/{creature,combat}.go` + new `ally_test.go`.
+- Tests first: an ally adjacent to a rat bites it (rat HP drops, player HP
+  untouched); an ally pursues a rat in range; an idle ally heels toward a
+  distant player; lifetime 2 expires ("disappears.", no corpse); a hostile
+  adjacent to both targets the ally.
+- Commit: `feat(game): ally AI — creature-vs-creature combat + summon lifetimes`
+
+## Task 2: behavior + data + ship
+- `summon_familiar` behavior + `scroll_familiar` def + goldens; full gate;
+  push, PR, CodeRabbit loop → merge.
+- Commit: `feat(content): scroll of Summon Familiar — the scroll list complete`
+
+## Done when
+Read the scroll and an imp pads after you for 500 turns, throwing itself at
+whatever you're fighting — all ten 0.40 scrolls shipped. Suite green.

--- a/go/data/data_test.go
+++ b/go/data/data_test.go
@@ -803,3 +803,15 @@ func TestEmbeddedMagicWeapon(t *testing.T) {
 		t.Errorf("scroll_magic_weapon def unexpected: %+v", s)
 	}
 }
+
+// TestEmbeddedSummonFamiliar checks the final scroll loaded (15w): all ten
+// 0.40 scrolls are now in.
+func TestEmbeddedSummonFamiliar(t *testing.T) {
+	c, err := content.Load(Files)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if s := c.Items["scroll_familiar"]; s == nil || s.Kind != "scroll" || s.Use != "summon_familiar" || s.Power != 500 || s.Name != "scroll of Summon Familiar" {
+		t.Errorf("scroll_familiar def unexpected: %+v", s)
+	}
+}

--- a/go/data/items.toml
+++ b/go/data/items.toml
@@ -468,3 +468,13 @@ color = "cyan"
 kind = "scroll"
 use = "magic_weapon"
 power = 22
+
+# The tenth and last scroll (15w, C magic.c summon_familiar): an imp ally for
+# 500 turns (C DEFAULT_SUMMON_LIFETIME). 0.40 capitalizes the name.
+[item.scroll_familiar]
+name = "scroll of Summon Familiar"
+glyph = "?"
+color = "normal"
+kind = "scroll"
+use = "summon_familiar"
+power = 500

--- a/go/internal/behaviors/behaviors.go
+++ b/go/internal/behaviors/behaviors.go
@@ -39,7 +39,18 @@ func Registry() map[string]game.Behavior {
 		"recall":          recall,
 		"detect_traps":    detectTraps,
 		"magic_weapon":    magicWeapon,
+		"summon_familiar": summonFamiliar,
 	}
+}
+
+// summonFamiliar calls forth an imp ally for Power ticks (C magic.c
+// summon_familiar: always an imp — the 1d4 switch has only a default —
+// charmed, DEFAULT_SUMMON_LIFETIME).
+func summonFamiliar(g *game.Game, it *game.Item) []string {
+	if g.SummonAlly("imp", it.Def.Power) {
+		return []string{"The imp has arrived."}
+	}
+	return []string{fmt.Sprintf("You read the %s, but nothing happens.", it.Def.Name)}
 }
 
 // magicWeapon ignites the reader's hands for Power turns, superseding any

--- a/go/internal/behaviors/behaviors_test.go
+++ b/go/internal/behaviors/behaviors_test.go
@@ -447,3 +447,23 @@ func TestMagicWeaponIgnitesHands(t *testing.T) {
 		t.Errorf("expected the C message, got %v", msgs)
 	}
 }
+
+func TestSummonFamiliarBringsAnImp(t *testing.T) {
+	sf, ok := Registry()["summon_familiar"]
+	if !ok {
+		t.Fatal("summon_familiar not registered")
+	}
+	floor := &content.TileDef{ID: "floor", Glyph: ".", Color: content.ColorNormal, Passable: true, Transparent: true}
+	g := &game.Game{
+		Level:   game.NewLevel(8, 3, floor),
+		Player:  game.Pos{X: 1, Y: 1},
+		Content: &content.Content{Monsters: map[string]*content.MonsterDef{"imp": {ID: "imp", Name: "imp", Glyph: "i", HP: 6, Attack: 8, Dodge: 2, Damage: "1d4"}}},
+	}
+	msgs := sf(g, &game.Item{Def: &content.ItemDef{Name: "scroll of Summon Familiar", Power: 500}})
+	if len(g.Level.Creatures) != 1 || !g.Level.Creatures[0].Ally {
+		t.Error("the scroll should summon a charmed imp")
+	}
+	if len(msgs) == 0 || msgs[0] != "The imp has arrived." {
+		t.Errorf("expected the C arrival line, got %v", msgs)
+	}
+}

--- a/go/internal/game/ally_test.go
+++ b/go/internal/game/ally_test.go
@@ -1,0 +1,84 @@
+package game
+
+import (
+	"testing"
+
+	"github.com/c0ze/tsl/internal/content"
+)
+
+// allyImp drops a player-allied imp into g at p.
+func allyImp(g *Game, p Pos) *Creature {
+	imp := &Creature{Def: &content.MonsterDef{ID: "imp", Name: "imp", Glyph: "i", HP: 6, Attack: 1000, Dodge: 2, Damage: "1d2"}, Pos: p, HP: 6, Ally: true}
+	g.Level.Creatures = append(g.Level.Creatures, imp)
+	return imp
+}
+
+func TestAllyBitesAdjacentHostile(t *testing.T) {
+	g := combatGame()
+	allyImp(g, Pos{3, 1})
+	rat := &Creature{Def: &content.MonsterDef{ID: "rat", Name: "rat", Glyph: "r", HP: 9, Attack: 0, Dodge: 0, Damage: "1d1"}, Pos: Pos{4, 1}, HP: 9}
+	g.Level.Creatures = append(g.Level.Creatures, rat)
+	hp := g.PlayerHP
+	g.worldTick()
+	if rat.HP >= 9 {
+		t.Error("an ally fights the player's enemies (C charm/ai_offensive)")
+	}
+	if g.PlayerHP != hp {
+		t.Error("the ally must not maul its master")
+	}
+}
+
+func TestAllyPursuesHostileInRange(t *testing.T) {
+	g := combatGame()
+	imp := allyImp(g, Pos{3, 1})
+	rat := &Creature{Def: &content.MonsterDef{ID: "rat", Name: "rat", Glyph: "r", HP: 9, Attack: 0, Dodge: 0, Damage: "1d1"}, Pos: Pos{7, 1}, HP: 9}
+	g.Level.Creatures = append(g.Level.Creatures, rat)
+	g.worldTick()
+	if imp.Pos.X != 4 {
+		t.Errorf("the ally should close on the rat, at %v", imp.Pos)
+	}
+}
+
+func TestIdleAllyHeelsToPlayer(t *testing.T) {
+	g := combatGame()
+	imp := allyImp(g, Pos{8, 1}) // far from the player at (1,1), no hostiles
+	g.worldTick()
+	if imp.Pos.X != 7 {
+		t.Errorf("an idle ally follows its master, at %v", imp.Pos)
+	}
+}
+
+func TestSummonLifetimeExpires(t *testing.T) {
+	g := combatGame()
+	imp := allyImp(g, Pos{2, 1})
+	imp.Lifetime = 2
+	g.worldTick()
+	g.worldTick()
+	if g.Level.CreatureAt(Pos{2, 1}) != nil {
+		t.Fatal("the summon should disappear when its lifetime runs out (C game.c)")
+	}
+	if !hasMessage(g, "disappears.") {
+		t.Errorf("expected the C disappearance message, got %v", g.Messages)
+	}
+	for _, it := range g.Level.Items {
+		if it.Pos == imp.Pos {
+			t.Error("a timed-out summon leaves no corpse")
+		}
+	}
+}
+
+func TestHostilePrefersAdjacentAlly(t *testing.T) {
+	g := combatGame()
+	imp := allyImp(g, Pos{3, 1})
+	rat := &Creature{Def: &content.MonsterDef{ID: "rat", Name: "rat", Glyph: "r", HP: 9, Attack: 1000, Dodge: 0, Damage: "1d2"}, Pos: Pos{4, 1}, HP: 9}
+	g.Level.Creatures = append(g.Level.Creatures, rat)
+	g.Player = Pos{1, 1} // two away from the rat; the imp is the adjacent target
+	hp := g.PlayerHP
+	g.worldTick()
+	if imp.HP >= 6 {
+		t.Error("a hostile bites the ally at its flank first (C enemies split)")
+	}
+	if g.PlayerHP != hp {
+		t.Error("the player was out of reach this tick")
+	}
+}

--- a/go/internal/game/ally_test.go
+++ b/go/internal/game/ally_test.go
@@ -82,3 +82,26 @@ func TestHostilePrefersAdjacentAlly(t *testing.T) {
 		t.Error("the player was out of reach this tick")
 	}
 }
+
+func TestSummonAllyArrivesBesideThePlayer(t *testing.T) {
+	g := combatGame()
+	g.Content.Monsters = map[string]*content.MonsterDef{"imp": {ID: "imp", Name: "imp", Glyph: "i", HP: 6, Attack: 8, Dodge: 2, Damage: "1d4"}}
+	if !g.SummonAlly("imp", 500) {
+		t.Fatal("the summon should find a spot")
+	}
+	var imp *Creature
+	for _, c := range g.Level.Creatures {
+		if c.Def.ID == "imp" {
+			imp = c
+		}
+	}
+	if imp == nil || !imp.Ally || imp.Lifetime != 500 {
+		t.Fatalf("expected a charmed 500-tick imp, got %+v", imp)
+	}
+	if d := chebyshev(imp.Pos, g.Player); d != 1 {
+		t.Errorf("the familiar arrives at its master's side, %d away", d)
+	}
+	if g.SummonAlly("ghost", 1) {
+		t.Error("an unknown def must not summon")
+	}
+}

--- a/go/internal/game/combat.go
+++ b/go/internal/game/combat.go
@@ -392,6 +392,16 @@ func (g *Game) worldTick() {
 		if g.Level.CreatureAt(m.Pos) != m {
 			continue // already removed this turn
 		}
+		if m.Lifetime > 0 {
+			m.Lifetime--
+			if m.Lifetime == 0 {
+				// A summon's time is up: it vanishes without corpse or drops
+				// (C game.c lifetime handling).
+				g.log("The %s disappears.", m.Def.Name)
+				g.Level.RemoveCreature(m)
+				continue
+			}
+		}
 		// Capture slow before ticking, so a 1-turn slow still applies this turn
 		// (symmetric with poison dealing its final tick before expiring).
 		slowed := m.HasEffect("slow")
@@ -430,10 +440,21 @@ func (g *Game) monsterAct(m *Creature) {
 		g.stepAway(m, g.Player) // frightened: it flees the player instead of attacking
 		return
 	}
+	if m.Ally {
+		g.allyAct(m)
+		return
+	}
 	dist := chebyshev(m.Pos, g.Player)
 	if dist == 1 {
 		g.monsterAttacks(m)
 		return
+	}
+	// A distant player doesn't shield an ally at the flank (C enemies split).
+	for _, c := range g.Level.Creatures {
+		if c.Ally && chebyshev(m.Pos, c.Pos) == 1 {
+			g.monsterFights(m, c)
+			return
+		}
 	}
 	if m.HasEffect("blind") {
 		return // blinded: it can flail at an adjacent foe but can't track at range
@@ -444,6 +465,50 @@ func (g *Game) monsterAct(m *Creature) {
 	}
 	if dist <= senseRange {
 		g.stepToward(m, g.Player)
+	}
+}
+
+// allyAct is a charmed creature's turn (C charm/ai_offensive): bite the
+// adjacent hostile, else close on the nearest one in sense range, else heel
+// to the player.
+func (g *Game) allyAct(m *Creature) {
+	var target *Creature
+	best := senseRange + 1
+	for _, c := range g.Level.Creatures {
+		if c == m || c.Ally {
+			continue
+		}
+		if d := chebyshev(m.Pos, c.Pos); d < best {
+			best, target = d, c
+		}
+	}
+	if target != nil && best == 1 {
+		g.monsterFights(m, target)
+		return
+	}
+	if target != nil {
+		g.stepToward(m, target.Pos)
+		return
+	}
+	if chebyshev(m.Pos, g.Player) > 2 {
+		g.stepToward(m, g.Player)
+	}
+}
+
+// monsterFights resolves one creature-vs-creature swing — an ally biting a
+// hostile or the reverse — on the same attack-vs-dodge model as every other
+// melee in the port.
+func (g *Game) monsterFights(a, d *Creature) {
+	if !g.RNG.Chance(a.Def.Attack, d.Def.Dodge) {
+		g.log("The %s misses the %s.", a.Def.Name, d.Def.Name)
+		return
+	}
+	d.RemoveEffect("sleep") // a landed hit wakes a sleeper (C combat.c)
+	dmg := g.RNG.RollSpec(a.Def.Damage)
+	d.HP -= dmg
+	g.log("The %s hits the %s for %d.", a.Def.Name, d.Def.Name, dmg)
+	if d.HP <= 0 {
+		g.killCreature(d)
 	}
 }
 

--- a/go/internal/game/creature.go
+++ b/go/internal/game/creature.go
@@ -19,6 +19,9 @@ type Creature struct {
 	Faction Faction
 	Energy  int
 	Effects []Effect // timed afflictions (e.g. poison from a venom wand)
+
+	Ally     bool // charmed to the player's side (C attr_player_ally)
+	Lifetime int  // ticks before a summon disappears (0 = permanent)
 }
 
 // AddEffect applies a timed status effect to the creature, refreshing an

--- a/go/internal/game/creature.go
+++ b/go/internal/game/creature.go
@@ -30,6 +30,31 @@ func (m *Creature) AddEffect(kind string, turns int) {
 	m.Effects = addEffect(m.Effects, kind, turns)
 }
 
+// SummonAlly conjures a charmed monster of the given def at the nearest free
+// tile beside the player (C magic.c summon_familiar / find_nearest_free_spot),
+// expiring after lifetime ticks. It reports whether a spot and def were found.
+func (g *Game) SummonAlly(id string, lifetime int) bool {
+	def := g.Content.Monsters[id]
+	if def == nil {
+		return false
+	}
+	for radius := 1; radius <= 3; radius++ {
+		for dy := -radius; dy <= radius; dy++ {
+			for dx := -radius; dx <= radius; dx++ {
+				p := Pos{X: g.Player.X + dx, Y: g.Player.Y + dy}
+				if chebyshev(p, g.Player) != radius {
+					continue // ring order: nearest spots first
+				}
+				if g.Level.Passable(p) && g.Level.CreatureAt(p) == nil {
+					g.Level.Creatures = append(g.Level.Creatures, &Creature{Def: def, Pos: p, HP: def.HP, Ally: true, Lifetime: lifetime})
+					return true
+				}
+			}
+		}
+	}
+	return false
+}
+
 // RemoveEffect drops an active effect by kind (e.g. a struck sleeper waking);
 // an absent kind is a no-op.
 func (m *Creature) RemoveEffect(kind string) {


### PR DESCRIPTION
## Summary
Plan 15w — the tenth and final scroll, bringing the port's first **ally AI** and **creature-vs-creature combat**:

- **Allies** (`Creature.Ally`, the C's `attr_player_ally` via `charm()`): a charmed creature bites the adjacent hostile, closes on the nearest one in sense range, and otherwise heels to the player. Hostiles bite an ally at their flank before chasing a distant player (the `enemies()` split, bounded — full mutual ranged targeting noted out of scope).
- **`monsterFights`**: the first creature-vs-creature swing, on the same attack-vs-dodge model as every other melee; a landed hit wakes a sleeping target, kills resolve through the shared `killCreature`.
- **Summon lifetimes** (`Creature.Lifetime`, C `game.c`): tick down each world tick; at zero the summon "disappears." — no corpse, no drops.
- **The scroll** (`magic.c summon_familiar`): always an imp (the C's 1d4 switch has only a default), 500 ticks (`DEFAULT_SUMMON_LIFETIME`), arriving at the nearest free ring tile beside its master (`find_nearest_free_spot`); "The imp has arrived." Name per `treasure.c:1171`: **"scroll of Summon Familiar"**, capitals in the original.

With this, **all ten 0.40 scrolls are shipped**: identify, magic mapping, trap detection, recharge, blink, familiar, mark, recall, amnesia, magic weapon.

## Test plan
- Ally bites the adjacent rat (player untouched); pursues in range; heels when idle; hostile prefers the flank ally over a distant player.
- Lifetime 2 expires on the second tick with the C message and no corpse.
- `SummonAlly` lands the imp exactly one tile from the player; unknown defs refuse; behavior + golden (capitalized name, power 500).
- gofmt + go vet + full `go test ./...` green (10/10 packages).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Scroll of Summon Familiar" scroll item that summons an allied imp to fight alongside the player in combat
  * Implemented ally mechanics: summoned creatures take combat turns, prioritize targeting hostile enemies, and expire after their lifetime duration
  * Allies support flanking behavior where enemies engage nearby allies instead of pursuing the player directly

<!-- end of auto-generated comment: release notes by coderabbit.ai -->