### PR TITLE
Breath weapons: cone attacks for the six 0.40 breathers

### DIFF
--- a/docs/superpowers/plans/2026-06-10-breath-weapons-19a.md
+++ b/docs/superpowers/plans/2026-06-10-breath-weapons-19a.md
@@ -1,0 +1,53 @@
+# Breath weapons (19a) Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** The breath subsystem (`breath.c`), monster side: **cone attacks**
+for the six 0.40 breathers already in our roster — the Dragon and flame
+spirit/burning skull breathe fire, the Lurker, giant slimy toad (and kin)
+noxious fumes. Settles the Lurker's noted TODO and gives the Dragon its
+signature. Player-side breath spellbooks are the arc's PR 2. Advances #19
+(breath/explode) + #13.
+
+## C grounding
+- `area.c area_cone`: walk `range` steps along the direction; each step the
+  cone swells, throwing two perpendicular side-rays of the swell length;
+  stops at walls. Fire range 3, poison range 4 (`missile.c get_spell_range`).
+- `breath.c breath_weapon`: every creature in the cone is hit — friendly
+  fire included. Fire: `2d4` (`BREATHE_FIRE_DAMAGE`). Poison: `1d2` +
+  poisoned 12 turns (`NOXIOUS_BREATH_*`), skipped for nonbreathers. Messages:
+  "breathes fire!"/"breathes poison!", the player "You get burned!" /
+  "You inhale the vile fumes!".
+- Breathers (`monster.c`/`unique.c`): Dragon, flame spirit, burning skull →
+  fire; Lurker, giant slimy toad, hellhound → per their C attrs (verified at
+  implementation against each block).
+- Bounded AI (the C picks via `cone_direction` + EP costs; our monsters have
+  no EP): breathe when the player is within breath range with line of sight,
+  along the dominant direction toward them; otherwise act as before.
+
+## Design
+- `game.breathCone(origin Pos, dx, dy, rng int) []Pos` — the C walk-and-swell,
+  wall-stopped.
+- `MonsterDef.Breath` ("" | "fire" | "poison") with ranges/damages as engine
+  consts; validation restricts the values.
+- `monsterAct`: a breather with the player in range + LOS exhales before
+  other options; every creature in the cone takes the roll (allies and
+  hostiles alike — C friendly fire), the player via `HurtPlayer`
+  (cause "<name>'s fiery breath" → noun "dragonfire"? keep cause = monster
+  name, consistent with melee).
+- Data: breath flags on the six defs + goldens.
+
+## Task 1: cone geometry + breath resolution (TDD)
+**Files:** `internal/game/{combat,los}.go` + new `breath_test.go`.
+- Tests first: cone shape (range 3 east = widening triangle, wall-clipped);
+  a fire breath burns the player and a bystander rat in the cone, spares one
+  outside; poison breath poisons; a breather out of range closes in instead.
+- Commit: `feat(game): breath weapons — C cone geometry + fire/poison breath`
+
+## Task 2: data flags + ship
+- Six defs flagged; goldens; full gate; PR; CodeRabbit loop → merge.
+- Commit: `feat(content): the Dragon (and friends) breathe`
+
+## Done when
+Standing three tiles from the Dragon is no longer safe: the cone lights you,
+your imp, and the unlucky kobold beside you. Suite green.

--- a/go/data/data_test.go
+++ b/go/data/data_test.go
@@ -815,3 +815,21 @@ func TestEmbeddedSummonFamiliar(t *testing.T) {
 		t.Errorf("scroll_familiar def unexpected: %+v", s)
 	}
 }
+
+// TestEmbeddedBreathers checks the six 0.40 breathers loaded (19a) — note the
+// hellhound breathes POISON in the C (monster.c:588), not fire.
+func TestEmbeddedBreathers(t *testing.T) {
+	c, err := content.Load(Files)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	breaths := map[string]string{
+		"dragon": "fire", "burning_skull": "fire", "flame_spirit": "fire",
+		"lurker": "poison", "hellhound": "poison", "giant_slimy_toad": "poison",
+	}
+	for id, want := range breaths {
+		if m := c.Monsters[id]; m == nil || m.Breath != want {
+			t.Errorf("%s should breathe %s, got %+v", id, want, m)
+		}
+	}
+}

--- a/go/data/monsters.toml
+++ b/go/data/monsters.toml
@@ -262,6 +262,7 @@ damage = "1d5"
 speed = 140
 corpse = "carcass"
 min_depth = 2
+breath = "poison"
 
 [monster.frostling]
 name = "frostling"
@@ -324,6 +325,7 @@ damage = "2d4"
 speed = 75
 corpse = "carcass"
 min_depth = 3
+breath = "poison"
 
 # Roster batch 5 (#13) — more of the canonical 0.40 bestiary (names/glyphs from
 # common/glyph.c), leaning into its sci-fi/horror streak (the Lab, the Comm Hub).
@@ -362,6 +364,7 @@ dodge = 3
 damage = "1d5"
 speed = 140
 min_depth = 3
+breath = "fire"
 
 [monster.gaoler]
 name = "gaoler"
@@ -420,6 +423,7 @@ dodge = 3
 damage = "1d10"
 speed = 110
 ranged = 4
+breath = "fire"
 
 # The Lurker (#18c/#13 uniques, C unique.c): a pool-bound horror — free_swim +
 # permaswim, poison fangs (C virtual_poison_fangs), speed 120. Placed only as
@@ -438,6 +442,7 @@ permaswim = true
 effect = "poison"
 effect_turns = 5
 min_depth = 99 # never in random spawn tables: boss placement only
+breath = "poison"
 
 # Roster batch 6 (13g) — canonical 0.40 foes (monster.c / glyph.c / places.c).
 # A slow, weak shock-eel of the early Dungeon (m_shock ability out of scope).
@@ -503,6 +508,7 @@ dodge = 3
 damage = "2d4"
 speed = 60
 min_depth = 8
+breath = "fire"
 
 # The Necromancer (13h, C unique.c:78): boss of the Catacombs. Glacial
 # (speed 10 — one move in ten player turns) but hurls bolts from afar

--- a/go/internal/content/content.go
+++ b/go/internal/content/content.go
@@ -71,6 +71,7 @@ type MonsterDef struct {
 	Permaswim   bool   `toml:"permaswim"`    // water only — it won't leave its pool (implies swim)
 	Effect      string `toml:"effect"`       // status effect a landed melee hit applies ("" = none)
 	EffectTurns int    `toml:"effect_turns"` // duration of Effect
+	Breath      string `toml:"breath"`       // cone attack: "fire", "poison", or "" (#19)
 }
 
 // Rune returns the monster's glyph as a rune.
@@ -430,6 +431,9 @@ func validateMonster(m *MonsterDef) error {
 	}
 	if m.Permaswim && !m.Swim {
 		return fmt.Errorf("permaswim requires swim")
+	}
+	if m.Breath != "" && m.Breath != "fire" && m.Breath != "poison" {
+		return fmt.Errorf("breath must be fire or poison, got %q", m.Breath)
 	}
 	if m.Effect != "" && m.EffectTurns <= 0 {
 		return fmt.Errorf("melee effect %q needs effect_turns > 0", m.Effect)

--- a/go/internal/game/breath.go
+++ b/go/internal/game/breath.go
@@ -1,8 +1,9 @@
 package game
 
 // Breath weapons (#19, C breath.c): cone attacks for fire- and
-// poison-breathing creatures. Every creature caught in the cone takes the
-// roll — friendly fire included — and there is no dodge against a breath.
+// poison-breathing creatures. Every creature caught in the cone is hit —
+// friendly fire included, no dodge — each taking its own damage roll, as in
+// the C (sroll() is called per target inside breath_weapon's loop).
 const (
 	breathFireRange    = 3     // C missile.c get_spell_range(m_breathe_fire)
 	breathFireDamage   = "2d4" // C rules.h BREATHE_FIRE_DAMAGE

--- a/go/internal/game/breath.go
+++ b/go/internal/game/breath.go
@@ -1,0 +1,113 @@
+package game
+
+// Breath weapons (#19, C breath.c): cone attacks for fire- and
+// poison-breathing creatures. Every creature caught in the cone takes the
+// roll — friendly fire included — and there is no dodge against a breath.
+const (
+	breathFireRange    = 3     // C missile.c get_spell_range(m_breathe_fire)
+	breathFireDamage   = "2d4" // C rules.h BREATHE_FIRE_DAMAGE
+	breathPoisonRange  = 4     // C get_spell_range(m_noxious_breath)
+	breathPoisonDamage = "1d2" // C NOXIOUS_BREATH_DAMAGE
+	breathPoisonTurns  = 12    // C NOXIOUS_BREATH_POISON
+)
+
+// breathRange is how far a monster's breath reaches, or 0 for non-breathers.
+func breathRange(m *Creature) int {
+	switch m.Def.Breath {
+	case "fire":
+		return breathFireRange
+	case "poison":
+		return breathPoisonRange
+	}
+	return 0
+}
+
+// breathable reports whether a breath can roll across p: open ground, water
+// and lava (the C's is_flyable), or any tile someone is standing on.
+func (g *Game) breathable(p Pos) bool {
+	if !g.Level.InBounds(p) {
+		return false
+	}
+	def := g.Level.At(p).Def
+	return def.Passable || def.Water || def.Lava || g.Level.CreatureAt(p) != nil
+}
+
+// breathCone collects the tiles of a breath cone (C area_cone): rng steps
+// along (dx,dy), each step swelling sideways with two perpendicular rays —
+// note the C's swell math narrows the tip back to a point. Walls stop the
+// spine and the rays alike.
+func (g *Game) breathCone(origin Pos, dx, dy, rng int) []Pos {
+	var tiles []Pos
+	seen := map[Pos]bool{}
+	add := func(p Pos) {
+		if !seen[p] {
+			seen[p] = true
+			tiles = append(tiles, p)
+		}
+	}
+	ray := func(from Pos, rdx, rdy, n int) {
+		p := from
+		for i := 0; i < n; i++ {
+			p = Pos{X: p.X + rdx, Y: p.Y + rdy}
+			if !g.breathable(p) {
+				return
+			}
+			add(p)
+		}
+	}
+	p := origin
+	swell := 0
+	for left := rng; left > 0; left-- {
+		swell++
+		if swell > left-1 {
+			swell = left - 1 // C: range--; swell++; swell = MIN(range, swell)
+		}
+		p = Pos{X: p.X + dx, Y: p.Y + dy}
+		if !g.breathable(p) {
+			break
+		}
+		add(p)
+		ray(p, -dy, dx, swell)
+		ray(p, dy, -dx, swell)
+	}
+	return tiles
+}
+
+// breathe is a breather's turn when the player is in range with line of
+// sight: exhale along the dominant direction and hit everything in the cone
+// (C breath.c breath_weapon).
+func (g *Game) breathe(m *Creature) {
+	kind := m.Def.Breath
+	if kind == "fire" {
+		g.log("The %s breathes fire!", m.Def.Name)
+	} else {
+		g.log("The %s breathes poison!", m.Def.Name)
+	}
+	dx, dy := signOf(g.Player.X-m.Pos.X), signOf(g.Player.Y-m.Pos.Y)
+	for _, p := range g.breathCone(m.Pos, dx, dy, breathRange(m)) {
+		if p == g.Player {
+			if kind == "fire" {
+				g.log("You get burned!")
+				g.HurtPlayer(g.RNG.RollSpec(breathFireDamage), m.Def.Name)
+			} else {
+				g.log("You inhale the vile fumes!")
+				g.HurtPlayer(g.RNG.RollSpec(breathPoisonDamage), m.Def.Name)
+				if !g.Dead {
+					g.AddEffect("poison", breathPoisonTurns)
+				}
+			}
+			continue
+		}
+		if c := g.Level.CreatureAt(p); c != nil && c != m {
+			if kind == "fire" {
+				c.HP -= g.RNG.RollSpec(breathFireDamage)
+			} else {
+				c.HP -= g.RNG.RollSpec(breathPoisonDamage)
+				c.AddEffect("poison", breathPoisonTurns)
+			}
+			if c.HP <= 0 {
+				g.killCreature(c)
+			}
+		}
+	}
+}

--- a/go/internal/game/breath_test.go
+++ b/go/internal/game/breath_test.go
@@ -1,0 +1,86 @@
+package game
+
+import (
+	"testing"
+
+	"github.com/c0ze/tsl/internal/content"
+)
+
+func TestBreathConeShape(t *testing.T) {
+	g := combatGame() // 10x3, all floor
+	tiles := g.breathCone(Pos{1, 1}, 1, 0, 3)
+	want := map[Pos]bool{
+		{2, 0}: true, {2, 1}: true, {2, 2}: true, // step 1, swell 1
+		{3, 0}: true, {3, 1}: true, {3, 2}: true, // step 2, swell 1
+		{4, 1}: true, // step 3: the tip narrows (C swell=MIN(range,swell))
+	}
+	if len(tiles) != len(want) {
+		t.Fatalf("cone east range 3: want %d tiles, got %d (%v)", len(want), len(tiles), tiles)
+	}
+	for _, p := range tiles {
+		if !want[p] {
+			t.Errorf("unexpected cone tile %v", p)
+		}
+	}
+}
+
+func TestBreathConeStopsAtWalls(t *testing.T) {
+	g := combatGame()
+	wall := &content.TileDef{ID: "wall", Glyph: "#", Passable: false}
+	g.Level.Set(Pos{3, 1}, wall) // block the spine at step 2
+	tiles := g.breathCone(Pos{1, 1}, 1, 0, 3)
+	for _, p := range tiles {
+		if p.X > 2 && p.Y == 1 {
+			t.Errorf("the cone spine must stop at the wall, got %v", p)
+		}
+	}
+}
+
+func TestFireBreathBurnsTheCone(t *testing.T) {
+	g := combatGame()
+	dragon := &Creature{Def: &content.MonsterDef{ID: "dragon", Name: "dragon", Glyph: "D", HP: 60, Attack: 10, Dodge: 2, Damage: "2d6", Breath: "fire"}, Pos: Pos{1, 1}, HP: 60}
+	bystander := &Creature{Def: &content.MonsterDef{ID: "rat", Name: "rat", Glyph: "r", HP: 9, Attack: 0, Dodge: 0, Damage: "1d1"}, Pos: Pos{3, 0}, HP: 9}
+	far := &Creature{Def: &content.MonsterDef{ID: "rat", Name: "rat", Glyph: "r", HP: 9, Attack: 0, Dodge: 0, Damage: "1d1"}, Pos: Pos{8, 1}, HP: 9}
+	g.Level.Creatures = append(g.Level.Creatures, dragon, bystander, far)
+	g.Player = Pos{4, 1} // three east of the dragon: the cone's tip
+	g.worldTick()
+	if g.PlayerHP >= 20 {
+		t.Error("the breath should burn the player at the cone's tip (C 2d4, no dodge)")
+	}
+	if bystander.HP >= 9 {
+		t.Error("friendly fire: a bystander inside the cone burns too (C breath_weapon)")
+	}
+	if far.HP != 9 {
+		t.Error("a creature outside the cone is untouched")
+	}
+	if !hasMessage(g, "The dragon breathes fire!") {
+		t.Errorf("expected the C breath line, got %v", g.Messages)
+	}
+}
+
+func TestPoisonBreathPoisons(t *testing.T) {
+	g := combatGame()
+	toad := &Creature{Def: &content.MonsterDef{ID: "toad", Name: "giant slimy toad", Glyph: "t", HP: 14, Attack: 5, Dodge: 1, Damage: "1d4", Breath: "poison"}, Pos: Pos{1, 1}, HP: 14}
+	g.Level.Creatures = append(g.Level.Creatures, toad)
+	g.Player = Pos{4, 1}
+	g.worldTick()
+	if !g.HasEffect("poison") {
+		t.Error("noxious breath poisons the player for 12 turns (C NOXIOUS_BREATH_POISON)")
+	}
+	if !hasMessage(g, "You inhale the vile fumes!") {
+		t.Errorf("expected the C inhale line, got %v", g.Messages)
+	}
+}
+
+func TestBreatherClosesWhenOutOfRange(t *testing.T) {
+	g := combatGame()
+	dragon := &Creature{Def: &content.MonsterDef{ID: "dragon", Name: "dragon", Glyph: "D", HP: 60, Attack: 10, Dodge: 2, Damage: "2d6", Breath: "fire"}, Pos: Pos{8, 1}, HP: 60}
+	g.Level.Creatures = append(g.Level.Creatures, dragon)
+	g.worldTick()
+	if dragon.Pos.X != 7 {
+		t.Errorf("out of breath range the dragon closes in, at %v", dragon.Pos)
+	}
+	if g.PlayerHP != 20 {
+		t.Error("no breath should reach from range 7")
+	}
+}

--- a/go/internal/game/combat.go
+++ b/go/internal/game/combat.go
@@ -459,6 +459,10 @@ func (g *Game) monsterAct(m *Creature) {
 	if m.HasEffect("blind") {
 		return // blinded: it can flail at an adjacent foe but can't track at range
 	}
+	if r := breathRange(m); r > 0 && dist <= r && g.lineOfSight(m.Pos, g.Player) {
+		g.breathe(m)
+		return
+	}
 	if m.Def.Ranged > 0 && dist <= m.Def.Ranged && g.lineOfSight(m.Pos, g.Player) {
 		g.rangedAttack(m)
 		return


### PR DESCRIPTION
## Summary
Plan 19a — the breath subsystem (`breath.c`), monster side, settling the Lurker's TODO from #59 and giving the Dragon its signature:

- **Cone geometry** (`area.c area_cone`, ported exactly): walk the range along the direction, swelling sideways with two perpendicular rays each step — including the C's quirk that the **tip narrows back to a point** (`swell = MIN(range, swell)` after the decrement). Walls stop the spine and rays; water/lava don't (the C's `is_flyable`).
- **Resolution** (`breath_weapon`): everything in the cone takes the roll — **no dodge, friendly fire included** (your imp can be collateral). Fire: 2d4, range 3. Poison: 1d2 + 12-turn poison, range 4. The C messages throughout ("breathes fire!", "You get burned!", "You inhale the vile fumes!").
- **AI** (bounded vs the C's `cone_direction` + EP costs, noted in the plan): a breather with the player in range and line of sight exhales along the dominant direction; adjacent it still bites; out of range it closes in.
- **The six 0.40 breathers** flagged: dragon / burning skull / flame spirit → fire; lurker / **hellhound** / giant slimy toad → poison. (Yes — the C hellhound breathes *poison*, `monster.c:588`; the golden test documents the surprise.)

## Test plan
- Cone shape east at range 3 is exactly the 3-3-1 triangle; a mid-spine wall clips it.
- Fire breath burns the player at the tip and a bystander rat in the flank, spares one outside; poison breath poisons with the C lines; an out-of-range breather closes in instead.
- Validation restricts `breath` to fire/poison; golden covers all six.
- gofmt + go vet + full `go test ./...` green (10/10 packages).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Monsters now have cone breath attacks: fire deals burn damage; poison applies a poison status. Affected monsters include Dragon, Burning Skull, Flame Spirit, Hellhound, Giant Slimy Toad, and Lurker.
* **Tests**
  * Added unit and content tests validating breath types, cone shapes, obstacle interaction, damage/effects, messaging, and AI range behavior.
* **Documentation**
  * Added an implementation plan describing design, validation, test tasks, and acceptance criteria.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->