### PR TITLE
Breath spellbooks (the player exhales too)

### DIFF
--- a/docs/superpowers/plans/2026-06-10-breath-books-19b.md
+++ b/docs/superpowers/plans/2026-06-10-breath-books-19b.md
@@ -1,0 +1,40 @@
+# Breath spellbooks (19b) Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Breath arc 2/2: the player exhales too. 0.40's first two spellbooks
+(`treasure.h:131`) are **book of Noxious Breath** and **book of Breathe
+Fire** — both cost 5 EP (`attrs.c:434/438`) and ride the cone machinery from
+#70. Advances #19 + #15.
+
+## C grounding
+- `treasure.h:132-133` + `treasure.c:1080/1086`: the books exist and are
+  named "book of Noxious Breath" / "book of Breathe Fire" (the C's "book
+  of" + capitals; our older five books say "spellbook of x" — a pre-existing
+  local convention left alone).
+- `attrs.c`: both invoke the same `breath_weapon` the monsters use, cost 5.
+- `breath.c`: the player picks a direction; "You breathe fire!"/"You breathe
+  poison!"; everything in the cone is hit, friendly fire (your imp!)
+  included, per-target rolls.
+
+## Design
+- `ItemDef.Breath` ("fire"/"poison", validated) mirroring MonsterDef.
+- `playerBreathe(kind, target)` in breath.go: direction from
+  `signOf(target − player)`, the #70 cone/damage/poison constants, kills via
+  `killCreature`.
+- `CastSpellAt`: a breath book spends its EP and exhales (before the beam
+  branch); the ui's cast wiring targets when `Ranged > 0 || Breath != ""` —
+  the existing Target prompt supplies the direction, no Prompter change.
+- Data: the two books, cost 5, C names; goldens.
+
+## Task: playerBreathe + cast wiring + data (TDD)
+**Files:** `internal/game/{breath,spell}.go` + tests, `internal/ui/ui.go`,
+`internal/content/content.go`, data + goldens.
+- Tests first: casting Breathe Fire at a rat three east burns it and a
+  flank bystander, spares one beyond the cone, spends 5 EP; Noxious Breath
+  poisons; insufficient EP refuses without a turn.
+- Commit: `feat(content): breath spellbooks — the player exhales too`
+- Full gate; push, PR, CodeRabbit loop → merge.
+
+## Done when
+Five EP buys you a cone of your own — point it away from the imp. Suite green.

--- a/go/data/data_test.go
+++ b/go/data/data_test.go
@@ -833,3 +833,18 @@ func TestEmbeddedBreathers(t *testing.T) {
 		}
 	}
 }
+
+// TestEmbeddedBreathBooks checks 0.40's first two spellbooks loaded (19b),
+// with the C's "book of" capitalized names.
+func TestEmbeddedBreathBooks(t *testing.T) {
+	c, err := content.Load(Files)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if b := c.Items["book_breathe_fire"]; b == nil || b.Kind != "spellbook" || b.Breath != "fire" || b.Cost != 5 || b.Name != "book of Breathe Fire" {
+		t.Errorf("book_breathe_fire def unexpected: %+v", b)
+	}
+	if b := c.Items["book_noxious_breath"]; b == nil || b.Kind != "spellbook" || b.Breath != "poison" || b.Cost != 5 || b.Name != "book of Noxious Breath" {
+		t.Errorf("book_noxious_breath def unexpected: %+v", b)
+	}
+}

--- a/go/data/items.toml
+++ b/go/data/items.toml
@@ -478,3 +478,21 @@ color = "normal"
 kind = "scroll"
 use = "summon_familiar"
 power = 500
+
+# Breath spellbooks (19b, C treasure.h's first two books): a cone of your own,
+# 5 EP each (C attrs.c). Point it away from the imp.
+[item.book_breathe_fire]
+name = "book of Breathe Fire"
+glyph = "+"
+color = "red"
+kind = "spellbook"
+breath = "fire"
+cost = 5
+
+[item.book_noxious_breath]
+name = "book of Noxious Breath"
+glyph = "+"
+color = "green"
+kind = "spellbook"
+breath = "poison"
+cost = 5

--- a/go/internal/content/content.go
+++ b/go/internal/content/content.go
@@ -100,6 +100,7 @@ type ItemDef struct {
 	Beam        bool   `toml:"beam"`         // a spell that strikes every creature in a line
 	NoSpawn     bool   `toml:"nospawn"`      // exclude from random floor loot (e.g. corpses)
 	Weight      int    `toml:"weight"`       // carry weight (0 = kind default, C rules.h WEIGHT_*)
+	Breath      string `toml:"breath"`       // spellbook cone: "fire", "poison", or "" (#19)
 }
 
 // kindWeights are the C's per-kind WEIGHT_* defaults (rules.h); an item with
@@ -467,8 +468,8 @@ func validateItem(i *ItemDef) error {
 	case "spellbook":
 		hasUse := strings.TrimSpace(i.Use) != ""
 		hasAttack := i.Ranged > 0 && i.Damage != ""
-		if !hasUse && !hasAttack {
-			return fmt.Errorf("spellbook needs a use behavior or a ranged damage spec")
+		if !hasUse && !hasAttack && i.Breath == "" {
+			return fmt.Errorf("spellbook needs a use behavior, a ranged damage spec, or a breath")
 		}
 		if hasAttack && !validDamageSpec(i.Damage) {
 			return fmt.Errorf("spellbook damage %q is not a valid dice spec", i.Damage)
@@ -507,6 +508,9 @@ func validateItem(i *ItemDef) error {
 	}
 	if i.Weight < 0 {
 		return fmt.Errorf("weight must be >= 0, got %d", i.Weight)
+	}
+	if i.Breath != "" && i.Breath != "fire" && i.Breath != "poison" {
+		return fmt.Errorf("breath must be fire or poison, got %q", i.Breath)
 	}
 	if i.Light < 0 {
 		return fmt.Errorf("light must be >= 0, got %d", i.Light)

--- a/go/internal/game/breath.go
+++ b/go/internal/game/breath.go
@@ -112,3 +112,32 @@ func (g *Game) breathe(m *Creature) {
 		}
 	}
 }
+
+// playerBreathe is the player's exhale (C breath.c, the is_player branch):
+// a cone toward the chosen target hitting every creature in it — your own
+// allies included — with the same per-target rolls the monsters use.
+func (g *Game) playerBreathe(kind string, target Pos) {
+	rng := breathFireRange
+	if kind == "fire" {
+		g.log("You breathe fire!")
+	} else {
+		g.log("You breathe poison!")
+		rng = breathPoisonRange
+	}
+	dx, dy := signOf(target.X-g.Player.X), signOf(target.Y-g.Player.Y)
+	for _, p := range g.breathCone(g.Player, dx, dy, rng) {
+		c := g.Level.CreatureAt(p)
+		if c == nil {
+			continue
+		}
+		if kind == "fire" {
+			c.HP -= g.RNG.RollSpec(breathFireDamage)
+		} else {
+			c.HP -= g.RNG.RollSpec(breathPoisonDamage)
+			c.AddEffect("poison", breathPoisonTurns)
+		}
+		if c.HP <= 0 {
+			g.killCreature(c)
+		}
+	}
+}

--- a/go/internal/game/breath_test.go
+++ b/go/internal/game/breath_test.go
@@ -84,3 +84,54 @@ func TestBreatherClosesWhenOutOfRange(t *testing.T) {
 		t.Error("no breath should reach from range 7")
 	}
 }
+
+func TestCastBreatheFireBurnsTheCone(t *testing.T) {
+	g := combatGame()
+	g.EP, g.EPMax = 10, 10
+	book := &Item{Def: &content.ItemDef{Name: "book of Breathe Fire", Kind: "spellbook", Cost: 5, Breath: "fire"}}
+	rat := &Creature{Def: &content.MonsterDef{ID: "rat", Name: "rat", Glyph: "r", HP: 9, Attack: 0, Dodge: 0, Damage: "1d1"}, Pos: Pos{4, 1}, HP: 9}
+	flank := &Creature{Def: &content.MonsterDef{ID: "rat", Name: "rat", Glyph: "r", HP: 9, Attack: 0, Dodge: 0, Damage: "1d1"}, Pos: Pos{3, 0}, HP: 9}
+	far := &Creature{Def: &content.MonsterDef{ID: "rat", Name: "rat", Glyph: "r", HP: 9, Attack: 0, Dodge: 0, Damage: "1d1"}, Pos: Pos{8, 1}, HP: 9}
+	g.Level.Creatures = append(g.Level.Creatures, rat, flank, far)
+	g.CastSpellAt(book, rat.Pos)
+	if rat.HP >= 9 || flank.HP >= 9 {
+		t.Error("the cone should burn the target and the flank bystander")
+	}
+	if far.HP != 9 {
+		t.Error("a creature beyond the cone is untouched")
+	}
+	if g.EP != 5 {
+		t.Errorf("the cast costs 5 EP (C attrs.c), EP %d", g.EP)
+	}
+	if !hasMessage(g, "You breathe fire!") {
+		t.Errorf("expected the C cast line, got %v", g.Messages)
+	}
+}
+
+func TestCastNoxiousBreathPoisons(t *testing.T) {
+	g := combatGame()
+	g.EP, g.EPMax = 10, 10
+	book := &Item{Def: &content.ItemDef{Name: "book of Noxious Breath", Kind: "spellbook", Cost: 5, Breath: "poison"}}
+	rat := &Creature{Def: &content.MonsterDef{ID: "rat", Name: "rat", Glyph: "r", HP: 9, Attack: 0, Dodge: 0, Damage: "1d1"}, Pos: Pos{3, 1}, HP: 9}
+	g.Level.Creatures = append(g.Level.Creatures, rat)
+	g.CastSpellAt(book, rat.Pos)
+	if !rat.HasEffect("poison") {
+		t.Error("noxious breath poisons the cone's occupants (C NOXIOUS_BREATH_POISON)")
+	}
+	if !hasMessage(g, "You breathe poison!") {
+		t.Errorf("expected the C cast line, got %v", g.Messages)
+	}
+}
+
+func TestBreathCastRefusedWithoutEP(t *testing.T) {
+	g := combatGame()
+	g.EP, g.EPMax = 2, 10
+	book := &Item{Def: &content.ItemDef{Name: "book of Breathe Fire", Kind: "spellbook", Cost: 5, Breath: "fire"}}
+	g.CastSpellAt(book, Pos{4, 1})
+	if g.EP != 2 {
+		t.Error("a refused cast must not spend EP")
+	}
+	if hasMessage(g, "You breathe fire!") {
+		t.Error("no EP, no fire")
+	}
+}

--- a/go/internal/game/spell.go
+++ b/go/internal/game/spell.go
@@ -53,6 +53,12 @@ func (g *Game) CastSpellAt(book *Item, target Pos) {
 		g.log("You lack the energy to cast %s.", book.Def.Name)
 		return
 	}
+	if book.Def.Breath != "" { // a breath book exhales a cone toward the target
+		g.EP -= book.Def.Cost
+		g.playerBreathe(book.Def.Breath, target)
+		g.advanceWorld()
+		return
+	}
 	if book.Def.Beam { // a beam fires in the aimed direction, hitting all in its path
 		g.EP -= book.Def.Cost
 		g.fireBeam(book, target)

--- a/go/internal/ui/ui.go
+++ b/go/internal/ui/ui.go
@@ -258,7 +258,7 @@ func Run(g *game.Game, p Prompter, r Renderer) error {
 				break
 			}
 			spell := spells[idx]
-			if spell.Def != nil && spell.Def.Ranged > 0 { // a targeted attack spell
+			if spell.Def != nil && (spell.Def.Ranged > 0 || spell.Def.Breath != "") { // a targeted or directed spell
 				if target, ok := p.Target(g.Player); ok {
 					g.CastSpellAt(spell, target)
 				}


### PR DESCRIPTION
## Summary
Plan 19b — breath arc 2/2. 0.40's first two spellbooks (`treasure.h:132-133`), both 5 EP (`attrs.c:434/438`), riding the #70 cone machinery:

- **book of Breathe Fire** / **book of Noxious Breath** (the C's "book of" capitalized names, `treasure.c:1080/1086`): `playerBreathe` exhales the same cone the monsters use — per-target rolls, friendly fire (your imp!), "You breathe fire!"/"You breathe poison!".
- **No Prompter change**: a cone only needs a direction, derived from the existing `Target` prompt (`signOf(target − player)`); the ui's cast wiring targets when `Ranged > 0 || Breath != ""`.
- `ItemDef.Breath` mirrors the monster field with the same validation; the spellbook validator gains the breath mode as a third legitimate shape (use / ranged+damage / breath).

## Test plan
- Casting Breathe Fire at a rat three east burns it and a flank bystander, spares one beyond the cone, spends exactly 5 EP.
- Noxious Breath poisons the cone's occupants; an empty EP pool refuses without spending or passing a turn.
- Goldens for both books (names, costs, breath kinds); validation rejects unknown breath values.
- gofmt + go vet + full `go test ./...` green (10/10 packages).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added two new spellbooks: "Breathe Fire" and "Noxious Breath" that cast directional cone attacks.
  * Breath spells consume EP and can hit multiple enemies in a cone pattern.
  * Poison breath now applies the poison effect to affected creatures in range.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->