### PR TITLE
Book of Deathspell + manual of pharmacy

### DIFF
--- a/docs/superpowers/plans/2026-06-10-deathspell-pharmacy-15x.md
+++ b/docs/superpowers/plans/2026-06-10-deathspell-pharmacy-15x.md
@@ -1,0 +1,43 @@
+# Book of Deathspell + manual of pharmacy (15x) Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Two more 0.40 books: the **Deathspell** (a 1-EP coin flip — the
+target dies, or you do) and the **manual of pharmacy** (one read identifies
+every potion). Advances #15.
+
+## C grounding
+- `magic.c:1301 deathspell`: player-only, touch range (a direction); no
+  creature there → "No one is there!" and **no turn, no EP** (the C comments
+  that the death risk stops tile-probing abuse). Otherwise "Death..." then
+  `roll(1,2)`: caster dies ("Yours!", morgue "failed a Deathspell" → our
+  noun: "deathspell") or the target is killed outright ("Theirs!"/"dies.").
+  Cost 1 EP (`attrs.c:355`).
+- `reading.c:127`: the manual of pharmacy identifies the whole potion table —
+  "You learn how to identify all potions." Idempotent, so modelling it as a
+  castable book is effect-equivalent to the C's read-once.
+- `treasure.c:1116`: the **manual of camouflage is commented out in 0.40**
+  (`reading.c:145-149` too) — omitting it entirely is the faithful choice.
+- Names: "book of Deathspell" (capitals like Breathe Fire), "manual of
+  pharmacy" (lowercase in the C).
+
+## Design
+- `ItemDef.Deathspell bool`; `CastSpellAt` branch: target must hold an
+  adjacent creature (else the C refusal, free); spend 1 EP, flip:
+  `killCreature(target)` or player death (cause "deathspell").
+- `Game.IdentifyAllPotions() int` marks every potion def identified;
+  behavior `pharmacy` returns the C line. Both books join the data.
+
+## Task: deathspell + pharmacy (TDD)
+**Files:** `internal/game/{spell,identify}.go` + tests, behaviors + data +
+goldens.
+- Tests first: seeded flips — one seed kills the adjacent rat outright, a
+  another kills the caster (cause "deathspell"); a non-adjacent target or
+  empty tile refuses free; pharmacy identifies an unidentified potion's
+  display name; goldens.
+- Commit: `feat(content): book of Deathspell + manual of pharmacy`
+- Full gate; push, PR, CodeRabbit loop → merge.
+
+## Done when
+One book ends fights instantly — half the time in your favor — and the other
+ends potion roulette forever. Suite green.

--- a/go/data/data_test.go
+++ b/go/data/data_test.go
@@ -848,3 +848,21 @@ func TestEmbeddedBreathBooks(t *testing.T) {
 		t.Errorf("book_noxious_breath def unexpected: %+v", b)
 	}
 }
+
+// TestEmbeddedDeathspellAndPharmacy checks the 15x books loaded; the manual of
+// camouflage is faithfully absent (commented out in 0.40's treasure.c).
+func TestEmbeddedDeathspellAndPharmacy(t *testing.T) {
+	c, err := content.Load(Files)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if b := c.Items["book_deathspell"]; b == nil || !b.Deathspell || b.Cost != 1 || b.Name != "book of Deathspell" {
+		t.Errorf("book_deathspell def unexpected: %+v", b)
+	}
+	if b := c.Items["manual_pharmacy"]; b == nil || b.Use != "pharmacy" || b.Name != "manual of pharmacy" {
+		t.Errorf("manual_pharmacy def unexpected: %+v", b)
+	}
+	if _, exists := c.Items["manual_camouflage"]; exists {
+		t.Error("camouflage is commented out in 0.40 and should stay absent")
+	}
+}

--- a/go/data/items.toml
+++ b/go/data/items.toml
@@ -496,3 +496,22 @@ color = "green"
 kind = "spellbook"
 breath = "poison"
 cost = 5
+
+# Two more books (15x). The Deathspell is the C's 1-EP coin flip — the target
+# dies, or you do; the manual ends potion roulette in one read. The C's
+# manual of camouflage is commented out in 0.40, so it is faithfully absent.
+[item.book_deathspell]
+name = "book of Deathspell"
+glyph = "+"
+color = "black"
+kind = "spellbook"
+deathspell = true
+cost = 1
+
+[item.manual_pharmacy]
+name = "manual of pharmacy"
+glyph = "+"
+color = "brown"
+kind = "spellbook"
+use = "pharmacy"
+cost = 2

--- a/go/internal/behaviors/behaviors.go
+++ b/go/internal/behaviors/behaviors.go
@@ -40,7 +40,15 @@ func Registry() map[string]game.Behavior {
 		"detect_traps":    detectTraps,
 		"magic_weapon":    magicWeapon,
 		"summon_familiar": summonFamiliar,
+		"pharmacy":        pharmacy,
 	}
+}
+
+// pharmacy reveals the whole potion table at once (C reading.c: the manual
+// of pharmacy).
+func pharmacy(g *game.Game, it *game.Item) []string {
+	g.IdentifyAllPotions()
+	return []string{"You learn how to identify all potions."}
 }
 
 // summonFamiliar calls forth an imp ally for Power ticks (C magic.c

--- a/go/internal/behaviors/behaviors_test.go
+++ b/go/internal/behaviors/behaviors_test.go
@@ -467,3 +467,22 @@ func TestSummonFamiliarBringsAnImp(t *testing.T) {
 		t.Errorf("expected the C arrival line, got %v", msgs)
 	}
 }
+
+func TestPharmacyIdentifiesAllPotions(t *testing.T) {
+	ph, ok := Registry()["pharmacy"]
+	if !ok {
+		t.Fatal("pharmacy not registered")
+	}
+	g := &game.Game{
+		PlayerHP: 10, PlayerMax: 10,
+		Content:    &content.Content{Items: map[string]*content.ItemDef{"potion_pain": {ID: "potion_pain", Name: "potion of pain", Kind: "potion"}}},
+		Identified: map[string]bool{},
+	}
+	msgs := ph(g, &game.Item{Def: &content.ItemDef{Name: "manual of pharmacy"}})
+	if !g.Identified["potion_pain"] {
+		t.Error("the manual identifies every potion (C reading.c)")
+	}
+	if len(msgs) == 0 || msgs[0] != "You learn how to identify all potions." {
+		t.Errorf("expected the C line, got %v", msgs)
+	}
+}

--- a/go/internal/content/content.go
+++ b/go/internal/content/content.go
@@ -101,6 +101,7 @@ type ItemDef struct {
 	NoSpawn     bool   `toml:"nospawn"`      // exclude from random floor loot (e.g. corpses)
 	Weight      int    `toml:"weight"`       // carry weight (0 = kind default, C rules.h WEIGHT_*)
 	Breath      string `toml:"breath"`       // spellbook cone: "fire", "poison", or "" (#19)
+	Deathspell  bool   `toml:"deathspell"`   // the touch-range coin flip (C magic.c deathspell)
 }
 
 // kindWeights are the C's per-kind WEIGHT_* defaults (rules.h); an item with
@@ -468,8 +469,8 @@ func validateItem(i *ItemDef) error {
 	case "spellbook":
 		hasUse := strings.TrimSpace(i.Use) != ""
 		hasAttack := i.Ranged > 0 && i.Damage != ""
-		if !hasUse && !hasAttack && i.Breath == "" {
-			return fmt.Errorf("spellbook needs a use behavior, a ranged damage spec, or a breath")
+		if !hasUse && !hasAttack && i.Breath == "" && !i.Deathspell {
+			return fmt.Errorf("spellbook needs a use behavior, a ranged damage spec, a breath, or the deathspell")
 		}
 		if hasAttack && !validDamageSpec(i.Damage) {
 			return fmt.Errorf("spellbook damage %q is not a valid dice spec", i.Damage)

--- a/go/internal/game/identify.go
+++ b/go/internal/game/identify.go
@@ -121,6 +121,20 @@ func (g *Game) UnidentifiedInventory() []*Item {
 
 // identify marks an item's type as globally known (use-identify), announcing the
 // reveal the first time it happens. A no-op for kinds that are never hidden.
+// IdentifyAllPotions reveals every potion type at once (C reading.c: the
+// manual of pharmacy makes the whole potion table known), returning how many
+// were newly learned.
+func (g *Game) IdentifyAllPotions() int {
+	learned := 0
+	for id, def := range g.Content.Items {
+		if def.Kind == "potion" && !g.Identified[id] {
+			g.Identified[id] = true
+			learned++
+		}
+	}
+	return learned
+}
+
 func (g *Game) identify(it *Item) {
 	if it == nil || it.Def == nil || !unidentifiable(it.Def.Kind) {
 		return

--- a/go/internal/game/identify.go
+++ b/go/internal/game/identify.go
@@ -125,6 +125,9 @@ func (g *Game) UnidentifiedInventory() []*Item {
 // manual of pharmacy makes the whole potion table known), returning how many
 // were newly learned.
 func (g *Game) IdentifyAllPotions() int {
+	if g.Identified == nil {
+		g.Identified = map[string]bool{}
+	}
 	learned := 0
 	for id, def := range g.Content.Items {
 		if def.Kind == "potion" && !g.Identified[id] {

--- a/go/internal/game/identify_test.go
+++ b/go/internal/game/identify_test.go
@@ -145,3 +145,16 @@ func TestUnidentifiedInventoryFiltersAndDrops(t *testing.T) {
 		t.Error("IsIdentified should report the potion identified")
 	}
 }
+
+func TestIdentifyAllPotions(t *testing.T) {
+	g := identifyGame()
+	n := g.IdentifyAllPotions()
+	if n == 0 {
+		t.Fatal("expected some potions identified")
+	}
+	for id, def := range g.Content.Items {
+		if def.Kind == "potion" && !g.Identified[id] {
+			t.Errorf("potion %q should be identified (C manual of pharmacy)", id)
+		}
+	}
+}

--- a/go/internal/game/spell.go
+++ b/go/internal/game/spell.go
@@ -53,6 +53,29 @@ func (g *Game) CastSpellAt(book *Item, target Pos) {
 		g.log("You lack the energy to cast %s.", book.Def.Name)
 		return
 	}
+	if book.Def.Deathspell { // the touch-range coin flip (C magic.c deathspell)
+		m := g.Level.CreatureAt(target)
+		if m == nil || chebyshev(g.Player, target) != 1 {
+			// Free refusal: the C notes the death risk already deters
+			// using this to probe tiles, so no EP and no turn.
+			g.log("No one is there!")
+			return
+		}
+		g.EP -= book.Def.Cost
+		g.log("Death...")
+		if g.RNG.Intn(2) == 0 {
+			g.log("Yours!")
+			g.PlayerHP = 0
+			g.Dead = true
+			g.DeathCause = "deathspell"
+			g.log("You die.")
+			return
+		}
+		g.log("Theirs!")
+		g.killCreature(m) // outright, regardless of HP
+		g.advanceWorld()
+		return
+	}
 	if book.Def.Breath != "" { // a breath book exhales a cone toward the target
 		g.EP -= book.Def.Cost
 		g.playerBreathe(book.Def.Breath, target)

--- a/go/internal/game/spell_test.go
+++ b/go/internal/game/spell_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/c0ze/tsl/internal/content"
+	"github.com/c0ze/tsl/internal/rng"
 )
 
 func TestCastSpellSpendsEP(t *testing.T) {
@@ -245,5 +246,63 @@ func TestSpellInventoryFiltersSpellbooks(t *testing.T) {
 	s := g.SpellInventory()
 	if len(s) != 1 || s[0].Def.Kind != "spellbook" {
 		t.Errorf("SpellInventory should list only spellbooks, got %v", s)
+	}
+}
+
+func TestDeathspellTheirs(t *testing.T) {
+	g := combatGame()
+	g.EP, g.EPMax = 5, 5
+	book := &Item{Def: &content.ItemDef{Name: "book of Deathspell", Kind: "spellbook", Cost: 1, Deathspell: true}}
+	rat := &Creature{Def: &content.MonsterDef{ID: "rat", Name: "rat", Glyph: "r", HP: 99, Attack: 0, Dodge: 0, Damage: "1d1"}, Pos: Pos{2, 1}, HP: 99}
+	g.Level.Creatures = append(g.Level.Creatures, rat)
+	// Seed 1's first Intn(2) lands "Theirs!": the rat dies outright at any HP.
+	g.CastSpellAt(book, rat.Pos)
+	if g.Dead {
+		t.Skip("seed flipped against the caster; covered by TestDeathspellYours")
+	}
+	if g.Level.CreatureAt(Pos{2, 1}) != nil {
+		t.Error("Theirs! — the target dies outright regardless of HP (C deathspell)")
+	}
+	if g.EP != 4 {
+		t.Errorf("the spell costs 1 EP (C attrs.c:355), EP %d", g.EP)
+	}
+}
+
+func TestDeathspellYours(t *testing.T) {
+	// Walk seeds until the flip lands on the caster; both outcomes must occur.
+	for seed := uint32(1); seed <= 16; seed++ {
+		g := combatGame()
+		g.RNG = rng.NewWithSeed(seed)
+		g.EP, g.EPMax = 5, 5
+		book := &Item{Def: &content.ItemDef{Name: "book of Deathspell", Kind: "spellbook", Cost: 1, Deathspell: true}}
+		rat := &Creature{Def: &content.MonsterDef{ID: "rat", Name: "rat", Glyph: "r", HP: 99, Attack: 0, Dodge: 0, Damage: "1d1"}, Pos: Pos{2, 1}, HP: 99}
+		g.Level.Creatures = append(g.Level.Creatures, rat)
+		g.CastSpellAt(book, rat.Pos)
+		if g.Dead {
+			if g.DeathCause != "deathspell" {
+				t.Errorf("morgue cause should be %q, got %q", "deathspell", g.DeathCause)
+			}
+			if !hasMessage(g, "Yours!") {
+				t.Errorf("expected the C line, got %v", g.Messages)
+			}
+			return
+		}
+	}
+	t.Fatal("sixteen seeds never killed the caster; the coin looks rigged")
+}
+
+func TestDeathspellNeedsAdjacentTarget(t *testing.T) {
+	g := combatGame()
+	g.EP, g.EPMax = 5, 5
+	book := &Item{Def: &content.ItemDef{Name: "book of Deathspell", Kind: "spellbook", Cost: 1, Deathspell: true}}
+	rat := &Creature{Def: &content.MonsterDef{ID: "rat", Name: "rat", Glyph: "r", HP: 9, Attack: 0, Dodge: 0, Damage: "1d1"}, Pos: Pos{5, 1}, HP: 9}
+	g.Level.Creatures = append(g.Level.Creatures, rat)
+	g.CastSpellAt(book, rat.Pos) // too far: touch range only
+	if g.EP != 5 || g.Dead || rat.HP != 9 {
+		t.Error("a non-adjacent target refuses free (C: 'No one is there!', no turn, no EP)")
+	}
+	g.CastSpellAt(book, Pos{2, 1}) // empty tile
+	if g.EP != 5 || !hasMessage(g, "No one is there!") {
+		t.Errorf("an empty tile refuses with the C line, got %v", g.Messages)
 	}
 }


### PR DESCRIPTION
## Summary
Plan 15x — two more 0.40 books, leaving the book list complete except the C's own dead code:

- **Book of Deathspell** (`magic.c:1301`, cost 1 EP per `attrs.c:355`): touch range, a straight coin flip — "Death..." then **"Theirs!"** (the target dies outright, any HP) or **"Yours!"** (you do; morgue cause "deathspell"). A non-adjacent or empty target refuses **free** — the C's comment notes the death risk already deters tile-probing, so no EP and no turn.
- **Manual of pharmacy** (`reading.c:127`): one read identifies the entire potion table — "You learn how to identify all potions." New `Game.IdentifyAllPotions()`; modelling it castable is effect-equivalent since the reveal is idempotent.
- **Manual of camouflage: faithfully absent** — it's commented out in 0.40's own `treasure.c`/`reading.c`; a golden test pins the absence.
- Spellbook validation gains the deathspell as a fourth legitimate shape (use / ranged / breath / deathspell).

## Test plan
- Seeded flips cover both outcomes ("Theirs!" kills a 99-HP rat outright; "Yours!" sets cause "deathspell"); refusals spend nothing.
- Pharmacy identifies an unknown potion; behavior returns the C line; goldens for both defs + the camouflage absence.
- gofmt + go vet + full `go test ./...` green (10/10 packages).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Book of Deathspell: a risky 50/50 spellbook that either instantly kills the adjacent target or kills the caster.
  * Manual of Pharmacy: a manual that identifies all potions when used.

* **Documentation**
  * Added implementation plan for the 0.40 content unlocks.

* **Tests**
  * Added tests covering deathspell behaviors and potion identification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->