### PR TITLE
Ammunition: arrows, stacking, Out of ammo!

### DIFF
--- a/docs/superpowers/plans/2026-06-10-ammunition-14a.md
+++ b/docs/superpowers/plans/2026-06-10-ammunition-14a.md
@@ -1,0 +1,37 @@
+# Ammunition (14a) Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** The shortbow stops firing for free: **arrows** as a stackable
+ammunition item, consumed per shot, with the C's "Out of ammo!" refusal.
+Closes #14's last noted TODO. Advances #14.
+
+## C grounding
+- `treasure.c:1332`: "crude arrow"/"crude arrows" (plus sharp/masterwork
+  tiers — one type bounds this PR, the quality tiers noted out of scope),
+  `item_type_ammo`, glyph `:` (`glyph.c:214`), weight 1 (`WEIGHT_MISSILE`),
+  found singly and in piles (`treasure_a_crude_pile`).
+- `player.c:1882-1887`: firing pulls one round from the equipped stack;
+  an empty quiver prints "Out of ammo!".
+
+## Design
+- Item kind `ammo` (validation + `kindWeights` 1); `arrow` def ("crude
+  arrow", `:`, power 8 = bundle size). Gen seeds `Charges` from Power like
+  wands; loot bundles land on floors.
+- **Stacking**: picking up ammo merges into an existing inventory stack of
+  the same def (Charges add; the duplicate item vanishes).
+- `FireWeapon`: a wielded bow needs an arrow stack — none or empty →
+  "Out of ammo!" free refusal; a shot consumes one, the stack vanishing at
+  zero.
+
+## Task: ammo kind + stacking + consumption (TDD)
+**Files:** `internal/content/content.go`, `internal/game/{fire,use}.go` +
+tests, `data/items.toml`, goldens.
+- Tests first: a shot consumes one arrow; the empty quiver refuses free with
+  the C line; pickup merges bundles; the stack disappears at zero; golden.
+- Commit: `feat(content): ammunition — arrows, stacking, Out of ammo!`
+- Full gate; push, PR, CodeRabbit loop → merge.
+
+## Done when
+Every shot counts — literally — and an empty quiver sends you back to the
+dagger. Suite green.

--- a/go/data/data_test.go
+++ b/go/data/data_test.go
@@ -866,3 +866,15 @@ func TestEmbeddedDeathspellAndPharmacy(t *testing.T) {
 		t.Error("camouflage is commented out in 0.40 and should stay absent")
 	}
 }
+
+// TestEmbeddedArrows checks the quiver loaded (14a): C crude arrows, glyph ':',
+// weight 1 (WEIGHT_MISSILE) via the ammo kind default.
+func TestEmbeddedArrows(t *testing.T) {
+	c, err := content.Load(Files)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if a := c.Items["arrow"]; a == nil || a.Kind != "ammo" || a.Glyph != ":" || a.Power != 8 || a.Weight != 1 {
+		t.Errorf("arrow def unexpected: %+v", a)
+	}
+}

--- a/go/data/items.toml
+++ b/go/data/items.toml
@@ -68,7 +68,7 @@ damage = "2d6"
 weight = 28
 
 # Ranged weapon (#14) — wield it, then fire (f) at a target in line of sight.
-# Weak in melee; its strength is reach. power/ammo are infinite for now.
+# Weak in melee; its strength is reach. Each shot spends a crude arrow (14a).
 [item.shortbow]
 name = "shortbow"
 glyph = "}"
@@ -515,3 +515,12 @@ color = "brown"
 kind = "spellbook"
 use = "pharmacy"
 cost = 2
+
+# Ammunition (14a, C treasure.c crude arrows): the shortbow stops firing for
+# free. Bundles merge into one quiver; power = arrows per found bundle.
+[item.arrow]
+name = "crude arrow"
+glyph = ":"
+color = "brown"
+kind = "ammo"
+power = 8

--- a/go/internal/content/content.go
+++ b/go/internal/content/content.go
@@ -108,7 +108,7 @@ type ItemDef struct {
 // no explicit weight inherits its kind's.
 var kindWeights = map[string]int{
 	"potion": 7, "scroll": 4, "wand": 21, "food": 8, "light": 12,
-	"spellbook": 12, "ring": 5, "amulet": 5, "weapon": 22, "armor": 40,
+	"spellbook": 12, "ring": 5, "amulet": 5, "weapon": 22, "armor": 40, "ammo": 1,
 }
 
 // Rune returns the item's glyph as a rune.
@@ -117,7 +117,7 @@ func (i *ItemDef) Rune() rune {
 	return r
 }
 
-var validItemKinds = map[string]bool{"potion": true, "weapon": true, "armor": true, "food": true, "wand": true, "scroll": true, "light": true, "spellbook": true, "ring": true, "amulet": true}
+var validItemKinds = map[string]bool{"potion": true, "weapon": true, "armor": true, "food": true, "wand": true, "scroll": true, "light": true, "spellbook": true, "ring": true, "amulet": true, "ammo": true}
 
 // SpawnEntry is one weighted entry in a level's monster spawn table.
 type SpawnEntry struct {

--- a/go/internal/game/fire.go
+++ b/go/internal/game/fire.go
@@ -19,6 +19,11 @@ func (g *Game) FireWeapon(target Pos) {
 		g.log("You have no ranged weapon to fire.")
 		return
 	}
+	arrows := g.ammoStack()
+	if arrows == nil {
+		g.log("Out of ammo!") // the C's empty-quiver refusal: free, no turn
+		return
+	}
 	if chebyshev(g.Player, target) > g.Weapon.Def.Ranged {
 		g.log("That is out of range.")
 		return
@@ -26,6 +31,11 @@ func (g *Game) FireWeapon(target Pos) {
 	if !g.lineOfSight(g.Player, target) {
 		g.log("You don't have a clear shot.")
 		return
+	}
+	// The arrow flies whether it finds flesh or floor (C: missiles are spent).
+	arrows.Charges--
+	if arrows.Charges <= 0 {
+		g.removeInventory(arrows)
 	}
 	if m := g.Level.CreatureAt(target); m != nil {
 		dmg := g.RNG.RollSpec(g.Weapon.Def.Damage)
@@ -38,4 +48,14 @@ func (g *Game) FireWeapon(target Pos) {
 		g.log("Your shot flies into empty space.")
 	}
 	g.advanceWorld()
+}
+
+// ammoStack returns the player's arrow bundle, or nil when the quiver is empty.
+func (g *Game) ammoStack() *Item {
+	for _, it := range g.Inventory {
+		if it.Def != nil && it.Def.Kind == "ammo" && it.Charges > 0 {
+			return it
+		}
+	}
+	return nil
 }

--- a/go/internal/game/fire_test.go
+++ b/go/internal/game/fire_test.go
@@ -7,8 +7,8 @@ import (
 )
 
 func TestFireWeaponKillsInRange(t *testing.T) {
-	g := combatGame() // player at (1,1), all floor
-	g.Weapon = &Item{Def: &content.ItemDef{Name: "shortbow", Kind: "weapon", Damage: "10d1", Ranged: 6}}
+	g := rangedGame() // player at (1,1), all floor
+	quiver(g, 5)
 	rat := &Creature{Def: &content.MonsterDef{ID: "rat", Name: "rat", HP: 3}, Pos: Pos{5, 1}, HP: 3}
 	g.Level.Creatures = append(g.Level.Creatures, rat)
 
@@ -61,5 +61,77 @@ func TestFireWeaponNoRangedWeapon(t *testing.T) {
 		// sanity: a plain dagger is not a ranged weapon
 	} else {
 		t.Error("a melee dagger should not count as a ranged weapon")
+	}
+}
+
+// rangedGame is a combat corridor with a wielded shortbow (arrows added per
+// test via quiver).
+func rangedGame() *Game {
+	g := combatGame()
+	g.Weapon = &Item{Def: &content.ItemDef{Name: "shortbow", Kind: "weapon", Damage: "10d1", Ranged: 6}}
+	return g
+}
+
+func quiver(g *Game, count int) *Item {
+	arrows := &Item{Def: &content.ItemDef{ID: "arrow", Name: "crude arrow", Kind: "ammo"}, Charges: count}
+	g.Inventory = append(g.Inventory, arrows)
+	return arrows
+}
+
+func TestFiringConsumesAnArrow(t *testing.T) {
+	g := rangedGame()
+	arrows := quiver(g, 3)
+	rat := &Creature{Def: &content.MonsterDef{ID: "rat", Name: "rat", Glyph: "r", HP: 9, Attack: 0, Dodge: 0, Damage: "1d1"}, Pos: Pos{4, 1}, HP: 9}
+	g.Level.Creatures = append(g.Level.Creatures, rat)
+	g.FireWeapon(rat.Pos)
+	if arrows.Charges != 2 {
+		t.Errorf("a shot spends one arrow (C throw_or_fire), %d left", arrows.Charges)
+	}
+	if rat.HP >= 9 {
+		t.Error("the shot should still land")
+	}
+}
+
+func TestEmptyQuiverRefusesFree(t *testing.T) {
+	g := rangedGame()
+	rat := &Creature{Def: &content.MonsterDef{ID: "rat", Name: "rat", Glyph: "r", HP: 9, Attack: 0, Dodge: 0, Damage: "1d1"}, Pos: Pos{4, 1}, HP: 9}
+	g.Level.Creatures = append(g.Level.Creatures, rat)
+	g.FireWeapon(rat.Pos) // no arrows at all
+	if rat.HP != 9 {
+		t.Error("no arrow, no shot")
+	}
+	if !hasMessage(g, "Out of ammo!") {
+		t.Errorf("expected the C refusal, got %v", g.Messages)
+	}
+}
+
+func TestLastArrowEmptiesTheQuiver(t *testing.T) {
+	g := rangedGame()
+	quiver(g, 1)
+	rat := &Creature{Def: &content.MonsterDef{ID: "rat", Name: "rat", Glyph: "r", HP: 99, Attack: 0, Dodge: 0, Damage: "1d1"}, Pos: Pos{4, 1}, HP: 99}
+	g.Level.Creatures = append(g.Level.Creatures, rat)
+	g.FireWeapon(rat.Pos)
+	for _, it := range g.Inventory {
+		if it.Def.Kind == "ammo" {
+			t.Fatal("an emptied stack should leave the pack")
+		}
+	}
+}
+
+func TestPickupMergesArrowStacks(t *testing.T) {
+	g := rangedGame()
+	def := &content.ItemDef{ID: "arrow", Name: "crude arrow", Kind: "ammo", Power: 8}
+	g.Inventory = append(g.Inventory, &Item{Def: def, Charges: 5})
+	g.Level.Items = append(g.Level.Items, &Item{Def: def, Charges: 8, Pos: g.Player})
+	g.PlayerPickup()
+	stacks, total := 0, 0
+	for _, it := range g.Inventory {
+		if it.Def.Kind == "ammo" {
+			stacks++
+			total += it.Charges
+		}
+	}
+	if stacks != 1 || total != 13 {
+		t.Errorf("bundles merge into one quiver: %d stacks holding %d", stacks, total)
 	}
 }

--- a/go/internal/game/use.go
+++ b/go/internal/game/use.go
@@ -12,6 +12,16 @@ func (g *Game) PlayerPickup() {
 	}
 	wasBurdened := g.burdened()
 	g.Level.RemoveItem(it)
+	if it.Def.Kind == "ammo" { // bundles merge into one quiver
+		for _, held := range g.Inventory {
+			if held.Def == it.Def {
+				held.Charges += it.Charges
+				g.log("You pick up the %s.", it.Def.Name)
+				g.advanceWorld()
+				return
+			}
+		}
+	}
 	g.Inventory = append(g.Inventory, it)
 	g.log("You pick up the %s.", it.Def.Name)
 	if !wasBurdened && g.burdened() {

--- a/go/internal/gen/gen.go
+++ b/go/internal/gen/gen.go
@@ -144,8 +144,8 @@ func placeItems(r *rng.MT, c *content.Content, lvl *game.Level, rooms []rect, st
 		}
 		def := c.Items[ids[r.Intn(len(ids))]]
 		it := &game.Item{Def: def, Pos: pos}
-		if def.Kind == "wand" {
-			it.Charges = def.Power // seed wand charges from its power
+		if def.Kind == "wand" || def.Kind == "ammo" {
+			it.Charges = def.Power // wand charges / arrows in the bundle
 		}
 		lvl.Items = append(lvl.Items, it)
 	}

--- a/go/internal/ui/ui_test.go
+++ b/go/internal/ui/ui_test.go
@@ -318,6 +318,7 @@ func TestRunFireWeaponAtCreature(t *testing.T) {
 	g := testGame(t, []string{".....", ".@...", "....."})
 	g.RNG = rng.NewWithSeed(1)
 	g.Weapon = &game.Item{Def: &content.ItemDef{Name: "shortbow", Kind: "weapon", Damage: "10d1", Ranged: 6}}
+	g.Inventory = append(g.Inventory, &game.Item{Def: &content.ItemDef{ID: "arrow", Name: "crude arrow", Kind: "ammo"}, Charges: 3})
 	g.Level.Creatures = append(g.Level.Creatures, &game.Creature{Def: &content.MonsterDef{ID: "rat", Name: "rat", HP: 3}, Pos: game.Pos{X: 3, Y: 1}, HP: 3})
 	g.UpdateFOV()
 	p := &zapPrompter{actions: []Action{{Kind: ActFire}, {Kind: ActQuit}}, target: game.Pos{X: 3, Y: 1}}


### PR DESCRIPTION
## Summary
Plan 14a — #14's last noted TODO closes; the shortbow stops firing for free:

- **Crude arrows** (`treasure.c:1332`, glyph `:` per `glyph.c:214`, weight 1 = `WEIGHT_MISSILE` via a new `ammo` kind default): found as bundles (power 8 seeds `Charges`, the wand pattern), merging into one quiver on pickup.
- **`FireWeapon`** requires the quiver: empty → the C's "Out of ammo!" refusal, free; otherwise each shot spends one arrow **whether it finds flesh or floor** (C: missiles are spent), the stack leaving the pack at zero (which can also relieve a burden).
- Quality tiers (sharp/masterwork, `treasure_a_sharp`+) noted out of scope — one arrow type bounds the PR.

## Test plan
- A shot consumes exactly one; the empty quiver refuses free with the C line; the last arrow removes the stack; pickup merges 5+8 into one 13-arrow quiver.
- The ui fire-loop test now carries arrows; golden covers the def (kind/glyph/power/weight-1 default).
- gofmt + go vet + full `go test ./...` green (10/10 packages).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Shortbows now require crude arrows (ammunition) to fire and consume one arrow per shot
  * Arrow stacks merge automatically when picked up, combining charges into a single stack
  * Attempting to fire without ammunition displays "Out of ammo!" without costing an action

* **Tests**
  * Added comprehensive tests for ammo consumption, empty quiver behavior, and stack merging

* **Documentation**
  * Added Ammunition (14a) Implementation Plan

<!-- end of auto-generated comment: release notes by coderabbit.ai -->