### PR TITLE
Ammo stacks weigh per arrow (C stack_size × weight)

### DIFF
--- a/go/internal/game/burden_test.go
+++ b/go/internal/game/burden_test.go
@@ -52,3 +52,25 @@ func TestLightPackNoBurden(t *testing.T) {
 		t.Errorf("a light pack costs nothing: rat should be at x=7, got x=%d", rat.Pos.X)
 	}
 }
+
+func TestAmmoStackWeighsPerArrow(t *testing.T) {
+	g, rat := schedulerGame()
+	// 500 arrows at WEIGHT_MISSILE 1 each: 500 > the 400 allowance
+	// (C burdened.c: carried = stack_size * weight).
+	g.Inventory = append(g.Inventory, &Item{Def: &content.ItemDef{ID: "arrow", Name: "crude arrow", Kind: "ammo", Weight: 1}, Charges: 500})
+	g.advanceWorld()
+	if rat.Pos.X != 6 {
+		t.Errorf("an overloaded quiver burdens like anything else: rat should be at x=6, got x=%d", rat.Pos.X)
+	}
+}
+
+func TestMergedPickupCanStagger(t *testing.T) {
+	g := combatGame()
+	def := &content.ItemDef{ID: "arrow", Name: "crude arrow", Kind: "ammo", Weight: 1, Power: 8}
+	g.Inventory = append(g.Inventory, &Item{Def: def, Charges: 390})
+	g.Level.Items = append(g.Level.Items, &Item{Def: def, Charges: 50, Pos: g.Player})
+	g.PlayerPickup() // merge crosses the 400 line
+	if !hasMessage(g, "You stagger under your load!") {
+		t.Errorf("a merged bundle that crosses the allowance staggers too, got %v", g.Messages)
+	}
+}

--- a/go/internal/game/combat.go
+++ b/go/internal/game/combat.go
@@ -35,9 +35,14 @@ const carryCapacity = 400
 func (g *Game) carriedWeight() int {
 	total := 0
 	for _, it := range g.Inventory {
-		if it != nil && it.Def != nil {
-			total += it.Def.Weight
+		if it == nil || it.Def == nil {
+			continue
 		}
+		if it.Def.Kind == "ammo" {
+			total += it.Charges * it.Def.Weight // a stack weighs per arrow (C burdened.c)
+			continue
+		}
+		total += it.Def.Weight
 	}
 	return total
 }

--- a/go/internal/game/use.go
+++ b/go/internal/game/use.go
@@ -17,6 +17,9 @@ func (g *Game) PlayerPickup() {
 			if held.Def == it.Def {
 				held.Charges += it.Charges
 				g.log("You pick up the %s.", it.Def.Name)
+				if !wasBurdened && g.burdened() {
+					g.log("You stagger under your load!")
+				}
 				g.advanceWorld()
 				return
 			}


### PR DESCRIPTION
## Summary
A small fidelity follow-up to #73, spotted right after merging:

- **Stack weight**: the C computes carried weight as `stack_size(item) * get_weight(item)` (`burdened.c:84`); our `carriedWeight` counted a quiver as one item. Ammo stacks now weigh `Charges × Weight` — a 500-arrow hoard burdens you like the C says it should.
- **Merge-path stagger**: #73's bundle-merge pickup returned before the stagger check, so a merge that crossed the 400 allowance stayed silent. The merge path now runs the same check as a plain pickup.

## Test plan
- A 500-arrow quiver halves player speed (the scheduler observable: the rat closes two tiles per step).
- Merging 390 + 50 arrows crosses the line and logs "You stagger under your load!".
- gofmt + go vet + full `go test ./...` green (10/10 packages).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ammo stacks now correctly contribute to player burden based on quantity.
  * Burden message displays when picking up ammo that causes overburdening.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->