### PR TITLE
The mimic: item disguise, wasted-swing reveal, rooted AI

### DIFF
--- a/docs/superpowers/plans/2026-06-11-mimic-13i.md
+++ b/docs/superpowers/plans/2026-06-11-mimic-13i.md
@@ -1,0 +1,50 @@
+# The mimic (13i) Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** The last unported bestiary regular: the **mimic** — it spawns
+disguised as loot, does nothing until disturbed, and the swing that exposes
+it is wasted. Advances #13.
+
+## C grounding
+- `monster.c:462`: HP 5, speed 70, dodge 0, immobile (`attr_p_move`),
+  `ai_mimic` (does nothing at all, `ai.c:145`); real glyph `m`
+  (`glyph.c:88`). At build a 1d4 roll disguises it as a random item, a dart
+  trap, or a medkit — the random-item case bounds this PR.
+- `actions.c:790 reveal_mimic`: "Wait! That is a small mimic!", then
+  `ai_offensive`. Attacking a disguised mimic **wastes the attacker's turn**
+  (`combat.c:237`); a mimic also reveals when it attacks or takes area
+  damage.
+- `places.c`: every level's encounter table carries the mimic at weight 1.
+
+## Design
+- `MonsterDef.Mimic bool`; `Creature.Disguised bool` +
+  `DisguiseAs *content.ItemDef`. Gen rolls a random spawnable item def for
+  any mimic-flagged spawn; the View renders a disguised creature with the
+  item's glyph/color.
+- `monsterAct`: disguised → do nothing. `playerAttacks`: a disguised target
+  reveals and the swing is wasted (no roll). A shared `revealMimic` also
+  fires from wand, breath, and creature-vs-creature damage paths.
+- A revealed mimic attacks from its tile but never moves (`creatureCanEnter`
+  refuses every step for immobile defs — `Mimic` implies rooted, like the C's
+  `attr_p_move`).
+- Data: the def (m, 5/6/0, 1d4, speed 70) + weight-1 spawn entries on every
+  level; goldens.
+
+## Task 1: disguise + reveal + rooted AI (TDD)
+**Files:** `internal/game/{creature,combat,breath}.go` + new `mimic_test.go`,
+`internal/ui/ui.go` + test, `internal/gen/gen.go` + test.
+- Tests first: a disguised mimic ignores an adjacent player; the first bump
+  reveals (message, no damage, turn passes); the revealed mimic bites back
+  but holds its tile; the View shows the item glyph then `m`; gen disguises
+  mimic spawns.
+- Commit: `feat(game): the mimic — item disguise, wasted-swing reveal, rooted AI`
+
+## Task 2: data + ship
+- Def + ten spawn entries + goldens; full gate; PR; CodeRabbit loop → merge.
+- Commit: `feat(content): mimics lurk on every level (C places.c)`
+
+## Done when
+That unguarded potion two rooms in might bite: the swing that finds out costs
+you the turn, and the thing under the glamour never chases — it just waits.
+Suite green.

--- a/go/data/data_test.go
+++ b/go/data/data_test.go
@@ -896,8 +896,12 @@ func TestEmbeddedMimic(t *testing.T) {
 		}
 		found := false
 		for _, s := range l.Spawn {
-			if s.Monster == "mimic" {
-				found = true
+			if s.Monster != "mimic" {
+				continue
+			}
+			found = true
+			if s.Weight != 1 {
+				t.Errorf("level %s mimic weight = %d, want 1 (C places.c)", id, s.Weight)
 			}
 		}
 		if !found {

--- a/go/data/data_test.go
+++ b/go/data/data_test.go
@@ -878,3 +878,30 @@ func TestEmbeddedArrows(t *testing.T) {
 		t.Errorf("arrow def unexpected: %+v", a)
 	}
 }
+
+// TestEmbeddedMimic checks the last bestiary regular loaded (13i): rooted,
+// mimic-flagged, and lurking on every level at weight 1 (C places.c).
+func TestEmbeddedMimic(t *testing.T) {
+	c, err := content.Load(Files)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	m := c.Monsters["mimic"]
+	if m == nil || !m.Mimic || m.Glyph != "m" || m.HP != 5 || m.Speed != 70 {
+		t.Fatalf("mimic def unexpected: %+v", m)
+	}
+	for id, l := range c.Levels {
+		if len(l.Spawn) == 0 {
+			continue
+		}
+		found := false
+		for _, s := range l.Spawn {
+			if s.Monster == "mimic" {
+				found = true
+			}
+		}
+		if !found {
+			t.Errorf("level %s should carry the mimic at weight 1 (C places.c)", id)
+		}
+	}
+}

--- a/go/data/levels.toml
+++ b/go/data/levels.toml
@@ -40,6 +40,9 @@ weight = 2
 [[level.dungeon.spawn]]
 monster = "sludge_dweller"
 weight = 1
+[[level.dungeon.spawn]]
+monster = "mimic"
+weight = 1
 
 [level.catacombs]
 name = "the Catacombs"
@@ -76,6 +79,9 @@ weight = 1
 [[level.catacombs.spawn]]
 monster = "severed_hand"
 weight = 2
+[[level.catacombs.spawn]]
+monster = "mimic"
+weight = 1
 
 [level.ominous_cave]
 name = "the Ominous Cave"
@@ -107,6 +113,9 @@ monster = "sludge_dweller"
 weight = 2
 [[level.ominous_cave.spawn]]
 monster = "electric_snake"
+weight = 1
+[[level.ominous_cave.spawn]]
+monster = "mimic"
 weight = 1
 
 [level.laboratory]
@@ -147,6 +156,9 @@ weight = 2
 [[level.laboratory.spawn]]
 monster = "sludge_dweller"
 weight = 2
+[[level.laboratory.spawn]]
+monster = "mimic"
+weight = 1
 
 [level.comm_hub]
 name = "the Communications Hub"
@@ -181,6 +193,9 @@ monster = "technician"
 weight = 1
 [[level.comm_hub.spawn]]
 monster = "sludge_dweller"
+weight = 1
+[[level.comm_hub.spawn]]
+monster = "mimic"
 weight = 1
 
 [level.underpass]
@@ -218,6 +233,9 @@ weight = 1
 [[level.underpass.spawn]]
 monster = "electric_snake"
 weight = 1
+[[level.underpass.spawn]]
+monster = "mimic"
+weight = 1
 
 [level.drowned_city]
 name = "the Drowned City"
@@ -252,6 +270,9 @@ monster = "giant_slimy_toad"
 weight = 2
 [[level.drowned_city.spawn]]
 monster = "sludge_dweller"
+weight = 1
+[[level.drowned_city.spawn]]
+monster = "mimic"
 weight = 1
 
 [level.frozen_vault]
@@ -289,6 +310,9 @@ weight = 1
 [[level.frozen_vault.spawn]]
 monster = "floating_brain"
 weight = 2
+[[level.frozen_vault.spawn]]
+monster = "mimic"
+weight = 1
 
 [level.dragons_lair]
 name = "the Dragons Lair"
@@ -329,6 +353,9 @@ weight = 1
 [[level.dragons_lair.spawn]]
 monster = "flame_spirit"
 weight = 2
+[[level.dragons_lair.spawn]]
+monster = "mimic"
+weight = 1
 
 [level.chapel]
 name = "the Chapel of Fallen Stars"
@@ -365,4 +392,7 @@ monster = "chrome_angel"
 weight = 2
 [[level.chapel.spawn]]
 monster = "nameless_horror"
+weight = 1
+[[level.chapel.spawn]]
+monster = "mimic"
 weight = 1

--- a/go/data/monsters.toml
+++ b/go/data/monsters.toml
@@ -527,3 +527,18 @@ ranged = 7
 effect = "slow"
 effect_turns = 3
 min_depth = 99 # boss placement only
+
+# The mimic (13i, C monster.c:462): spawns wearing a random item's glamour,
+# does nothing until disturbed — and the swing that finds out is wasted.
+# Rooted in place (attr_p_move). Lurks on every level at weight 1 (places.c).
+[monster.mimic]
+name = "mimic"
+glyph = "m"
+color = "normal"
+hp = 5
+attack = 6
+dodge = 0
+damage = "1d4"
+speed = 70
+mimic = true
+min_depth = 1

--- a/go/internal/content/content.go
+++ b/go/internal/content/content.go
@@ -72,6 +72,7 @@ type MonsterDef struct {
 	Effect      string `toml:"effect"`       // status effect a landed melee hit applies ("" = none)
 	EffectTurns int    `toml:"effect_turns"` // duration of Effect
 	Breath      string `toml:"breath"`       // cone attack: "fire", "poison", or "" (#19)
+	Mimic       bool   `toml:"mimic"`        // spawns disguised as loot, rooted in place (#13)
 }
 
 // Rune returns the monster's glyph as a rune.

--- a/go/internal/game/breath.go
+++ b/go/internal/game/breath.go
@@ -100,6 +100,7 @@ func (g *Game) breathe(m *Creature) {
 			continue
 		}
 		if c := g.Level.CreatureAt(p); c != nil && c != m {
+			g.revealMimic(c) // C breath.c calls reveal_mimic per target
 			if kind == "fire" {
 				c.HP -= g.RNG.RollSpec(breathFireDamage)
 			} else {
@@ -130,6 +131,7 @@ func (g *Game) playerBreathe(kind string, target Pos) {
 		if c == nil {
 			continue
 		}
+		g.revealMimic(c)
 		if kind == "fire" {
 			c.HP -= g.RNG.RollSpec(breathFireDamage)
 		} else {

--- a/go/internal/game/combat.go
+++ b/go/internal/game/combat.go
@@ -164,7 +164,21 @@ func (g *Game) playerDodgeStat() int {
 	return dodge
 }
 
+// revealMimic tears the glamour off a disguised mimic (C reveal_mimic). It
+// reports whether a reveal happened — the swing that finds out is wasted.
+func (g *Game) revealMimic(m *Creature) bool {
+	if !m.Disguised {
+		return false
+	}
+	m.Disguised = false
+	g.log("Wait! That is a small mimic!")
+	return true
+}
+
 func (g *Game) playerAttacks(m *Creature) {
+	if g.revealMimic(m) {
+		return // turn wasted! (C combat.c:237)
+	}
 	if !g.RNG.Chance(g.playerAttackStat(), m.Def.Dodge) {
 		g.log("You miss the %s.", m.Def.Name)
 		return
@@ -207,6 +221,7 @@ func (g *Game) ZapWand(it *Item, target Pos) {
 	it.Charges--
 	g.identify(it) // zapping a wand reveals its type
 	if m := g.Level.CreatureAt(target); m != nil {
+		g.revealMimic(m) // a bolt tears the glamour (C reveal_mimic)
 		if it.Def.Damage != "" {
 			dmg := g.RNG.RollSpec(it.Def.Damage)
 			m.HP -= dmg
@@ -434,6 +449,9 @@ func (g *Game) worldTick() {
 // monsterAct is a single monster action: attack the player if adjacent, else
 // step toward the player if within sense range.
 func (g *Game) monsterAct(m *Creature) {
+	if m.Disguised {
+		return // a mimic in its glamour does nothing at all (C ai_mimic)
+	}
 	if m.HasEffect("sleep") {
 		return // asleep: it loses the turn outright (C game.c effect_sleep skip)
 	}
@@ -508,6 +526,7 @@ func (g *Game) allyAct(m *Creature) {
 // hostile or the reverse — on the same attack-vs-dodge model as every other
 // melee in the port.
 func (g *Game) monsterFights(a, d *Creature) {
+	g.revealMimic(d)
 	if !g.RNG.Chance(a.Def.Attack, d.Def.Dodge) {
 		g.log("The %s misses the %s.", a.Def.Name, d.Def.Name)
 		return
@@ -527,6 +546,9 @@ func (g *Game) monsterFights(a, d *Creature) {
 func (g *Game) creatureCanEnter(m *Creature, dst Pos) bool {
 	if !g.Level.InBounds(dst) {
 		return false
+	}
+	if m.Def.Mimic {
+		return false // rooted in place (C attr_p_move)
 	}
 	if m.Def.Permaswim {
 		return g.Level.At(dst).Def.Water

--- a/go/internal/game/creature.go
+++ b/go/internal/game/creature.go
@@ -22,6 +22,9 @@ type Creature struct {
 
 	Ally     bool // charmed to the player's side (C attr_player_ally)
 	Lifetime int  // ticks before a summon disappears (0 = permanent)
+
+	Disguised  bool             // a mimic still wearing its glamour (C ai_mimic)
+	DisguiseAs *content.ItemDef // the loot it poses as while disguised
 }
 
 // AddEffect applies a timed status effect to the creature, refreshing an

--- a/go/internal/game/mimic_test.go
+++ b/go/internal/game/mimic_test.go
@@ -1,0 +1,79 @@
+package game
+
+import (
+	"testing"
+
+	"github.com/c0ze/tsl/internal/content"
+)
+
+// hiddenMimic plants a disguised mimic at p, posing as a potion.
+func hiddenMimic(g *Game, p Pos) *Creature {
+	m := &Creature{
+		Def: &content.MonsterDef{ID: "mimic", Name: "mimic", Glyph: "m", HP: 5, Attack: 6, Dodge: 0, Damage: "1d4", Mimic: true},
+		Pos: p, HP: 5,
+		Disguised:  true,
+		DisguiseAs: &content.ItemDef{ID: "healing_potion", Name: "healing potion", Glyph: "!", Color: content.ColorRed, Kind: "potion"},
+	}
+	g.Level.Creatures = append(g.Level.Creatures, m)
+	return m
+}
+
+func TestDisguisedMimicDoesNothing(t *testing.T) {
+	g := combatGame()
+	hiddenMimic(g, Pos{2, 1}) // adjacent to the player
+	hp := g.PlayerHP
+	for i := 0; i < 5; i++ {
+		g.worldTick()
+	}
+	if g.PlayerHP != hp {
+		t.Error("a disguised mimic does nothing at all (C ai_mimic)")
+	}
+}
+
+func TestFirstSwingRevealsAndIsWasted(t *testing.T) {
+	g := combatGame()
+	m := hiddenMimic(g, Pos{2, 1})
+	g.PlayerStep(DirE) // the bump that finds out
+	if m.Disguised {
+		t.Fatal("the swing should reveal the mimic")
+	}
+	if m.HP != 5 {
+		t.Error("the revealing swing is wasted — no damage (C combat.c:237)")
+	}
+	if !hasMessage(g, "Wait! That is a small mimic!") {
+		t.Errorf("expected the C reveal line, got %v", g.Messages)
+	}
+	g.PlayerStep(DirE) // now it's just a monster
+	if m.HP >= 5 && g.Level.CreatureAt(Pos{2, 1}) != nil {
+		t.Error("the second swing lands normally")
+	}
+}
+
+func TestRevealedMimicBitesButNeverMoves(t *testing.T) {
+	g := combatGame()
+	m := hiddenMimic(g, Pos{2, 1})
+	m.Disguised = false
+	m.Def.Attack = 1000
+	hp := g.PlayerHP
+	g.worldTick()
+	if g.PlayerHP >= hp {
+		t.Error("a revealed mimic bites the adjacent player")
+	}
+	g.Player = Pos{6, 1} // walk away: it cannot follow
+	for i := 0; i < 5; i++ {
+		g.worldTick()
+	}
+	if m.Pos != (Pos{2, 1}) {
+		t.Errorf("a mimic is rooted (C attr_p_move), at %v", m.Pos)
+	}
+}
+
+func TestWandDamageRevealsMimic(t *testing.T) {
+	g := combatGame()
+	m := hiddenMimic(g, Pos{3, 1})
+	wand := &Item{Def: &content.ItemDef{ID: "wand_force_bolt", Name: "wand of force bolt", Kind: "wand", Damage: "1d1"}, Charges: 2}
+	g.ZapWand(wand, m.Pos)
+	if m.Disguised {
+		t.Error("a bolt to the glamour exposes it (C reveal_mimic in missile paths)")
+	}
+}

--- a/go/internal/gen/gen.go
+++ b/go/internal/gen/gen.go
@@ -442,6 +442,26 @@ func placeTraps(r *rng.MT, c *content.Content, lvl *game.Level, rooms []rect, n 
 	}
 }
 
+// disguiseMimic dresses a freshly spawned mimic as a random spawnable item
+// (C monster.c: the build-time 1d4 disguise roll, item case).
+func disguiseMimic(r *rng.MT, c *content.Content, m *game.Creature) {
+	if !m.Def.Mimic {
+		return
+	}
+	ids := make([]string, 0, len(c.Items))
+	for id, it := range c.Items {
+		if !it.NoSpawn {
+			ids = append(ids, id)
+		}
+	}
+	if len(ids) == 0 {
+		return
+	}
+	sort.Strings(ids)
+	m.Disguised = true
+	m.DisguiseAs = c.Items[ids[r.Intn(len(ids))]]
+}
+
 // placeSpawnMonsters scatters def.Monsters monsters drawn from def's weighted
 // spawn table across the rooms (never on the start tile).
 func placeSpawnMonsters(r *rng.MT, c *content.Content, lvl *game.Level, rooms []rect, def *content.LevelDef) {
@@ -459,7 +479,9 @@ func placeSpawnMonsters(r *rng.MT, c *content.Content, lvl *game.Level, rooms []
 			continue
 		}
 		mdef := c.Monsters[pickSpawn(r, def.Spawn, total)]
-		lvl.Creatures = append(lvl.Creatures, &game.Creature{Def: mdef, Pos: pos, HP: mdef.HP})
+		m := &game.Creature{Def: mdef, Pos: pos, HP: mdef.HP}
+		disguiseMimic(r, c, m)
+		lvl.Creatures = append(lvl.Creatures, m)
 	}
 }
 

--- a/go/internal/gen/gen_test.go
+++ b/go/internal/gen/gen_test.go
@@ -516,3 +516,28 @@ func TestLevelFromDefCarvesLavaPools(t *testing.T) {
 		}
 	}
 }
+
+func TestMimicSpawnsDisguised(t *testing.T) {
+	c := levelDefContent()
+	c.Monsters["mimic"] = &content.MonsterDef{ID: "mimic", Name: "mimic", Glyph: "m", HP: 5, Attack: 6, Damage: "1d4", Speed: 70, Mimic: true}
+	c.Items = map[string]*content.ItemDef{"healing_potion": {ID: "healing_potion", Name: "healing potion", Glyph: "!", Color: content.ColorRed, Kind: "potion"}}
+	def := &content.LevelDef{ID: "x", Name: "X", W: 60, H: 24, Links: []string{"y"}, Monsters: 12,
+		Spawn: []content.SpawnEntry{{Monster: "mimic", Weight: 1}}}
+	lvl, err := LevelFromDef(rng.NewWithSeed(2), c, def)
+	if err != nil {
+		t.Fatal(err)
+	}
+	found := false
+	for _, m := range lvl.Creatures {
+		if m.Def.ID != "mimic" {
+			continue
+		}
+		found = true
+		if !m.Disguised || m.DisguiseAs == nil {
+			t.Errorf("a spawned mimic should wear a loot glamour, got %+v", m)
+		}
+	}
+	if !found {
+		t.Skip("no mimic placed this seed")
+	}
+}

--- a/go/internal/ui/ui.go
+++ b/go/internal/ui/ui.go
@@ -102,9 +102,14 @@ func BuildView(g *game.Game) View {
 		}
 	}
 	for _, m := range l.Creatures {
-		if l.InBounds(m.Pos) && l.At(m.Pos).Visible {
-			*v.At(m.Pos.X, m.Pos.Y) = Cell{Glyph: m.Def.Rune(), Color: m.Def.Color}
+		if !l.InBounds(m.Pos) || !l.At(m.Pos).Visible {
+			continue
 		}
+		if m.Disguised && m.DisguiseAs != nil { // a mimic wears its loot glamour
+			*v.At(m.Pos.X, m.Pos.Y) = Cell{Glyph: m.DisguiseAs.Rune(), Color: m.DisguiseAs.Color}
+			continue
+		}
+		*v.At(m.Pos.X, m.Pos.Y) = Cell{Glyph: m.Def.Rune(), Color: m.Def.Color}
 	}
 	if l.InBounds(g.Player) {
 		*v.At(g.Player.X, g.Player.Y) = Cell{Glyph: PlayerGlyph, Color: PlayerColor}

--- a/go/internal/ui/ui_test.go
+++ b/go/internal/ui/ui_test.go
@@ -469,3 +469,24 @@ func TestBuildViewHidesDisguisedTraps(t *testing.T) {
 		t.Errorf("a revealed trap should show itself, got %q", got)
 	}
 }
+
+func TestBuildViewShowsMimicGlamour(t *testing.T) {
+	g := testGame(t, []string{".@..."})
+	m := &game.Creature{
+		Def: &content.MonsterDef{ID: "mimic", Name: "mimic", Glyph: "m", Color: content.ColorNormal, HP: 5},
+		Pos: game.Pos{X: 3, Y: 0}, HP: 5,
+		Disguised:  true,
+		DisguiseAs: &content.ItemDef{ID: "healing_potion", Name: "healing potion", Glyph: "!", Color: content.ColorRed, Kind: "potion"},
+	}
+	g.Level.Creatures = append(g.Level.Creatures, m)
+	g.Level.At(game.Pos{X: 3, Y: 0}).Visible = true
+	v := BuildView(g)
+	if got := v.At(3, 0).Glyph; got != '!' {
+		t.Errorf("a disguised mimic renders as its loot, got %q", got)
+	}
+	m.Disguised = false
+	v = BuildView(g)
+	if got := v.At(3, 0).Glyph; got != 'm' {
+		t.Errorf("a revealed mimic shows itself, got %q", got)
+	}
+}


### PR DESCRIPTION
## Summary
Plan 13i — the last unported bestiary regular, riding the disguise concepts from #66:

- **The glamour**: a mimic spawns `Disguised` wearing a random spawnable item's glyph/color (the C's build-time 1d4 roll, item case — gen picks it deterministically per seed) and the View renders the loot, not the monster. While disguised it does **nothing at all** (`ai.c:145`).
- **The reveal** (`actions.c:790`): the swing that finds out is **wasted** — no roll, just "Wait! That is a small mimic!" (`combat.c:237`'s turn-wasted rule). Wands, breath cones, and creature-vs-creature melee also tear the glamour (the C's `reveal_mimic` call sites).
- **Rooted**: revealed, it bites from its tile but `creatureCanEnter` refuses every step for mimic defs (`attr_p_move`) — walk away and it just waits for the next victim.
- **Everywhere**: weight-1 spawn entries on all ten levels, exactly the C's per-level encounter tables (`places.c`); the golden test sweeps every spawn table.
- Out of scope: the dart-trap and medkit disguise variants (no medkit item yet).

## Test plan
- A disguised mimic ignores an adjacent player for five ticks; the first bump reveals with the C line and zero damage; the second lands; a revealed mimic bites but never follows.
- A wand bolt tears the glamour; the View shows `!` then `m`; gen dresses spawns; goldens for the def + all-levels coverage.
- gofmt + go vet + full `go test ./...` green (10/10 packages).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced mimic monsters that spawn disguised as loot across dungeon levels; they stay rooted and are revealed when interacted with, wasting the first attack.
  * Visuals: mimics render as the disguised loot until revealed.

* **Tests**
  * Added tests for mimic disguise, reveal, combat behavior, spawn tables, and rendering.

* **Documentation**
  * Added a plan detailing mimic mechanics, execution steps, and definition of done.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->