### PR TITLE
t)alk verb + the King of Worms

### DIFF
--- a/docs/superpowers/plans/2026-06-11-talk-king-of-worms-13j.md
+++ b/docs/superpowers/plans/2026-06-11-talk-king-of-worms-13j.md
@@ -1,0 +1,44 @@
+# Talk verb + the King of Worms (13j) Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** The C's interaction verb (`actions.c:790 interact`) and the unique it
+was deferred for: **the King of Worms**, boss of the Ominous Cave
+(`places.c` gives that level `boss = encounter_king_of_worms`). Advances #13.
+
+## C grounding
+- `actions.c interact`: talking to a sleeping creature reports "appears to be
+  asleep." without a turn; otherwise per-creature flavor — the gnoblin
+  "snarls at you!", the ghoul "appears to desire your brain.", the imp
+  "giggles impishly!", the slime "oozes around, indifferent to your
+  inquiries." — and the King's lore line: "He keeps the wisdom that you need,
+  the password that you want." A successful chat passes the turn.
+- The C's no-line default is literally "BUG: Undefined generic interaction!"
+  — a debug marker, not content; we default to "You get no reply."
+  (deliberate, gentle deviation).
+- `unique.c:97`: the King — `W` (`glyph.c:113`), HP 30, **speed 10** (the
+  Necromancer's glacial turret pace), sleep-immune, no spells: a lore fixture
+  you can still pick a fight with. The password quest itself needs systems
+  0.40 never finished; the line is the content.
+
+## Design
+- `MonsterDef.Chat` — the full rendered line. `Game.Talk()`: first adjacent
+  creature; none → free refusal; asleep → free "appears to be asleep.";
+  chat → the line + a turn; silent → the gentle default + a turn.
+- ui `ActTalk` on `t` (free key) through the Run loop and tcell map.
+- Data: chat lines for gnoblin/ghoul/imp/slime; `king_of_worms` def
+  (boss-only) + `ominous_cave` boss wiring; goldens.
+
+## Task: Talk + the King (TDD)
+**Files:** `internal/game/` (new talk.go + test), `internal/ui/ui.go` +
+tcell map + tests, data + goldens.
+- Tests first: chatting an adjacent gnoblin logs its line and passes a turn
+  (rat closes in elsewhere); no neighbor refuses free; a sleeping neighbor
+  reports free; a silent monster gets the default; the King's def + boss
+  wiring goldens.
+- Commit: `feat(game): t)alk — the C interaction verb + the King of Worms`
+- Full gate; push, PR, CodeRabbit loop → merge.
+
+## Done when
+Deep in the Ominous Cave a `W` waits, barely moving, and answers exactly one
+question with the line 0.40 players remember. Suite green.

--- a/go/data/data_test.go
+++ b/go/data/data_test.go
@@ -909,3 +909,28 @@ func TestEmbeddedMimic(t *testing.T) {
 		}
 	}
 }
+
+// TestEmbeddedKingOfWorms checks the talk-verb unique loaded (13j): the
+// Ominous Cave's boss with his C lore line, plus the four interact flavor
+// lines from actions.c.
+func TestEmbeddedKingOfWorms(t *testing.T) {
+	c, err := content.Load(Files)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	k := c.Monsters["king_of_worms"]
+	if k == nil || k.Glyph != "W" || k.HP != 30 || k.Speed != 10 {
+		t.Fatalf("king_of_worms def unexpected: %+v", k)
+	}
+	if k.Chat != "He keeps the wisdom that you need, the password that you want." {
+		t.Errorf("the King's line must be exact (C actions.c:877), got %q", k.Chat)
+	}
+	if l := c.Levels["ominous_cave"]; l == nil || l.Boss != "king_of_worms" {
+		t.Errorf("the Ominous Cave should host the King (C places.c), got %+v", l)
+	}
+	for _, id := range []string{"gnoblin", "ghoul", "imp", "slime"} {
+		if m := c.Monsters[id]; m == nil || m.Chat == "" {
+			t.Errorf("%s should carry its C interact line", id)
+		}
+	}
+}

--- a/go/data/levels.toml
+++ b/go/data/levels.toml
@@ -89,6 +89,7 @@ width = 60
 height = 24
 links = ["dungeon", "comm_hub", "underpass"]
 monsters = 9
+boss = "king_of_worms"
 dark = true
 [[level.ominous_cave.spawn]]
 monster = "graveling"

--- a/go/data/monsters.toml
+++ b/go/data/monsters.toml
@@ -24,6 +24,7 @@ dodge = 2
 damage = "1d4"
 speed = 80
 corpse = "ghoul_corpse"
+chat = "The ghoul appears to desire your brain."
 
 [monster.graveling]
 name = "graveling"
@@ -46,6 +47,7 @@ dodge = 2
 damage = "1d3"
 speed = 85
 corpse = "corpse"
+chat = "The gnoblin snarls at you!"
 
 [monster.crypt_vermin]
 name = "crypt vermin"
@@ -92,6 +94,7 @@ dodge = 0
 damage = "1d4"
 speed = 80
 min_depth = 3
+chat = "The slime oozes around, indifferent to your inquiries."
 
 # Roster batch 2 (#13) — more standard foes across the tiers. Corpses reuse the
 # generic carcass/corpse food; the undead leave none. Depth is enforced by which
@@ -177,6 +180,7 @@ damage = "1d4"
 speed = 110
 ranged = 5
 min_depth = 2
+chat = "The imp giggles impishly!"
 
 # Roster batch 3 (#13) — more beasts across the tiers. Generic corpses where
 # edible; spiders and wisps leave none.
@@ -542,3 +546,19 @@ damage = "1d4"
 speed = 70
 mimic = true
 min_depth = 1
+
+# The King of Worms (13j, C unique.c:97): boss of the Ominous Cave
+# (places.c). Glacial like the Necromancer, no spells — a lore fixture you
+# can still pick a fight with. "The password" quest needs systems 0.40 never
+# finished; the line is the content.
+[monster.king_of_worms]
+name = "King of Worms"
+glyph = "W"
+color = "normal"
+hp = 30
+attack = 5
+dodge = 1
+damage = "1d4"
+speed = 10
+chat = "He keeps the wisdom that you need, the password that you want."
+min_depth = 99 # boss placement only

--- a/go/internal/content/content.go
+++ b/go/internal/content/content.go
@@ -73,6 +73,7 @@ type MonsterDef struct {
 	EffectTurns int    `toml:"effect_turns"` // duration of Effect
 	Breath      string `toml:"breath"`       // cone attack: "fire", "poison", or "" (#19)
 	Mimic       bool   `toml:"mimic"`        // spawns disguised as loot, rooted in place (#13)
+	Chat        string `toml:"chat"`         // the line it gives a t)alking player (C actions.c interact)
 }
 
 // Rune returns the monster's glyph as a rune.

--- a/go/internal/game/talk.go
+++ b/go/internal/game/talk.go
@@ -1,0 +1,34 @@
+package game
+
+// Talk is the C's interaction verb (actions.c interact): address the first
+// adjacent creature. A chat line passes the turn; an empty square, a sleeping
+// neighbor, or a wordless one costs nothing — except the wordless one still
+// takes your turn, since you did stop to ask (the C passes the turn for any
+// awake interaction; its no-line default is literally a BUG marker, so ours
+// is gentler).
+func (g *Game) Talk() {
+	if g.Dead || g.Won {
+		return
+	}
+	var who *Creature
+	for _, c := range g.Level.Creatures {
+		if chebyshev(g.Player, c.Pos) == 1 {
+			who = c
+			break
+		}
+	}
+	if who == nil {
+		g.log("There is no one to talk to.")
+		return
+	}
+	if who.HasEffect("sleep") {
+		g.log("The %s appears to be asleep.", who.Def.Name)
+		return // no turn (C interact returns false)
+	}
+	if who.Def.Chat != "" {
+		g.log("%s", who.Def.Chat)
+	} else {
+		g.log("You get no reply.")
+	}
+	g.advanceWorld()
+}

--- a/go/internal/game/talk.go
+++ b/go/internal/game/talk.go
@@ -1,11 +1,10 @@
 package game
 
 // Talk is the C's interaction verb (actions.c interact): address the first
-// adjacent creature. A chat line passes the turn; an empty square, a sleeping
-// neighbor, or a wordless one costs nothing — except the wordless one still
-// takes your turn, since you did stop to ask (the C passes the turn for any
-// awake interaction; its no-line default is literally a BUG marker, so ours
-// is gentler).
+// adjacent creature. Any awake interaction passes the turn — a chat line or
+// the silent default alike — while an empty square or a sleeping neighbor
+// costs nothing (the C returns false for sleepers; its no-line default is
+// literally a BUG marker, so ours is gentler).
 func (g *Game) Talk() {
 	if g.Dead || g.Won {
 		return

--- a/go/internal/game/talk_test.go
+++ b/go/internal/game/talk_test.go
@@ -51,9 +51,13 @@ func TestTalkToSleeperIsFree(t *testing.T) {
 func TestTalkToSilentMonster(t *testing.T) {
 	g := combatGame()
 	rat := &Creature{Def: &content.MonsterDef{ID: "rat", Name: "rat", Glyph: "r", HP: 3, Attack: 0, Dodge: 1, Damage: "1d1"}, Pos: Pos{2, 1}, HP: 3}
-	g.Level.Creatures = append(g.Level.Creatures, rat)
+	observer := &Creature{Def: &content.MonsterDef{ID: "rat", Name: "rat", Glyph: "r", HP: 3, Attack: 0, Dodge: 1, Damage: "1d1"}, Pos: Pos{8, 1}, HP: 3}
+	g.Level.Creatures = append(g.Level.Creatures, rat, observer)
 	g.Talk()
 	if !hasMessage(g, "You get no reply.") {
 		t.Errorf("a silent monster gets the gentle default (the C's line is a BUG marker), got %v", g.Messages)
+	}
+	if observer.Pos.X != 7 {
+		t.Error("stopping to ask still costs the turn")
 	}
 }

--- a/go/internal/game/talk_test.go
+++ b/go/internal/game/talk_test.go
@@ -1,0 +1,59 @@
+package game
+
+import (
+	"testing"
+
+	"github.com/c0ze/tsl/internal/content"
+)
+
+func TestTalkGetsTheChatLine(t *testing.T) {
+	g := combatGame()
+	gnoblin := &Creature{Def: &content.MonsterDef{ID: "gnoblin", Name: "gnoblin", Glyph: "g", HP: 4, Attack: 0, Dodge: 1, Damage: "1d2", Chat: "The gnoblin snarls at you!"}, Pos: Pos{2, 1}, HP: 4}
+	rat := &Creature{Def: &content.MonsterDef{ID: "rat", Name: "rat", Glyph: "r", HP: 3, Attack: 0, Dodge: 1, Damage: "1d1"}, Pos: Pos{8, 1}, HP: 3}
+	g.Level.Creatures = append(g.Level.Creatures, gnoblin, rat)
+	g.Talk()
+	if !hasMessage(g, "The gnoblin snarls at you!") {
+		t.Errorf("expected the C interact line, got %v", g.Messages)
+	}
+	if rat.Pos.X != 7 {
+		t.Error("a chat passes the turn (C interact returns true)")
+	}
+}
+
+func TestTalkToNobodyIsFree(t *testing.T) {
+	g := combatGame()
+	rat := &Creature{Def: &content.MonsterDef{ID: "rat", Name: "rat", Glyph: "r", HP: 3, Attack: 0, Dodge: 1, Damage: "1d1"}, Pos: Pos{8, 1}, HP: 3}
+	g.Level.Creatures = append(g.Level.Creatures, rat)
+	g.Talk()
+	if !hasMessage(g, "There is no one to talk to.") {
+		t.Errorf("expected a refusal, got %v", g.Messages)
+	}
+	if rat.Pos.X != 8 {
+		t.Error("talking to the air costs nothing")
+	}
+}
+
+func TestTalkToSleeperIsFree(t *testing.T) {
+	g := combatGame()
+	gnoblin := &Creature{Def: &content.MonsterDef{ID: "gnoblin", Name: "gnoblin", Glyph: "g", HP: 4, Attack: 0, Dodge: 1, Damage: "1d2", Chat: "The gnoblin snarls at you!"}, Pos: Pos{2, 1}, HP: 4}
+	gnoblin.AddEffect("sleep", 10)
+	rat := &Creature{Def: &content.MonsterDef{ID: "rat", Name: "rat", Glyph: "r", HP: 3, Attack: 0, Dodge: 1, Damage: "1d1"}, Pos: Pos{8, 1}, HP: 3}
+	g.Level.Creatures = append(g.Level.Creatures, gnoblin, rat)
+	g.Talk()
+	if !hasMessage(g, "The gnoblin appears to be asleep.") {
+		t.Errorf("expected the C sleep line, got %v", g.Messages)
+	}
+	if hasMessage(g, "snarls") || rat.Pos.X != 8 {
+		t.Error("a sleeping neighbor neither chats nor costs a turn (C interact returns false)")
+	}
+}
+
+func TestTalkToSilentMonster(t *testing.T) {
+	g := combatGame()
+	rat := &Creature{Def: &content.MonsterDef{ID: "rat", Name: "rat", Glyph: "r", HP: 3, Attack: 0, Dodge: 1, Damage: "1d1"}, Pos: Pos{2, 1}, HP: 3}
+	g.Level.Creatures = append(g.Level.Creatures, rat)
+	g.Talk()
+	if !hasMessage(g, "You get no reply.") {
+		t.Errorf("a silent monster gets the gentle default (the C's line is a BUG marker), got %v", g.Messages)
+	}
+}

--- a/go/internal/ui/tcell/screen.go
+++ b/go/internal/ui/tcell/screen.go
@@ -137,6 +137,8 @@ func keyToAction(ev *tc.EventKey) (ui.Action, bool) {
 		return ui.Action{Kind: ui.ActFire}, true
 	case 'c':
 		return ui.Action{Kind: ui.ActCast}, true
+	case 't':
+		return ui.Action{Kind: ui.ActTalk}, true
 	case '>':
 		return ui.Action{Kind: ui.ActTravel}, true
 	}

--- a/go/internal/ui/tcell/screen_test.go
+++ b/go/internal/ui/tcell/screen_test.go
@@ -50,6 +50,7 @@ func TestKeyToAction(t *testing.T) {
 		{tc.NewEventKey(tc.KeyRune, 'r', tc.ModNone), ui.Action{Kind: ui.ActRead}, true},
 		{tc.NewEventKey(tc.KeyRune, 'f', tc.ModNone), ui.Action{Kind: ui.ActFire}, true},
 		{tc.NewEventKey(tc.KeyRune, 'c', tc.ModNone), ui.Action{Kind: ui.ActCast}, true},
+		{tc.NewEventKey(tc.KeyRune, 't', tc.ModNone), ui.Action{Kind: ui.ActTalk}, true},
 		{tc.NewEventKey(tc.KeyRune, 'X', tc.ModNone), ui.Action{}, false},
 	}
 	for _, tt := range cases {

--- a/go/internal/ui/ui.go
+++ b/go/internal/ui/ui.go
@@ -45,6 +45,7 @@ const (
 	ActRead
 	ActFire
 	ActCast
+	ActTalk
 )
 
 // Action is a decoded player intent. Dir is meaningful only when Kind==ActMove.
@@ -197,6 +198,8 @@ func Run(g *game.Game, p Prompter, r Renderer) error {
 			}
 		case ActTravel:
 			g.Travel()
+		case ActTalk:
+			g.Talk()
 		case ActEat:
 			food := g.EdibleInventory()
 			if len(food) == 0 {


### PR DESCRIPTION
## Summary
Plan 13j — the C's interaction verb and the unique deferred behind it (from the #61 plan):

- **`t)alk`** (`actions.c:790 interact`): address the first adjacent creature. A chat line passes the turn; an empty square refuses free; a **sleeping** neighbor reports "appears to be asleep." free (the C returns false there). The C's no-line default is literally "BUG: Undefined generic interaction!" — a debug marker, so ours is a gentle "You get no reply." (deliberate deviation, documented).
- **Four C flavor lines**: the gnoblin snarls, the ghoul desires your brain, the imp giggles impishly, the slime is indifferent to your inquiries.
- **The King of Worms** (`unique.c:97`, `W` per `glyph.c:113`): HP 30, the Necromancer's glacial speed 10, no spells — the Ominous Cave's boss (`places.c`), a lore fixture you can still pick a fight with. His password quest needs systems 0.40 never finished; **the line is the content**: "He keeps the wisdom that you need, the password that you want."
- Wired through `ActTalk` on the free `t` key (ui Run loop + tcell map + key test).

## Test plan
- Chatting an adjacent gnoblin logs its line and passes a turn (a distant rat closes in); empty air and sleepers cost nothing; a silent rat gets the default.
- Goldens: the King's exact line + Ominous Cave boss wiring + all four flavor lines present.
- gofmt + go vet + full `go test ./...` green (10/10 packages).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "Talk" interaction (press t) to converse with adjacent creatures; talking advances the game when a reply occurs.
  * Creatures may have unique dialogue lines; silent monsters give no reply. Sleeping creatures show asleep message and talking is free.
  * King of Worms boss added with specific placement and dialogue.

* **Tests**
  * Unit and data tests added to validate talk behaviors, dialogues, and boss embedding.

* **Documentation**
  * New plan page describing talk interaction behavior and acceptance criteria.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->