### PR TITLE
Save/resume 1/2: the engine round-trip

### DIFF
--- a/docs/superpowers/plans/2026-06-11-save-resume-20a.md
+++ b/docs/superpowers/plans/2026-06-11-save-resume-20a.md
@@ -1,0 +1,58 @@
+# Save/resume, engine round-trip (20a) Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** The save/resume arc, PR 1 of 2: a complete, tested **engine
+round-trip** — `Game.Save(io.Writer)` and `LoadGame(...)` that reconstruct
+the whole world (dungeon cache included) so play continues exactly where it
+stopped. PR 2 (20b) wires the S)ave key, load-on-start, and the C's
+delete-on-load rule. Advances the last big roadmap arc.
+
+## C grounding
+- `saveload.c try_to_save_game`: serialize everything, "Game saved.", then
+  **exit** — saving is quitting. `try_to_load_game` at startup restores and
+  the savefile is deleted (no save-scumming); `play()`'s opening
+  `goto creature_turn` means the player always acts first on resume —
+  "saving is a free action". Our zero-surplus `playerEnergy` convention
+  already encodes that invariant.
+- The C dumps raw structs through a pointer table (`build_saveload_table`);
+  the *format* is an implementation detail — the faithful part is the
+  behavior. We use JSON DTOs.
+
+## Design
+- `internal/rng`: `Snapshot() []uint32` / `Restore(snapshot)` exposing the
+  MT state, so the post-load dice sequence continues exactly — full
+  determinism across the save boundary.
+- `internal/game/save.go`: DTO types with JSON tags mirroring Game, Level,
+  Creature, Item, Tile (def pointers ↔ content IDs; equipped slots ↔
+  inventory indices; `Disguise`/`DisguiseAs` ↔ IDs; all unexported clocks —
+  `playerEnergy`, `swimFatigue`, `epTurn`, recall pin — included).
+- `Game.Save(w io.Writer) error` walks the Dungeon's level cache;
+  `LoadGame(r, content, behaviors, build) (*Game, error)` rebuilds the
+  Dungeon around the restored cache (defs/build re-injected, like cmd does
+  at boot).
+- Unknown content IDs in a savefile fail the load with a clear error
+  (the fail-fast convention).
+
+## Task 1: RNG snapshot (TDD)
+**Files:** `internal/rng/mt.go` + test.
+- Tests first: snapshot → draw N values → restore → the same N values again.
+- Commit: `feat(rng): MT state snapshot/restore for save games`
+
+## Task 2: the round-trip (TDD)
+**Files:** `internal/game/save.go` + `save_test.go`.
+- Tests first: (1) the **fixed-point invariant** — save(load(save(g))) ==
+  save(g) on a world salted with every kind of state (effects, identify +
+  appearances, recall pin, equipped gear, ally with lifetime, disguised
+  mimic, revealed trap, wand/ammo charges, two visited levels);
+  (2) RNG continuity — a worldTick after load moves a rat exactly as the
+  unsaved twin does; (3) equipped identity — the loaded Weapon IS the
+  inventory entry; (4) a marked recall still works cross-level after load;
+  (5) an unknown item ID fails loudly.
+- Commit: `feat(game): save/load — the full world round-trips through JSON`
+- Full gate; push, PR, CodeRabbit loop → merge. 20b follows.
+
+## Done when
+A buffer holds the entire dungeon — every clock, glamour, and pinned recall —
+and a game loaded from it is indistinguishable from one that never stopped.
+Suite green.

--- a/go/internal/game/save.go
+++ b/go/internal/game/save.go
@@ -1,0 +1,301 @@
+package game
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"sort"
+
+	"github.com/c0ze/tsl/internal/content"
+	"github.com/c0ze/tsl/internal/rng"
+)
+
+// Save/load (#20, C saveload.c). The C dumps raw structs through a pointer
+// table; the format here is JSON DTOs — the faithful part is the behavior
+// (an exact resume), not the bytes. Def pointers travel as content IDs and
+// the equipped slots as inventory indices.
+
+type savedEffect struct {
+	Kind  string `json:"k"`
+	Turns int    `json:"t"`
+}
+
+type savedItem struct {
+	ID      string `json:"id"`
+	Pos     Pos    `json:"pos"`
+	Charges int    `json:"ch,omitempty"`
+}
+
+type savedCreature struct {
+	ID         string        `json:"id"`
+	Pos        Pos           `json:"pos"`
+	HP         int           `json:"hp"`
+	Faction    Faction       `json:"f,omitempty"`
+	Energy     int           `json:"e,omitempty"`
+	Effects    []savedEffect `json:"fx,omitempty"`
+	Ally       bool          `json:"ally,omitempty"`
+	Lifetime   int           `json:"life,omitempty"`
+	Disguised  bool          `json:"dis,omitempty"`
+	DisguiseAs string        `json:"das,omitempty"`
+}
+
+type savedTile struct {
+	ID             string `json:"id"`
+	Visible        bool   `json:"v,omitempty"`
+	Seen           bool   `json:"s,omitempty"`
+	Disguise       string `json:"d,omitempty"`
+	Revealed       bool   `json:"r,omitempty"`
+	TrapDifficulty int    `json:"td,omitempty"`
+}
+
+type savedLevel struct {
+	ID        string          `json:"id"`
+	W         int             `json:"w"`
+	H         int             `json:"h"`
+	Tiles     []savedTile     `json:"tiles"`
+	Creatures []savedCreature `json:"creatures,omitempty"`
+	Items     []savedItem     `json:"items,omitempty"`
+	Start     Pos             `json:"start"`
+	Return    Pos             `json:"return"`
+	Entered   bool            `json:"entered,omitempty"`
+	Portals   []Portal        `json:"portals,omitempty"`
+	Dark      bool            `json:"dark,omitempty"`
+}
+
+type savedGame struct {
+	Player       Pos               `json:"player"`
+	PlayerHP     int               `json:"hp"`
+	PlayerMax    int               `json:"hpmax"`
+	EP           int               `json:"ep"`
+	EPMax        int               `json:"epmax"`
+	EPTurn       int               `json:"epturn,omitempty"`
+	PlayerEnergy int               `json:"penergy,omitempty"`
+	SwimFatigue  int               `json:"swim,omitempty"`
+	RecallLevel  string            `json:"rlevel,omitempty"`
+	RecallPos    Pos               `json:"rpos,omitempty"`
+	RecallSet    bool              `json:"rset,omitempty"`
+	Dead         bool              `json:"dead,omitempty"`
+	Won          bool              `json:"won,omitempty"`
+	DeathCause   string            `json:"cause,omitempty"`
+	Messages     []string          `json:"msgs,omitempty"`
+	Effects      []savedEffect     `json:"fx,omitempty"`
+	Identified   map[string]bool   `json:"identified,omitempty"`
+	Appearances  map[string]string `json:"appearances,omitempty"`
+	Inventory    []savedItem       `json:"inventory,omitempty"`
+	Weapon       int               `json:"weapon"` // inventory indices; -1 = empty slot
+	Armor        int               `json:"armor"`
+	Ring         int               `json:"ring"`
+	Amulet       int               `json:"amulet"`
+	RNG          []uint32          `json:"rng,omitempty"`
+	Current      string            `json:"current"` // the level the player is on
+	Levels       []savedLevel      `json:"levels"`
+}
+
+func saveEffects(fx []Effect) []savedEffect {
+	out := make([]savedEffect, 0, len(fx))
+	for _, e := range fx {
+		out = append(out, savedEffect{Kind: e.Kind, Turns: e.Turns})
+	}
+	return out
+}
+
+func loadEffects(fx []savedEffect) []Effect {
+	out := make([]Effect, 0, len(fx))
+	for _, e := range fx {
+		out = append(out, Effect{Kind: e.Kind, Turns: e.Turns})
+	}
+	return out
+}
+
+// slotIndex locates an equipped item inside the inventory (-1 when empty).
+func slotIndex(inv []*Item, slot *Item) int {
+	for i, it := range inv {
+		if it == slot {
+			return i
+		}
+	}
+	return -1
+}
+
+// Save serializes the whole game — player, clocks, identify state, and the
+// Dungeon's entire level cache — as JSON. The Behaviors registry, content
+// defs, and the level builder are runtime wiring, re-injected on load.
+func (g *Game) Save(w io.Writer) error {
+	sg := savedGame{
+		Player: g.Player, PlayerHP: g.PlayerHP, PlayerMax: g.PlayerMax,
+		EP: g.EP, EPMax: g.EPMax, EPTurn: g.epTurn,
+		PlayerEnergy: g.playerEnergy, SwimFatigue: g.swimFatigue,
+		RecallLevel: g.recallLevel, RecallPos: g.recallPos, RecallSet: g.recallSet,
+		Dead: g.Dead, Won: g.Won, DeathCause: g.DeathCause,
+		Messages: g.Messages, Effects: saveEffects(g.Effects),
+		Identified: g.Identified, Appearances: g.appearances,
+		Weapon: slotIndex(g.Inventory, g.Weapon), Armor: slotIndex(g.Inventory, g.Armor),
+		Ring: slotIndex(g.Inventory, g.Ring), Amulet: slotIndex(g.Inventory, g.Amulet),
+	}
+	if g.RNG != nil {
+		sg.RNG = g.RNG.Snapshot()
+	}
+	for _, it := range g.Inventory {
+		sg.Inventory = append(sg.Inventory, savedItem{ID: it.Def.ID, Pos: it.Pos, Charges: it.Charges})
+	}
+	if g.Dungeon != nil {
+		sg.Current = g.Dungeon.current
+		ids := make([]string, 0, len(g.Dungeon.cache))
+		for id := range g.Dungeon.cache {
+			ids = append(ids, id)
+		}
+		sort.Strings(ids) // deterministic save bytes
+		for _, id := range ids {
+			sg.Levels = append(sg.Levels, saveLevel(id, g.Dungeon.cache[id]))
+		}
+	} else if g.Level != nil { // bare unit-test games: a single anonymous level
+		sg.Levels = append(sg.Levels, saveLevel(g.Level.ID, g.Level))
+		sg.Current = g.Level.ID
+	}
+	enc := json.NewEncoder(w)
+	return enc.Encode(&sg)
+}
+
+func saveLevel(id string, l *Level) savedLevel {
+	sl := savedLevel{
+		ID: id, W: l.W, H: l.H,
+		Start: l.Start, Return: l.Return, Entered: l.entered,
+		Portals: l.Portals, Dark: l.Dark,
+	}
+	sl.Tiles = make([]savedTile, len(l.tiles))
+	for i, t := range l.tiles {
+		st := savedTile{ID: t.Def.ID, Visible: t.Visible, Seen: t.Seen,
+			Revealed: t.Revealed, TrapDifficulty: t.TrapDifficulty}
+		if t.Disguise != nil {
+			st.Disguise = t.Disguise.ID
+		}
+		sl.Tiles[i] = st
+	}
+	for _, c := range l.Creatures {
+		sc := savedCreature{ID: c.Def.ID, Pos: c.Pos, HP: c.HP, Faction: c.Faction,
+			Energy: c.Energy, Effects: saveEffects(c.Effects),
+			Ally: c.Ally, Lifetime: c.Lifetime, Disguised: c.Disguised}
+		if c.DisguiseAs != nil {
+			sc.DisguiseAs = c.DisguiseAs.ID
+		}
+		sl.Creatures = append(sl.Creatures, sc)
+	}
+	for _, it := range l.Items {
+		sl.Items = append(sl.Items, savedItem{ID: it.Def.ID, Pos: it.Pos, Charges: it.Charges})
+	}
+	return sl
+}
+
+// LoadGame reconstructs a saved game. Content defs, the behaviors registry,
+// and the level builder are the same runtime wiring cmd injects at boot; an
+// ID the content no longer knows fails the load (the fail-fast convention).
+func LoadGame(r io.Reader, c *content.Content, behaviors map[string]Behavior,
+	build func(*content.LevelDef) (*Level, error)) (*Game, error) {
+	var sg savedGame
+	if err := json.NewDecoder(r).Decode(&sg); err != nil {
+		return nil, fmt.Errorf("load: %w", err)
+	}
+	g := &Game{
+		Content: c, Behaviors: behaviors,
+		Player: sg.Player, PlayerHP: sg.PlayerHP, PlayerMax: sg.PlayerMax,
+		EP: sg.EP, EPMax: sg.EPMax, epTurn: sg.EPTurn,
+		playerEnergy: sg.PlayerEnergy, swimFatigue: sg.SwimFatigue,
+		recallLevel: sg.RecallLevel, recallPos: sg.RecallPos, recallSet: sg.RecallSet,
+		Dead: sg.Dead, Won: sg.Won, DeathCause: sg.DeathCause,
+		Messages: sg.Messages, Effects: loadEffects(sg.Effects),
+		Identified: sg.Identified, appearances: sg.Appearances,
+	}
+	if sg.RNG != nil {
+		if g.RNG = rng.Restore(sg.RNG); g.RNG == nil {
+			return nil, fmt.Errorf("load: corrupt RNG snapshot")
+		}
+	}
+	for _, si := range sg.Inventory {
+		it, err := loadItem(c, si)
+		if err != nil {
+			return nil, err
+		}
+		g.Inventory = append(g.Inventory, it)
+	}
+	for slot, idx := range map[**Item]int{&g.Weapon: sg.Weapon, &g.Armor: sg.Armor, &g.Ring: sg.Ring, &g.Amulet: sg.Amulet} {
+		if idx >= 0 {
+			if idx >= len(g.Inventory) {
+				return nil, fmt.Errorf("load: equipped slot index %d out of range", idx)
+			}
+			*slot = g.Inventory[idx]
+		}
+	}
+	cache := map[string]*Level{}
+	for _, sl := range sg.Levels {
+		lvl, err := loadLevel(c, sl)
+		if err != nil {
+			return nil, err
+		}
+		cache[sl.ID] = lvl
+	}
+	if cache[sg.Current] == nil {
+		return nil, fmt.Errorf("load: current level %q missing from save", sg.Current)
+	}
+	g.Level = cache[sg.Current]
+	if len(c.Levels) > 0 { // a real dungeon graph (bare test games have none)
+		g.Dungeon = &Dungeon{defs: c.Levels, cache: cache, current: sg.Current, build: build}
+	}
+	return g, nil
+}
+
+func loadItem(c *content.Content, si savedItem) (*Item, error) {
+	def := c.Items[si.ID]
+	if def == nil {
+		return nil, fmt.Errorf("load: unknown item %q", si.ID)
+	}
+	return &Item{Def: def, Pos: si.Pos, Charges: si.Charges}, nil
+}
+
+func loadLevel(c *content.Content, sl savedLevel) (*Level, error) {
+	if len(sl.Tiles) != sl.W*sl.H {
+		return nil, fmt.Errorf("load: level %q has %d tiles for %dx%d", sl.ID, len(sl.Tiles), sl.W, sl.H)
+	}
+	lvl := &Level{
+		W: sl.W, H: sl.H, ID: sl.ID,
+		Start: sl.Start, Return: sl.Return, entered: sl.Entered,
+		Portals: sl.Portals, Dark: sl.Dark,
+		tiles: make([]Tile, len(sl.Tiles)),
+	}
+	for i, st := range sl.Tiles {
+		def := c.Tiles[st.ID]
+		if def == nil {
+			return nil, fmt.Errorf("load: unknown tile %q", st.ID)
+		}
+		t := Tile{Def: def, Visible: st.Visible, Seen: st.Seen,
+			Revealed: st.Revealed, TrapDifficulty: st.TrapDifficulty}
+		if st.Disguise != "" {
+			if t.Disguise = c.Tiles[st.Disguise]; t.Disguise == nil {
+				return nil, fmt.Errorf("load: unknown disguise tile %q", st.Disguise)
+			}
+		}
+		lvl.tiles[i] = t
+	}
+	for _, sc := range sl.Creatures {
+		def := c.Monsters[sc.ID]
+		if def == nil {
+			return nil, fmt.Errorf("load: unknown monster %q", sc.ID)
+		}
+		cr := &Creature{Def: def, Pos: sc.Pos, HP: sc.HP, Faction: sc.Faction,
+			Energy: sc.Energy, Effects: loadEffects(sc.Effects),
+			Ally: sc.Ally, Lifetime: sc.Lifetime, Disguised: sc.Disguised}
+		if sc.DisguiseAs != "" {
+			if cr.DisguiseAs = c.Items[sc.DisguiseAs]; cr.DisguiseAs == nil {
+				return nil, fmt.Errorf("load: unknown disguise item %q", sc.DisguiseAs)
+			}
+		}
+		lvl.Creatures = append(lvl.Creatures, cr)
+	}
+	for _, si := range sl.Items {
+		it, err := loadItem(c, si)
+		if err != nil {
+			return nil, err
+		}
+		lvl.Items = append(lvl.Items, it)
+	}
+	return lvl, nil
+}

--- a/go/internal/game/save_test.go
+++ b/go/internal/game/save_test.go
@@ -1,0 +1,168 @@
+package game
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/c0ze/tsl/internal/content"
+	"github.com/c0ze/tsl/internal/rng"
+)
+
+// savedWorld builds a two-level dungeon over registered content and salts it
+// with every kind of state the save format must carry.
+func savedWorld(t *testing.T) *Game {
+	t.Helper()
+	floor := &content.TileDef{ID: "floor", Glyph: ".", Passable: true, Transparent: true}
+	c := &content.Content{
+		Tiles: map[string]*content.TileDef{
+			"floor": floor,
+			"water": {ID: "water", Glyph: "_", Transparent: true, Water: true},
+			"trap":  {ID: "trap", Glyph: "^", Passable: true, Transparent: true, Effect: "poison", EffectTurns: 5},
+		},
+		Monsters: map[string]*content.MonsterDef{
+			"rat":   {ID: "rat", Name: "rat", Glyph: "r", HP: 3, Attack: 2, Dodge: 1, Damage: "1d2"},
+			"imp":   {ID: "imp", Name: "imp", Glyph: "i", HP: 6, Attack: 8, Dodge: 2, Damage: "1d4"},
+			"mimic": {ID: "mimic", Name: "mimic", Glyph: "m", HP: 5, Attack: 6, Damage: "1d4", Mimic: true},
+		},
+		Items: map[string]*content.ItemDef{
+			"dagger": {ID: "dagger", Name: "dagger", Glyph: ")", Kind: "weapon", Attack: 2, Damage: "1d4", Weight: 18},
+			"potion": {ID: "potion", Name: "odd potion", Glyph: "!", Kind: "potion", Weight: 7},
+			"arrow":  {ID: "arrow", Name: "crude arrow", Glyph: ":", Kind: "ammo", Weight: 1},
+		},
+		Levels: map[string]*content.LevelDef{
+			"a": {ID: "a", Name: "Level A", W: 8, H: 4, Start: true, Links: []string{"b"}},
+			"b": {ID: "b", Name: "Level B", W: 8, H: 4, Links: []string{"a"}},
+		},
+	}
+	build := func(def *content.LevelDef) (*Level, error) {
+		l := NewLevel(def.W, def.H, floor)
+		l.Start = Pos{1, 1}
+		l.Portals = []Portal{{Pos: Pos{6, 1}, Target: def.Links[0]}}
+		return l, nil
+	}
+	d, err := NewDungeon(c.Levels, "a", build)
+	if err != nil {
+		t.Fatal(err)
+	}
+	g := &Game{
+		Content: c, Dungeon: d, Level: d.Current(),
+		RNG: rng.NewWithSeed(99), PlayerHP: 17, PlayerMax: 20, EP: 3, EPMax: 9,
+		Identified: map[string]bool{"potion": true},
+	}
+	g.EnterStart()
+
+	// Salt the world: clocks, effects, gear, allies, glamours, hidden traps.
+	g.AddEffect("poison", 4)
+	g.swimFatigue = 2
+	g.epTurn = 1
+	dagger := &Item{Def: c.Items["dagger"]}
+	arrows := &Item{Def: c.Items["arrow"], Charges: 13}
+	g.Inventory = append(g.Inventory, dagger, arrows)
+	g.Weapon = dagger
+	g.MarkRecall() // pinned on level a at the start tile
+	lvl := d.Current()
+	lvl.Set(Pos{4, 2}, c.Tiles["trap"])
+	tr := lvl.At(Pos{4, 2})
+	tr.Disguise = floor
+	tr.TrapDifficulty = 9
+	lvl.Set(Pos{6, 2}, c.Tiles["water"])
+	rat := &Creature{Def: c.Monsters["rat"], Pos: Pos{5, 1}, HP: 3}
+	rat.AddEffect("slow", 6)
+	imp := &Creature{Def: c.Monsters["imp"], Pos: Pos{2, 2}, HP: 6, Ally: true, Lifetime: 321, Energy: 40}
+	mim := &Creature{Def: c.Monsters["mimic"], Pos: Pos{3, 3}, HP: 5, Disguised: true, DisguiseAs: c.Items["potion"]}
+	lvl.Creatures = append(lvl.Creatures, rat, imp, mim)
+	lvl.Items = append(lvl.Items, &Item{Def: c.Items["potion"], Pos: Pos{5, 2}})
+
+	// Visit level b so the cache holds two levels with state.
+	g.Player = Pos{6, 1}
+	g.Travel()
+	return g
+}
+
+func TestSaveLoadFixedPoint(t *testing.T) {
+	g := savedWorld(t)
+	var first bytes.Buffer
+	if err := g.Save(&first); err != nil {
+		t.Fatal(err)
+	}
+	g2, err := LoadGame(bytes.NewReader(first.Bytes()), g.Content, g.Behaviors, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var second bytes.Buffer
+	if err := g2.Save(&second); err != nil {
+		t.Fatal(err)
+	}
+	if first.String() != second.String() {
+		t.Error("save(load(save(g))) must equal save(g) — some state fell out of the round-trip")
+	}
+}
+
+func TestLoadContinuesDiceExactly(t *testing.T) {
+	g := savedWorld(t)
+	var buf bytes.Buffer
+	if err := g.Save(&buf); err != nil {
+		t.Fatal(err)
+	}
+	g2, err := LoadGame(&buf, g.Content, g.Behaviors, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i := 0; i < 25; i++ {
+		if a, b := g.RNG.Uint32(), g2.RNG.Uint32(); a != b {
+			t.Fatalf("dice diverged at draw %d: %d vs %d", i, a, b)
+		}
+	}
+}
+
+func TestLoadRestoresEquippedIdentity(t *testing.T) {
+	g := savedWorld(t)
+	var buf bytes.Buffer
+	if err := g.Save(&buf); err != nil {
+		t.Fatal(err)
+	}
+	g2, err := LoadGame(&buf, g.Content, g.Behaviors, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if g2.Weapon == nil || g2.Weapon != g2.Inventory[0] {
+		t.Error("the loaded weapon must BE the inventory entry, not a copy")
+	}
+	if g2.Inventory[1].Charges != 13 {
+		t.Errorf("the quiver should still hold 13, got %d", g2.Inventory[1].Charges)
+	}
+}
+
+func TestLoadKeepsRecallAcrossLevels(t *testing.T) {
+	g := savedWorld(t) // saved while standing on level b, pin on a
+	var buf bytes.Buffer
+	if err := g.Save(&buf); err != nil {
+		t.Fatal(err)
+	}
+	g2, err := LoadGame(&buf, g.Content, g.Behaviors, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if g2.Dungeon.current != "b" {
+		t.Fatalf("should resume on level b, got %q", g2.Dungeon.current)
+	}
+	if !g2.Recall() {
+		t.Fatal("the pinned recall should survive the save")
+	}
+	if g2.Dungeon.current != "a" || g2.Player != (Pos{1, 1}) {
+		t.Errorf("recall should land on a at the pin, got %q %v", g2.Dungeon.current, g2.Player)
+	}
+}
+
+func TestLoadFailsOnUnknownContent(t *testing.T) {
+	g := savedWorld(t)
+	var buf bytes.Buffer
+	if err := g.Save(&buf); err != nil {
+		t.Fatal(err)
+	}
+	doctored := strings.ReplaceAll(buf.String(), `"id":"rat"`, `"id":"ghost"`)
+	if _, err := LoadGame(strings.NewReader(doctored), g.Content, g.Behaviors, nil); err == nil {
+		t.Error("a save referencing unknown content must fail the load (fail-fast)")
+	}
+}

--- a/go/internal/rng/mt.go
+++ b/go/internal/rng/mt.go
@@ -121,3 +121,27 @@ func (g *MT) Intn(nn int) int {
 		}
 	}
 }
+
+// Snapshot captures the generator's full internal state (the MT word array
+// plus the index) so a saved game's dice continue exactly where they stopped.
+func (g *MT) Snapshot() []uint32 {
+	out := make([]uint32, n+1)
+	copy(out, g.mt[:])
+	out[n] = uint32(g.mti)
+	return out
+}
+
+// Restore rebuilds a generator from a Snapshot, or returns nil if the
+// snapshot is malformed.
+func Restore(snapshot []uint32) *MT {
+	if len(snapshot) != n+1 {
+		return nil
+	}
+	g := &MT{}
+	copy(g.mt[:], snapshot[:n])
+	g.mti = int(snapshot[n])
+	if g.mti < 0 || g.mti > n {
+		return nil
+	}
+	return g
+}

--- a/go/internal/rng/mt_test.go
+++ b/go/internal/rng/mt_test.go
@@ -55,3 +55,27 @@ func TestNewWithKeyPanicsOnEmptyKey(t *testing.T) {
 	}()
 	NewWithKey([]uint32{})
 }
+
+func TestSnapshotRestoreContinuesSequence(t *testing.T) {
+	g := NewWithSeed(42)
+	for i := 0; i < 100; i++ {
+		g.Uint32() // advance into the stream
+	}
+	snap := g.Snapshot()
+	want := make([]uint32, 50)
+	for i := range want {
+		want[i] = g.Uint32()
+	}
+	r := Restore(snap)
+	for i := range want {
+		if got := r.Uint32(); got != want[i] {
+			t.Fatalf("restored stream diverged at %d: got %d, want %d", i, got, want[i])
+		}
+	}
+}
+
+func TestRestoreRejectsBadSnapshot(t *testing.T) {
+	if Restore([]uint32{1, 2, 3}) != nil {
+		t.Error("a truncated snapshot must not restore")
+	}
+}


### PR DESCRIPTION
## Summary
Plan 20a — the save/resume arc opens with a complete, tested **engine round-trip** (the C's `saveload.c` dumps raw structs through a pointer table; the faithful part is the *behavior* — an exact resume — so the format here is JSON DTOs):

- **`Game.Save(io.Writer)` / `LoadGame(r, content, behaviors, build)`**: everything round-trips — player clocks (`playerEnergy`, `swimFatigue`, `epTurn`), effects, identify + appearance maps, the recall pin, **equipped slots as inventory indices** (pointer identity restored, not copies), and the Dungeon's whole level cache: tiles with disguises/trap difficulties, creatures with allies/lifetimes/mimic glamours, items with charges. Levels emit in sorted order for deterministic bytes.
- **RNG continuity**: `rng.Snapshot()`/`Restore()` expose the MT state, so the post-load dice sequence continues exactly where it stopped.
- **Fail-fast**: a save referencing content the data files no longer define refuses to load with a clear error.
- PR 2 (20b) wires the C's behavior shell: the S)ave key (save-and-quit, "Game saved."), load-on-start, and delete-on-load (no save-scumming); the zero-surplus `playerEnergy` convention already encodes "the player acts first on resume".

## Test plan
- **Fixed-point invariant**: `save(load(save(g))) == save(g)` byte-for-byte on a two-level world salted with every kind of state.
- 25 post-load dice draws match the unsaved twin exactly; the loaded weapon IS its inventory entry; a recall pinned on level A still pulls the player back from B after the round-trip; a doctored save with an unknown monster fails loudly.
- gofmt + go vet + full `go test ./...` green (10/10 packages).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Players can now save and load game progress with full state persistence
  * Saved games maintain deterministic round-trip integrity
  * Random number generation continues accurately after loading
  * Equipped items preserve their identity across save/load cycles
  * Cross-level recall positioning persists through game sessions
  * Corrupted save files are detected and safely rejected

<!-- end of auto-generated comment: release notes by coderabbit.ai -->