### PR TITLE
Save/resume 2/2: S)ave-and-quit, resume-on-start, no scumming

### DIFF
--- a/docs/superpowers/plans/2026-06-11-save-resume-20b.md
+++ b/docs/superpowers/plans/2026-06-11-save-resume-20b.md
@@ -20,7 +20,8 @@ startup and is **deleted on load** (no save-scumming). Completes the arc.
 - ui: `ActSave` on `S` (shift-s); `Run` returns the sentinel
   `ErrSaveRequested` — the ui layer never touches files; cmd owns the path.
 - cmd: `savePath()` (home dotfile), `saveTo(path, g)`,
-  `loadFrom(path, content, behaviors, build)` — load success deletes the
+  `loadFrom(path, content)` (behaviors and the lazy level builder are
+  constructed inside) — load success deletes the
   file, load failure reports and exits without deleting. main: resume if a
   savefile exists, else new game; on `ErrSaveRequested` save, print
   "Game saved.", exit 0; a failed save logs "Couldn't save game!" and

--- a/docs/superpowers/plans/2026-06-11-save-resume-20b.md
+++ b/docs/superpowers/plans/2026-06-11-save-resume-20b.md
@@ -1,0 +1,40 @@
+# Save/resume, the behavior shell (20b) Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Save/resume arc 2/2: wire #77's engine round-trip to the C's
+player-facing behavior — **S)ave is save-and-quit**, a savefile resumes at
+startup and is **deleted on load** (no save-scumming). Completes the arc.
+
+## C grounding
+- `saveload.c try_to_save_game`: on success "Game saved." then exit; on
+  failure "Couldn't save game!" and play resumes — never crash a live game.
+- `try_to_load_game` at startup; the savefile is deleted after a successful
+  restore (`delete_savefile`); a corrupt savefile aborts *without* deleting,
+  so nothing is silently lost. `SAVE_FILENAME "TSL-SAVE"` (`main.h:15`) —
+  ours: `~/.tsl-save.json`.
+- Resume order: `play()`'s `goto creature_turn` — the player acts first;
+  the zero-surplus `playerEnergy` already encodes this.
+
+## Design
+- ui: `ActSave` on `S` (shift-s); `Run` returns the sentinel
+  `ErrSaveRequested` — the ui layer never touches files; cmd owns the path.
+- cmd: `savePath()` (home dotfile), `saveTo(path, g)`,
+  `loadFrom(path, content, behaviors, build)` — load success deletes the
+  file, load failure reports and exits without deleting. main: resume if a
+  savefile exists, else new game; on `ErrSaveRequested` save, print
+  "Game saved.", exit 0; a failed save logs "Couldn't save game!" and
+  resumes the loop.
+
+## Task: the shell (TDD)
+**Files:** `internal/ui/ui.go` + test, `internal/ui/tcell/screen.go` + test,
+`cmd/tsl/main.go` + test.
+- Tests first: `S` maps to ActSave; Run surfaces ErrSaveRequested; a cmd
+  round-trip through a temp file resumes the same state and deletes the
+  file; a corrupt file errors without deletion.
+- Commit: `feat(cmd): S)ave-and-quit + resume-on-start (no save-scumming)`
+- Full gate; push, PR, CodeRabbit loop → merge.
+
+## Done when
+Press S, see "Game saved.", relaunch, and the dungeon is exactly where you
+left it — once, because the savefile is gone. Suite green.

--- a/go/cmd/tsl/main.go
+++ b/go/cmd/tsl/main.go
@@ -111,12 +111,12 @@ func loadFrom(path string, c *content.Content) (*game.Game, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer f.Close()
 	var g *game.Game
 	build := func(def *content.LevelDef) (*game.Level, error) {
 		return gen.LevelFromDef(g.RNG, c, def) // bound after load; called lazily on first entry
 	}
 	g, err = game.LoadGame(f, c, behaviors.Registry(), build)
+	f.Close() // before the delete: Windows refuses to remove an open file
 	if err != nil {
 		return nil, fmt.Errorf("savefile %s: %w", path, err)
 	}

--- a/go/cmd/tsl/main.go
+++ b/go/cmd/tsl/main.go
@@ -2,8 +2,10 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
 	"time"
 
 	"github.com/c0ze/tsl/data"
@@ -32,17 +34,34 @@ func run() (string, error) {
 	if err != nil {
 		return "", err
 	}
-	g, err := newGame(c, uint32(time.Now().UnixNano()))
+	g, err := loadFrom(savePath(), c)
 	if err != nil {
-		return "", err
+		return "", err // a corrupt savefile aborts without deleting it (C saveload_abort)
+	}
+	if g == nil { // no savefile: a fresh descent
+		if g, err = newGame(c, uint32(time.Now().UnixNano())); err != nil {
+			return "", err
+		}
 	}
 	screen, err := tcellui.New()
 	if err != nil {
 		return "", err
 	}
 	defer screen.Close()
-	if err := ui.Run(g, screen, screen); err != nil {
-		return "", err
+	for {
+		err := ui.Run(g, screen, screen)
+		if errors.Is(err, ui.ErrSaveRequested) {
+			if serr := saveTo(savePath(), g); serr != nil {
+				// Never crash a live game over a failed save (C: resume play).
+				g.Messages = append(g.Messages, "Couldn't save game!")
+				continue
+			}
+			return "Game saved.", nil
+		}
+		if err != nil {
+			return "", err
+		}
+		break
 	}
 	switch {
 	case g.Won:
@@ -55,6 +74,56 @@ func run() (string, error) {
 	default:
 		return "You leave the dungeon. Farewell.", nil
 	}
+}
+
+// savePath is where the savefile lives (the C's SAVE_FILENAME in the home
+// directory; the working directory when no home is known).
+func savePath() string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ".tsl-save.json"
+	}
+	return filepath.Join(home, ".tsl-save.json")
+}
+
+// saveTo writes the game to path (save-and-quit's file half).
+func saveTo(path string, g *game.Game) error {
+	f, err := os.Create(path)
+	if err != nil {
+		return err
+	}
+	if err := g.Save(f); err != nil {
+		f.Close()
+		return err
+	}
+	return f.Close()
+}
+
+// loadFrom resumes a saved game if path exists, deleting the savefile on a
+// successful restore (no save-scumming, C delete_savefile). No savefile is
+// not an error: (nil, nil) means start fresh. A corrupt file errors without
+// deletion so nothing is silently lost.
+func loadFrom(path string, c *content.Content) (*game.Game, error) {
+	f, err := os.Open(path)
+	if os.IsNotExist(err) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+	var g *game.Game
+	build := func(def *content.LevelDef) (*game.Level, error) {
+		return gen.LevelFromDef(g.RNG, c, def) // bound after load; called lazily on first entry
+	}
+	g, err = game.LoadGame(f, c, behaviors.Registry(), build)
+	if err != nil {
+		return nil, fmt.Errorf("savefile %s: %w", path, err)
+	}
+	if err := os.Remove(path); err != nil {
+		return nil, err
+	}
+	return g, nil
 }
 
 // newGame builds the dungeon graph from content, seeds the generator, and

--- a/go/cmd/tsl/main_test.go
+++ b/go/cmd/tsl/main_test.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/c0ze/tsl/data"
@@ -126,5 +128,62 @@ func TestNewGameStartsOnStartLevel(t *testing.T) {
 	}
 	if g.Player != g.Level.Start {
 		t.Errorf("player at %v, want start level's Start %v", g.Player, g.Level.Start)
+	}
+}
+
+func TestSaveFileRoundTripAndNoScumming(t *testing.T) {
+	c, err := content.Load(data.Files)
+	if err != nil {
+		t.Fatal(err)
+	}
+	g, err := newGame(c, 7)
+	if err != nil {
+		t.Fatal(err)
+	}
+	g.PlayerHP = 11 // salt something recognisable
+	path := filepath.Join(t.TempDir(), "save.json")
+	if err := saveTo(path, g); err != nil {
+		t.Fatal(err)
+	}
+	g2, err := loadFrom(path, c)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if g2 == nil || g2.PlayerHP != 11 {
+		t.Fatalf("the resumed game should carry the saved state, got %+v", g2)
+	}
+	if g2.LocationName() == "" {
+		t.Error("the resumed game should have its dungeon wired")
+	}
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Error("a successful load deletes the savefile (C delete_savefile - no scumming)")
+	}
+}
+
+func TestMissingSaveMeansFreshStart(t *testing.T) {
+	c, err := content.Load(data.Files)
+	if err != nil {
+		t.Fatal(err)
+	}
+	g, err := loadFrom(filepath.Join(t.TempDir(), "absent.json"), c)
+	if err != nil || g != nil {
+		t.Errorf("no savefile is not an error: got g=%v err=%v", g, err)
+	}
+}
+
+func TestCorruptSaveErrorsWithoutDeleting(t *testing.T) {
+	c, err := content.Load(data.Files)
+	if err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(t.TempDir(), "save.json")
+	if err := os.WriteFile(path, []byte("{not json"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := loadFrom(path, c); err == nil {
+		t.Fatal("a corrupt savefile must error")
+	}
+	if _, err := os.Stat(path); err != nil {
+		t.Error("a failed load must not delete the savefile (C saveload_abort)")
 	}
 }

--- a/go/internal/ui/tcell/screen.go
+++ b/go/internal/ui/tcell/screen.go
@@ -139,6 +139,8 @@ func keyToAction(ev *tc.EventKey) (ui.Action, bool) {
 		return ui.Action{Kind: ui.ActCast}, true
 	case 't':
 		return ui.Action{Kind: ui.ActTalk}, true
+	case 'S':
+		return ui.Action{Kind: ui.ActSave}, true
 	case '>':
 		return ui.Action{Kind: ui.ActTravel}, true
 	}

--- a/go/internal/ui/tcell/screen_test.go
+++ b/go/internal/ui/tcell/screen_test.go
@@ -51,6 +51,7 @@ func TestKeyToAction(t *testing.T) {
 		{tc.NewEventKey(tc.KeyRune, 'f', tc.ModNone), ui.Action{Kind: ui.ActFire}, true},
 		{tc.NewEventKey(tc.KeyRune, 'c', tc.ModNone), ui.Action{Kind: ui.ActCast}, true},
 		{tc.NewEventKey(tc.KeyRune, 't', tc.ModNone), ui.Action{Kind: ui.ActTalk}, true},
+		{tc.NewEventKey(tc.KeyRune, 'S', tc.ModNone), ui.Action{Kind: ui.ActSave}, true},
 		{tc.NewEventKey(tc.KeyRune, 'X', tc.ModNone), ui.Action{}, false},
 	}
 	for _, tt := range cases {

--- a/go/internal/ui/ui.go
+++ b/go/internal/ui/ui.go
@@ -4,6 +4,7 @@
 package ui
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 
@@ -46,6 +47,7 @@ const (
 	ActFire
 	ActCast
 	ActTalk
+	ActSave
 )
 
 // Action is a decoded player intent. Dir is meaningful only when Kind==ActMove.
@@ -71,6 +73,11 @@ type Prompter interface {
 type Renderer interface {
 	Render(View)
 }
+
+// ErrSaveRequested is returned by Run when the player asks to save: the ui
+// layer never touches files, so the front-end's owner (cmd) saves and quits
+// — the C's save-is-quitting (saveload.c try_to_save_game).
+var ErrSaveRequested = errors.New("save requested")
 
 // Player avatar rendering (Plan 1; later the player becomes a creature def).
 const PlayerGlyph = '@'
@@ -200,6 +207,8 @@ func Run(g *game.Game, p Prompter, r Renderer) error {
 			g.Travel()
 		case ActTalk:
 			g.Talk()
+		case ActSave:
+			return ErrSaveRequested
 		case ActEat:
 			food := g.EdibleInventory()
 			if len(food) == 0 {

--- a/go/internal/ui/ui_test.go
+++ b/go/internal/ui/ui_test.go
@@ -490,3 +490,11 @@ func TestBuildViewShowsMimicGlamour(t *testing.T) {
 		t.Errorf("a revealed mimic shows itself, got %q", got)
 	}
 }
+
+func TestRunSurfacesSaveRequest(t *testing.T) {
+	g := testGame(t, []string{".@."})
+	p := &zapPrompter{actions: []Action{{Kind: ActSave}}}
+	if err := Run(g, p, &nullRenderer{}); err != ErrSaveRequested {
+		t.Errorf("Run should surface the save sentinel, got %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
Plan 20b closes the save/resume arc — the C's player-facing behavior (`saveload.c`) over #77's engine round-trip:

- **`S` is save-and-quit**: the ui surfaces `ErrSaveRequested` (the ui layer never touches files); cmd writes `~/.tsl-save.json`, prints "Game saved.", and exits — `try_to_save_game`'s exact shape. A **failed save never crashes a live game**: the loop resumes with "Couldn't save game!" (the C's explicit kindness).
- **Resume-on-start**: a savefile restores the whole world and is **deleted on successful load** (`delete_savefile` — no save-scumming). A corrupt file aborts *without* deleting (`saveload_abort`), so nothing is silently lost; a missing file just means a fresh descent.
- The resumed game's lazy level builder re-binds to the restored RNG, so levels first entered *after* a resume still generate from the continued dice stream.
- "The player acts first on resume" needed no code: the zero-surplus `playerEnergy` convention from #54 already encodes it.

## Test plan
- cmd round-trip through a temp file: salted state survives, the dungeon is wired, and the savefile is gone; a missing file is (nil, nil); a corrupt file errors and survives.
- `S` maps to ActSave (tcell); Run surfaces the sentinel (ui).
- gofmt + go vet + full `go test ./...` green (10/10 packages).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Press 'S' to save game progress; games resume from saved state on startup. Successful restores delete the savefile to prevent re-use; save errors show a message and gameplay continues; corrupt saves are preserved to avoid silent data loss.

* **Documentation**
  * Added implementation plan for the save/resume workflow.

* **Tests**
  * Added end-to-end tests covering save/load round-trip, missing-save, and corrupt-save behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->