### PR TITLE
Polymorph: the 0.40 potion table completes

### DIFF
--- a/docs/superpowers/plans/2026-06-11-polymorph-22a.md
+++ b/docs/superpowers/plans/2026-06-11-polymorph-22a.md
@@ -1,0 +1,37 @@
+# Polymorph (22a) Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** The last named arc: player-side **shapeshift** (`shapeshf.c`) and
+the **potion of polymorph** — completing the 0.40 potion table (13/13).
+
+## C grounding
+- `shapeshift_random` (the potion, `potions.c treasure_p_polymorph`): any
+  monster in the roster; "You transform into a <name>!"; the form lasts
+  `SHAPESHIFT_DURATION` (85, `rules.h:128`), then `shapeshift_native` —
+  "You return to your native shape." HP and effects carry across; the form's
+  stats, speed, and abilities replace yours.
+- Monster-side shapeshift (moon wolf etc.) is out of scope — the potion is
+  the spawnable content.
+
+## Design
+- `Game.Shape *content.MonsterDef` (nil = native) + effect `polymorph`
+  (85 turns; expiry hook in tickEffects reverts, like levitate's landing).
+- While shaped: attack/dodge/damage are the form's (gear grants nothing to
+  claws; temp weapons still supersede); `playerSpeed` bases on the form's
+  speed with haste/slow/burden on top; a swimming form crosses water and
+  never drowns; the View draws the form's glyph.
+- Behavior `polymorph`: a random def (sorted IDs), Shape + effect, the C
+  line. Save: `shape` ID in the DTO + the fixed-point salt.
+- Data: `potion_polymorph`, use `polymorph`, power 85.
+
+## Task: shapeshift + the potion (TDD)
+- Tests: quaff transforms (message, Shape, 85); the form's stats/speed/swim
+  govern; expiry reverts with the C line; the View shows the form; save
+  round-trips; golden (the table completes).
+- Commit: `feat(game): polymorph — the 0.40 potion table completes`
+- Full gate; push, PR, CodeRabbit loop → merge.
+
+## Done when
+One unidentified bottle and you're a sludge dweller for 85 turns — slower,
+softer, but suddenly at home in the water. Then you're you again. Suite green.

--- a/go/data/data_test.go
+++ b/go/data/data_test.go
@@ -934,3 +934,15 @@ func TestEmbeddedKingOfWorms(t *testing.T) {
 		}
 	}
 }
+
+// TestEmbeddedPolymorph checks the final potion loaded (22a): with it the
+// 0.40 potion table is complete.
+func TestEmbeddedPolymorph(t *testing.T) {
+	c, err := content.Load(Files)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if p := c.Items["potion_polymorph"]; p == nil || p.Kind != "potion" || p.Use != "polymorph" || p.Power != 85 {
+		t.Errorf("potion_polymorph def unexpected: %+v", p)
+	}
+}

--- a/go/data/items.toml
+++ b/go/data/items.toml
@@ -524,3 +524,13 @@ glyph = ":"
 color = "brown"
 kind = "ammo"
 power = 8
+
+# The thirteenth and final potion (22a, C treasure_p_polymorph): any shape in
+# the roster, for 85 turns (C SHAPESHIFT_DURATION). The table is complete.
+[item.potion_polymorph]
+name = "potion of polymorph"
+glyph = "!"
+color = "normal"
+kind = "potion"
+use = "polymorph"
+power = 85

--- a/go/internal/behaviors/behaviors.go
+++ b/go/internal/behaviors/behaviors.go
@@ -5,6 +5,7 @@ package behaviors
 
 import (
 	"fmt"
+	"sort"
 
 	"github.com/c0ze/tsl/internal/game"
 )
@@ -41,7 +42,25 @@ func Registry() map[string]game.Behavior {
 		"magic_weapon":    magicWeapon,
 		"summon_familiar": summonFamiliar,
 		"pharmacy":        pharmacy,
+		"polymorph":       polymorph,
 	}
+}
+
+// polymorph turns the drinker into a random creature for Power turns
+// (C potions.c treasure_p_polymorph -> shapeshift_random: any shape in the
+// roster).
+func polymorph(g *game.Game, it *game.Item) []string {
+	ids := make([]string, 0, len(g.Content.Monsters))
+	for id := range g.Content.Monsters {
+		ids = append(ids, id)
+	}
+	if len(ids) == 0 {
+		return []string{"You feel briefly unlike yourself."}
+	}
+	sort.Strings(ids)
+	g.Shape = g.Content.Monsters[ids[g.RNG.Intn(len(ids))]]
+	g.AddEffect("polymorph", it.Def.Power)
+	return []string{fmt.Sprintf("You transform into a %s!", g.Shape.Name)}
 }
 
 // pharmacy reveals the whole potion table at once (C reading.c: the manual

--- a/go/internal/behaviors/behaviors_test.go
+++ b/go/internal/behaviors/behaviors_test.go
@@ -486,3 +486,23 @@ func TestPharmacyIdentifiesAllPotions(t *testing.T) {
 		t.Errorf("expected the C line, got %v", msgs)
 	}
 }
+
+func TestPolymorphTransforms(t *testing.T) {
+	poly, ok := Registry()["polymorph"]
+	if !ok {
+		t.Fatal("polymorph not registered")
+	}
+	g := &game.Game{
+		PlayerHP: 10, PlayerMax: 10, RNG: rng.NewWithSeed(3),
+		Content: &content.Content{Monsters: map[string]*content.MonsterDef{
+			"rat": {ID: "rat", Name: "rat", Glyph: "r", HP: 3, Attack: 2, Dodge: 1, Damage: "1d2"},
+		}},
+	}
+	msgs := poly(g, &game.Item{Def: &content.ItemDef{Name: "potion of polymorph", Power: 85}})
+	if g.Shape == nil || !g.HasEffect("polymorph") {
+		t.Error("the potion should set a form for 85 turns (C SHAPESHIFT_DURATION)")
+	}
+	if len(msgs) == 0 || msgs[0] != "You transform into a rat!" {
+		t.Errorf("expected the C transform line, got %v", msgs)
+	}
+}

--- a/go/internal/game/combat.go
+++ b/go/internal/game/combat.go
@@ -58,6 +58,9 @@ func (g *Game) burdened() bool { return g.carriedWeight() > carryCapacity }
 // effect mods as in increment_counters).
 func (g *Game) playerSpeed() int {
 	speed := defaultSpeed
+	if g.Shape != nil && g.Shape.Speed > 0 {
+		speed = g.Shape.Speed // the form's pace, modifiers on top
+	}
 	if g.HasEffect("haste") {
 		speed += hasteBonus
 	}
@@ -107,7 +110,8 @@ func (g *Game) PlayerStep(d Direction) {
 		g.log("You open the door.")
 		acted = true
 	} else if g.Level.InBounds(dst) && (g.Level.At(dst).Def.Water || g.Level.At(dst).Def.Lava) &&
-		(g.HasEffect("blind") || g.HasEffect("levitate")) {
+		(g.HasEffect("blind") || g.HasEffect("levitate") ||
+			(g.Level.At(dst).Def.Water && g.Shape != nil && g.Shape.Swim)) {
 		// Deep water and lava turn away a sighted walker; the blinded blunder
 		// in and floaters drift across (C move_creature).
 		g.Player = dst
@@ -132,6 +136,9 @@ func (g *Game) equippedGear() []*Item {
 }
 
 func (g *Game) playerAttackStat() int {
+	if g.Shape != nil {
+		return g.Shape.Attack // the form's claws; gear grants nothing (C shapeshift)
+	}
 	atk := playerAttack
 	for _, it := range g.equippedGear() {
 		atk += it.Def.Attack
@@ -154,6 +161,9 @@ func (g *Game) playerDamageSpec() string {
 		// A temp weapon supersedes the wielded one (C set_temp_weapon).
 		return flameHandsDamage
 	}
+	if g.Shape != nil && g.Shape.Damage != "" {
+		return g.Shape.Damage // the form's natural attack
+	}
 	if g.Weapon != nil && g.Weapon.Def.Damage != "" {
 		return g.Weapon.Def.Damage
 	}
@@ -161,6 +171,9 @@ func (g *Game) playerDamageSpec() string {
 }
 
 func (g *Game) playerDodgeStat() int {
+	if g.Shape != nil {
+		return g.Shape.Dodge
+	}
 	dodge := playerDodge
 	for _, it := range g.equippedGear() {
 		dodge += it.Def.Dodge
@@ -383,6 +396,9 @@ const playerSwimming = 0
 func (g *Game) swimCheck() {
 	if g.HasEffect("levitate") {
 		return // airborne: the fatigue counter freezes (C swim() skips floaters)
+	}
+	if g.Shape != nil && g.Shape.Swim {
+		return // a swimming form never drowns (C swim() free_swim)
 	}
 	if !g.Level.At(g.Player).Def.Water {
 		g.swimFatigue = 0

--- a/go/internal/game/effects.go
+++ b/go/internal/game/effects.go
@@ -21,6 +21,7 @@ var effectLabels = map[string]string{
 	"levitate":    "Floating",
 	"flame_hands": "Flaming hands",
 	"hungry_book": "Hungry book",
+	"polymorph":   "Polymorphed",
 }
 
 // HasEffect reports whether a timed effect of the given kind is active on the
@@ -136,6 +137,9 @@ func (g *Game) tickEffects() {
 			g.log("You wake up!") // sleep ran its course (C creature_sleep)
 		} else if e.Kind == "levitate" {
 			landed = true // resolved below, once the effects slice is settled
+		} else if e.Kind == "polymorph" && g.Shape != nil {
+			g.Shape = nil
+			g.log("You return to your native shape.") // C shapeshift_native
 		}
 	}
 	g.Effects = kept

--- a/go/internal/game/game.go
+++ b/go/internal/game/game.go
@@ -130,9 +130,10 @@ type Game struct {
 	Won          bool
 	DeathCause   string
 	Effects      []Effect
-	Identified   map[string]bool   // item ids whose type is globally known this game
-	Known        map[string]bool   // spellbook ids learned by reading (C reading.c)
-	appearances  map[string]string // item id -> shuffled cosmetic name while unidentified
+	Identified   map[string]bool     // item ids whose type is globally known this game
+	Known        map[string]bool     // spellbook ids learned by reading (C reading.c)
+	Shape        *content.MonsterDef // polymorphed form (nil = native; C shapeshf.c)
+	appearances  map[string]string   // item id -> shuffled cosmetic name while unidentified
 }
 
 // Move attempts to move the player one step in d. It returns true if the player

--- a/go/internal/game/save.go
+++ b/go/internal/game/save.go
@@ -81,6 +81,7 @@ type savedGame struct {
 	Effects      []savedEffect     `json:"fx,omitempty"`
 	Identified   map[string]bool   `json:"identified,omitempty"`
 	Known        map[string]bool   `json:"known,omitempty"`
+	Shape        string            `json:"shape,omitempty"`
 	Appearances  map[string]string `json:"appearances,omitempty"`
 	Inventory    []savedItem       `json:"inventory,omitempty"`
 	Weapon       int               `json:"weapon"` // inventory indices; -1 = empty slot
@@ -132,6 +133,9 @@ func (g *Game) Save(w io.Writer) error {
 		Identified: g.Identified, Known: g.Known, Appearances: g.appearances,
 		Weapon: slotIndex(g.Inventory, g.Weapon), Armor: slotIndex(g.Inventory, g.Armor),
 		Ring: slotIndex(g.Inventory, g.Ring), Amulet: slotIndex(g.Inventory, g.Amulet),
+	}
+	if g.Shape != nil {
+		sg.Shape = g.Shape.ID
 	}
 	if g.RNG != nil {
 		sg.RNG = g.RNG.Snapshot()
@@ -205,6 +209,11 @@ func LoadGame(r io.Reader, c *content.Content, behaviors map[string]Behavior,
 		Dead: sg.Dead, Won: sg.Won, DeathCause: sg.DeathCause,
 		Messages: sg.Messages, Effects: loadEffects(sg.Effects),
 		Identified: sg.Identified, Known: sg.Known, appearances: sg.Appearances,
+	}
+	if sg.Shape != "" {
+		if g.Shape = c.Monsters[sg.Shape]; g.Shape == nil {
+			return nil, fmt.Errorf("load: unknown shape %q", sg.Shape)
+		}
 	}
 	if sg.RNG != nil {
 		if g.RNG = rng.Restore(sg.RNG); g.RNG == nil {

--- a/go/internal/game/shape_test.go
+++ b/go/internal/game/shape_test.go
@@ -1,0 +1,79 @@
+package game
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/c0ze/tsl/internal/content"
+)
+
+func wolfForm() *content.MonsterDef {
+	return &content.MonsterDef{ID: "dire_wolf", Name: "dire wolf", Glyph: "d", HP: 10, Attack: 9, Dodge: 4, Damage: "2d3", Speed: 50}
+}
+
+func TestShapedStatsGovern(t *testing.T) {
+	g := combatGame()
+	g.Weapon = &Item{Def: &content.ItemDef{Name: "doomblade", Kind: "weapon", Attack: 5, Damage: "2d6"}}
+	g.Shape = wolfForm()
+	if got := g.playerDamageSpec(); got != "2d3" {
+		t.Errorf("claws, not the blade: damage spec %q", got)
+	}
+	if g.playerAttackStat() != 9 || g.playerDodgeStat() != 4 {
+		t.Errorf("the form's combat stats govern, got %d/%d", g.playerAttackStat(), g.playerDodgeStat())
+	}
+}
+
+func TestShapedSpeedGoverns(t *testing.T) {
+	g, rat := schedulerGame()
+	g.Shape = wolfForm() // speed 50: the world ticks twice per action
+	g.advanceWorld()
+	if rat.Pos.X != 6 {
+		t.Errorf("a slow form drags like a slow effect: rat at x=%d, want 6", rat.Pos.X)
+	}
+}
+
+func TestSwimmingFormCrossesWater(t *testing.T) {
+	g := waterGame()
+	g.Shape = &content.MonsterDef{ID: "merman", Name: "merman", Glyph: "M", HP: 8, Attack: 4, Dodge: 2, Damage: "1d4", Speed: 100, Swim: true}
+	g.PlayerStep(DirE) // into the pool, fins first
+	if g.Player != (Pos{2, 1}) {
+		t.Fatalf("a swimming form enters water (C move_creature), at %v", g.Player)
+	}
+	g.advanceWorld()
+	if g.PlayerHP != 20 {
+		t.Errorf("a swimming form never drowns (C swim() free_swim), HP %d", g.PlayerHP)
+	}
+}
+
+func TestPolymorphExpiryReverts(t *testing.T) {
+	g := combatGame()
+	g.Shape = wolfForm()
+	g.AddEffect("polymorph", 2)
+	g.advanceWorld()
+	g.advanceWorld()
+	if g.Shape != nil {
+		t.Fatal("the form should expire (C SHAPESHIFT_DURATION)")
+	}
+	if !hasMessage(g, "You return to your native shape.") {
+		t.Errorf("expected the C revert line, got %v", g.Messages)
+	}
+}
+
+func TestShapeSurvivesTheSave(t *testing.T) {
+	g := savedWorld(t)
+	g.Content.Monsters["wolf"] = wolfForm()
+	g.Content.Monsters["wolf"].ID = "wolf"
+	g.Shape = g.Content.Monsters["wolf"]
+	g.AddEffect("polymorph", 40)
+	var buf bytes.Buffer
+	if err := g.Save(&buf); err != nil {
+		t.Fatal(err)
+	}
+	g2, err := LoadGame(&buf, g.Content, g.Behaviors, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if g2.Shape == nil || g2.Shape.ID != "wolf" {
+		t.Errorf("the form should survive the save, got %+v", g2.Shape)
+	}
+}

--- a/go/internal/ui/ui.go
+++ b/go/internal/ui/ui.go
@@ -120,7 +120,11 @@ func BuildView(g *game.Game) View {
 		*v.At(m.Pos.X, m.Pos.Y) = Cell{Glyph: m.Def.Rune(), Color: m.Def.Color}
 	}
 	if l.InBounds(g.Player) {
-		*v.At(g.Player.X, g.Player.Y) = Cell{Glyph: PlayerGlyph, Color: PlayerColor}
+		if g.Shape != nil { // a polymorphed player wears the form's glyph
+			*v.At(g.Player.X, g.Player.Y) = Cell{Glyph: g.Shape.Rune(), Color: g.Shape.Color}
+		} else {
+			*v.At(g.Player.X, g.Player.Y) = Cell{Glyph: PlayerGlyph, Color: PlayerColor}
+		}
 	}
 	v.Status = statusLine(g)
 	v.Messages = lastN(g.Messages, 4)


### PR DESCRIPTION
## Summary
Plan 22a — the last named roadmap arc: player-side shapeshift (`shapeshf.c`) and the **potion of polymorph**, the thirteenth and final entry of 0.40's potion table.

- **`Game.Shape`** + the `polymorph` effect (85 turns, `SHAPESHIFT_DURATION`): while shaped, the form's attack/dodge/damage **replace** yours (gear grants nothing to claws; the temp weapons from magic-weapon/hungry-book still supersede, as the C's `set_temp_weapon` would), `playerSpeed` bases on the form's pace with haste/slow/burden on top, a **swimming form enters water and never drowns** (`swim()`'s free_swim), and the View draws the form's glyph instead of `@`. HP and effects carry across, as in the C.
- **Expiry reverts** — "You return to your native shape." (`shapeshift_native`) — via the same tickEffects expiry hook pattern as levitation's landing.
- **The potion** (`treasure_p_polymorph` → `shapeshift_random`): any shape in the roster (the C rolls across the whole monster enum), "You transform into a <name>!"; the form survives the save (`shape` ID in the DTO, fail-fast on unknown forms).

## Test plan
- A wolf-formed player fights with 2d3 claws at 9/4 ignoring the doomblade; a speed-50 form drags the scheduler like a slow effect; a merman form crosses the pool dry; expiry reverts with the C line; the save round-trips the form; behavior + golden (the table is complete).
- gofmt + go vet + full `go test ./...` green (10/10 packages).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features

* Introduced polymorph potion: transforms the player into a random monster from the bestiary for 85 turns
* Polymorphed form affects combat stats (attack, damage, dodge), movement speed, and swimming ability
* Player appearance updates to match the polymorphed form
* Transformation automatically reverts upon effect expiry
* Polymorphed state persists through save/load

<!-- end of auto-generated comment: release notes by coderabbit.ai -->