### PR TITLE
The chainsaw ogre: the last 0.40 bestiary regular (closes the #13 audit gap)

### DIFF
--- a/data/data_test.go
+++ b/data/data_test.go
@@ -946,3 +946,27 @@ func TestEmbeddedPolymorph(t *testing.T) {
 		t.Errorf("potion_polymorph def unexpected: %+v", p)
 	}
 }
+
+// TestEmbeddedChainsawOgre checks the last 0.40 bestiary regular loaded (13k):
+// found auditing issue #13 — fast, loud, and at home in the worm caves.
+func TestEmbeddedChainsawOgre(t *testing.T) {
+	c, err := content.Load(Files)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	m := c.Monsters["chainsaw_ogre"]
+	if m == nil || m.Glyph != "O" || m.HP != 8 || m.Speed != 120 || m.Damage != "1d5+2" {
+		t.Fatalf("chainsaw_ogre def unexpected: %+v", m)
+	}
+	for _, lvl := range []string{"ominous_cave", "underpass"} {
+		found := false
+		for _, s := range c.Levels[lvl].Spawn {
+			if s.Monster == "chainsaw_ogre" {
+				found = true
+			}
+		}
+		if !found {
+			t.Errorf("%s should spawn the chainsaw ogre (C places.c lead std_enemy)", lvl)
+		}
+	}
+}

--- a/data/levels.toml
+++ b/data/levels.toml
@@ -118,6 +118,9 @@ weight = 1
 [[level.ominous_cave.spawn]]
 monster = "mimic"
 weight = 1
+[[level.ominous_cave.spawn]]
+monster = "chainsaw_ogre"
+weight = 2
 
 [level.laboratory]
 name = "the Laboratory"
@@ -237,6 +240,9 @@ weight = 1
 [[level.underpass.spawn]]
 monster = "mimic"
 weight = 1
+[[level.underpass.spawn]]
+monster = "chainsaw_ogre"
+weight = 2
 
 [level.drowned_city]
 name = "the Drowned City"

--- a/data/monsters.toml
+++ b/data/monsters.toml
@@ -562,3 +562,20 @@ damage = "1d4"
 speed = 10
 chat = "He keeps the wisdom that you need, the password that you want."
 min_depth = 99 # boss placement only
+
+# The chainsaw ogre (13k, C monster.c:408): fast, loud, and the lead enemy of
+# the worm caves (places.c). The 3/3/5/5/7/7 chainsaw chain ≈ 1d5+2 (avg 5,
+# max 7, exact). Grenades/aimed shot/wound rider out of scope (explode and
+# wound subsystems unported). 'O' is shared with the filler ogre by color —
+# the C reuses glyphs itself.
+[monster.chainsaw_ogre]
+name = "chainsaw ogre"
+glyph = "O"
+color = "red"
+hp = 8
+attack = 8
+dodge = 1
+damage = "1d5+2"
+speed = 120
+corpse = "corpse"
+min_depth = 3

--- a/docs/superpowers/plans/2026-06-11-chainsaw-ogre-13k.md
+++ b/docs/superpowers/plans/2026-06-11-chainsaw-ogre-13k.md
@@ -1,0 +1,26 @@
+# The chainsaw ogre (13k) Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Auditing issue #13 against the C surfaced one missed spawnable
+regular: the **chainsaw ogre** (`tsl-0.40/common/monster.c:408`). The last
+bestiary gap closes. Advances #13 to completion.
+
+## C grounding
+- HP 8, **speed 120**, glyph `O` (`glyph.c:110`); `virtual_chainsaw` melee —
+  a 3/3/5/5/7/7 chain (avg 5, max 7) ≈ **1d5+2**, exact on avg/max/min per
+  the #68 dice convention. Sometimes drops an ogre corpse.
+- Homes (`places.c:97/245`): lead `std_enemy` of the Ominous Cave and the
+  Underpass.
+- Out of scope (noted): grenade throwing (`treasure_grenade` — the explode
+  subsystem), aimed shot, the chainsaw's wound rider (`attr_i_wound` — wounds
+  unported), per-monster vision 3 (sense range is global).
+- Our `[monster.ogre]` ('O') is pre-parity filler — no plain ogre exists in
+  0.40; it joins the filler-retirement chip. The C reuses glyphs itself, so
+  the shared `O` differs by color.
+
+## Task: def + spawns + golden (TDD)
+- Golden first (red): def (O / 8 / speed 120 / 1d5+2) + spawn presence on
+  ominous_cave and underpass; fill TOML (green); full gate; PR; CodeRabbit
+  loop → merge.
+- Commit: `feat(content): the chainsaw ogre — the last 0.40 bestiary regular`


### PR DESCRIPTION
## Summary
Auditing issue #13's written scope against the C surfaced exactly one missed spawnable monster: the **chainsaw ogre** (`tsl-0.40/common/monster.c:408`) — fast (speed 120), loud, and the **lead `std_enemy` of both worm-cave levels** (`places.c:97/245` → our Ominous Cave and Underpass).

- Damage: the `virtual_chainsaw` 3/3/5/5/7/7 chain ≈ **1d5+2** — exact on average (5), max (7), and min (3) per the #68 dice convention.
- Out of scope, noted in the def: grenade throwing (the explode subsystem), aimed shot, the chainsaw's wound rider (wounds unported), per-monster vision.
- `O` is shared with our pre-parity filler `ogre` by color — the C reuses glyphs itself, and the filler joins the retirement chip's scope.

## Test plan
- Golden: def (O / 8 / 120 / 1d5+2) + spawn presence on both worm-cave levels.
- gofmt + go vet + full `go test ./...` green (11/11 packages).

Part of #13.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
- Added chainsaw ogre, a new enemy type with distinctive stats and appearance.
- Chainsaw ogre now spawns in ominous cave and underpass dungeon levels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->