### PR TITLE
The door chain: secret doors, locked doors, keys, and the close verb (issue #18 remainder, part 2)

### DIFF
--- a/data/data_test.go
+++ b/data/data_test.go
@@ -1026,3 +1026,24 @@ func TestEmbeddedGearSlots(t *testing.T) {
 		}
 	}
 }
+
+// TestEmbeddedDoorChain checks the 18g door kit: secret and locked doors,
+// a closable open door, and the key (C treasure.c WEIGHT_KEY 1).
+func TestEmbeddedDoorChain(t *testing.T) {
+	c, err := content.Load(Files)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if d := c.Tiles["door_secret"]; d == nil || !d.Secret || d.Glyph != "#" || d.Passable {
+		t.Errorf("door_secret should be a wall-looking secret tile, got %+v", d)
+	}
+	if d := c.Tiles["door_locked"]; d == nil || !d.Locked || d.OpensTo != "" {
+		t.Errorf("door_locked should be locked and not plainly openable, got %+v", d)
+	}
+	if d := c.Tiles["door_open"]; d == nil || d.ClosesTo != "door_closed" {
+		t.Errorf("door_open should close back to door_closed, got %+v", d)
+	}
+	if k := c.Items["key"]; k == nil || k.Kind != "tool" || k.Weight != 1 || k.Glyph != "'" {
+		t.Errorf("key def unexpected: %+v", k)
+	}
+}

--- a/data/items.toml
+++ b/data/items.toml
@@ -635,3 +635,12 @@ kind = "weapon"
 attack = 2
 damage = "1d5"
 weight = 18
+
+# The key (C treasure.c:343): weight 1, opens locked doors, consumed on use.
+# Floor loot — the C deals them from item_table_supply at 6 in 20.
+[item.key]
+name = "key"
+glyph = "'"
+color = "normal"
+kind = "tool"
+weight = 1

--- a/data/tiles.toml
+++ b/data/tiles.toml
@@ -49,6 +49,7 @@ glyph = "'"
 color = "brown"
 passable = true
 transparent = true
+closes_to = "door_closed"
 
 # Deep water (#18, C tiles.c): impassable on foot — only the blinded stumble in
 # (later: levitation floats over) — and each turn spent in it drains the wader.
@@ -101,3 +102,20 @@ passable = true
 transparent = true
 effect = "polymorph"
 effect_turns = 85
+
+# The door chain (18g, C doors.c). Secret doors wear the wall glyph until a
+# bump finds them; maybe_locked_door then makes them locked or closed at
+# 50/50. replace_doors locks half of all ordinary closed doors at gen, too.
+[tile.door_secret]
+glyph = "#"
+color = "normal"
+passable = false
+transparent = false
+secret = true
+
+[tile.door_locked]
+glyph = "+"
+color = "brown"
+passable = false
+transparent = false
+locked = true

--- a/docs/superpowers/plans/2026-06-11-door-chain-18g.md
+++ b/docs/superpowers/plans/2026-06-11-door-chain-18g.md
@@ -43,7 +43,7 @@ in the doorway); success flips door_open→door_closed and costs the turn.
   secret), `door_locked` (glyph `+`, locked); `door_open` gains
   `closes_to = "door_closed"`. New item `key`.
 - Engine stays I/O-free: bumping a locked door logs "It is locked." and parks
-  the position in `g.LockedBump`; `ui.Run` collects it via `TakeLockedBump()`
+  the position in `g.lockedBump`; `ui.Run` collects it via `TakeLockedBump()`
   and drives the C's prompt chain with `Menu` yes/no, calling
   `g.UnlockDoor(pos)` / `g.ForceDoor(pos)` (each ends with `advanceWorld`).
 - Bumping a secret door reveals in `PlayerStep`: log, 50/50 swap def to

--- a/docs/superpowers/plans/2026-06-11-door-chain-18g.md
+++ b/docs/superpowers/plans/2026-06-11-door-chain-18g.md
@@ -1,0 +1,76 @@
+# Secret doors, locked doors, keys, and the close verb (issue #18, part 2)
+
+The last #18 remainder: the door chain. All grounded in `tsl-0.40/common/doors.c`,
+`player.c`, `treasure.c`, `level.c`, `keymap.c`.
+
+## What the C does
+
+**Generation** (`replace_doors`, doors.c, called from level.c:363): every doorway
+starts as a secret door; 3+1d5 per level stay secret; the rest convert 50% to
+plain floor, 50% to a closed door; then `maybe_locked_door` locks 50% of ALL
+remaining closed doors. Net per doorway beyond the secret quota: 50% floor,
+25% closed, 25% locked.
+
+**Secret doors** (player.c:1609): bump → "You find a secret door!" →
+`maybe_locked_door` (50% locked / 50% closed); costs the turn. (Blind discovery
+takes two bumps — deviation: we reveal on the first bump regardless; our blind
+play doesn't track per-tile memory blankness.) Two C tiles (v/h) exist only for
+wall-glyph memory; our walls are uniform `#`, so one `door_secret` def.
+
+**Locked doors** (doors.c:275): bump → "It is locked." → if carrying keys,
+prompt "Unlock it (%d key|keys)?" → yes: `unlock_door` consumes ONE key, "You
+unlock the door.", and sets the tile straight to **tile_door_open** (unlocking
+opens — verified in the body). Declined/no key → prompt "Attempt to
+break it with your crowbar?" / "Attempt to break it?" → crowbar: guaranteed,
+"You break the door open with your crowbar!"; bare hands: `roll_xn(5,3)` = 5/8,
+"You break the door open!" — success sets the tile to FLOOR (door destroyed);
+failure: "You fail to force the door." + loud noise. Decline both: "Never mind,
+then.", no turn. Monsters never interact with locked doors.
+
+**Keys** (treasure.c:343): "key"/"keys", glyph `'`, weight 1 (WEIGHT_KEY), tool;
+item_table_supply rolls them 6/20. Our uniform floor-loot pick is the
+established approximation — adding the def makes them spawn.
+
+**Close** (doors.c close_door; keymap.c binds action_close to 'O' in the C's
+own default map): "Close which door?" + direction; "It is already closed." /
+"There is no door there." / "There is something in the way." (creature or item
+in the doorway); success flips door_open→door_closed and costs the turn.
+
+## Design
+
+- `TileDef` gains `Secret bool`, `Locked bool`, `ClosesTo string` (validated:
+  must name a defined tile). New defs: `door_secret` (glyph `#`, wall-look,
+  secret), `door_locked` (glyph `+`, locked); `door_open` gains
+  `closes_to = "door_closed"`. New item `key`.
+- Engine stays I/O-free: bumping a locked door logs "It is locked." and parks
+  the position in `g.LockedBump`; `ui.Run` collects it via `TakeLockedBump()`
+  and drives the C's prompt chain with `Menu` yes/no, calling
+  `g.UnlockDoor(pos)` / `g.ForceDoor(pos)` (each ends with `advanceWorld`).
+- Bumping a secret door reveals in `PlayerStep`: log, 50/50 swap def to
+  locked/closed via the shared RNG, spend the turn.
+- `ActClose` on 'O' (the C's own default binding): ui.Run scans the eight
+  neighbors for `ClosesTo` tiles — none: also scan for closed doors to say
+  "It is already closed.", else "There is no door there."; one: close it;
+  several: Menu "Close which door?" by direction. Engine method
+  `g.CloseDoor(pos)` re-checks blockers ("There is something in the way.").
+- Gen `placeDoors` ports `replace_doors`: shuffle doorways, keep 3+1d5 secret,
+  rest 50% floor / 50% closed, closed then 50% locked.
+
+## Tests (red first)
+
+1. Secret door bump: wall-look glyph in View; bump → "You find a secret door!",
+   def becomes door_closed or door_locked (seeded both ways), turn spent.
+2. Locked bump parks LockedBump + "It is locked."; UnlockDoor consumes exactly
+   one key from a stack, "You unlock the door.", tile → door_open.
+3. ForceDoor with crowbar: guaranteed, C line, tile → floor. Bare-handed
+   failure path: C line, turn still spent.
+4. CloseDoor: open→closed with turn; blocked by a creature → "There is
+   something in the way."; ClosesTo validation.
+5. Gen: with a seeded level, doorways yield a mix of secret/closed/locked/floor
+   and secret count ≤ 3+5.
+6. Golden: key def (weight 1, glyph '), door defs wired.
+
+## Order
+
+PR C branches from master AFTER #85 (gear) and #86 (traps) merge — all three
+touch `PlayerStep`.

--- a/internal/content/content.go
+++ b/internal/content/content.go
@@ -45,6 +45,9 @@ type TileDef struct {
 	EffectTurns int    `toml:"effect_turns"` // duration of Effect
 	Damage      string `toml:"damage"`       // straight trap damage dice (the electrified plate, #18)
 	OpensTo     string `toml:"opens_to"`     // tile id this becomes when opened ("" = not a door)
+	ClosesTo    string `toml:"closes_to"`    // tile id this becomes when closed ("" = not closable)
+	Secret      bool   `toml:"secret"`       // looks like a wall until bumped (C tile_door_secret_*)
+	Locked      bool   `toml:"locked"`       // a key, a crowbar, or force opens it (C tile_door_locked)
 }
 
 // Rune returns the tile's glyph as a rune. Glyph is guaranteed by validateTile
@@ -116,7 +119,7 @@ type ItemDef struct {
 // no explicit weight inherits its kind's.
 var kindWeights = map[string]int{
 	"potion": 7, "scroll": 4, "wand": 21, "food": 8, "light": 12,
-	"spellbook": 12, "ring": 5, "amulet": 5, "weapon": 22, "armor": 40, "ammo": 1, "boots": 35, "head": 20, "cloak": 25,
+	"spellbook": 12, "ring": 5, "amulet": 5, "weapon": 22, "armor": 40, "ammo": 1, "boots": 35, "head": 20, "cloak": 25, "tool": 1,
 }
 
 // Rune returns the item's glyph as a rune.
@@ -125,7 +128,7 @@ func (i *ItemDef) Rune() rune {
 	return r
 }
 
-var validItemKinds = map[string]bool{"potion": true, "weapon": true, "armor": true, "food": true, "wand": true, "scroll": true, "light": true, "spellbook": true, "ring": true, "amulet": true, "ammo": true, "boots": true, "head": true, "cloak": true}
+var validItemKinds = map[string]bool{"potion": true, "weapon": true, "armor": true, "food": true, "wand": true, "scroll": true, "light": true, "spellbook": true, "ring": true, "amulet": true, "ammo": true, "boots": true, "head": true, "cloak": true, "tool": true}
 
 // SpawnEntry is one weighted entry in a level's monster spawn table.
 type SpawnEntry struct {
@@ -254,15 +257,19 @@ func Load(fsys fs.FS) (*Content, error) {
 	return c, nil
 }
 
-// validateTileRefs checks that every tile's opens_to (when set) names a defined
-// tile, so a door always has an open state to become.
+// validateTileRefs checks that every tile's opens_to / closes_to (when set)
+// names a defined tile, so a door always has a state to become.
 func validateTileRefs(c *Content) error {
 	for id, t := range c.Tiles {
-		if t.OpensTo == "" {
-			continue
+		if t.OpensTo != "" {
+			if _, ok := c.Tiles[t.OpensTo]; !ok {
+				return fmt.Errorf("tile %q: opens_to %q is not a defined tile", id, t.OpensTo)
+			}
 		}
-		if _, ok := c.Tiles[t.OpensTo]; !ok {
-			return fmt.Errorf("tile %q: opens_to %q is not a defined tile", id, t.OpensTo)
+		if t.ClosesTo != "" {
+			if _, ok := c.Tiles[t.ClosesTo]; !ok {
+				return fmt.Errorf("tile %q: closes_to %q is not a defined tile", id, t.ClosesTo)
+			}
 		}
 	}
 	return nil

--- a/internal/game/combat.go
+++ b/internal/game/combat.go
@@ -116,6 +116,10 @@ func (g *Game) PlayerStep(d Direction) {
 			// already fired regardless, the C's trap_win exception.
 			g.springTrapAt(g.Player)
 		}
+	} else if g.revealSecretDoor(dst) { // the discovering bump costs the turn
+		acted = true
+	} else if g.bumpLockedDoor(dst) {
+		// The unlock/force prompts run in the front-end; no turn passes here.
 	} else if g.openDoor(dst) { // blocked by a closed door: open it (costs the turn)
 		g.log("You open the door.")
 		acted = true

--- a/internal/game/combat.go
+++ b/internal/game/combat.go
@@ -478,10 +478,7 @@ func (g *Game) gasProtected() bool {
 // our mapping of the C's attr_stealth detection rolls. Floor 2: nothing
 // misses you at arm's length.
 func (g *Game) noticeRange() int {
-	r := senseRange
-	for _, it := range g.equippedGear() {
-		r -= it.Def.Stealth
-	}
+	r := senseRange - g.playerStealth()
 	if r < 2 {
 		r = 2
 	}

--- a/internal/game/door.go
+++ b/internal/game/door.go
@@ -19,3 +19,145 @@ func (g *Game) openDoor(p Pos) bool {
 	g.Level.Set(p, open)
 	return true
 }
+
+// revealSecretDoor handles a bump into a secret door: the C reveals it with
+// "You find a secret door!" (player.c:1620) and maybe_locked_door rolls 50/50
+// locked vs closed (doors.c). Reports whether one was revealed — the
+// discovering bump costs the turn. (The C's blind two-bump discovery is not
+// reproduced; we reveal on the first bump regardless.)
+func (g *Game) revealSecretDoor(p Pos) bool {
+	if !g.Level.InBounds(p) || !g.Level.At(p).Def.Secret {
+		return false
+	}
+	g.log("You find a secret door!")
+	if g.RNG.Intn(2) == 0 {
+		g.Level.Set(p, g.Content.Tiles["door_locked"])
+	} else {
+		g.Level.Set(p, g.Content.Tiles["door_closed"])
+	}
+	return true
+}
+
+// bumpLockedDoor notes a bump into a locked door ("It is locked.",
+// doors.c:278) and parks the position for the front-end's unlock/force prompt
+// chain. The bump itself passes no turn; UnlockDoor/ForceDoor charge it.
+func (g *Game) bumpLockedDoor(p Pos) bool {
+	if !g.Level.InBounds(p) || !g.Level.At(p).Def.Locked {
+		return false
+	}
+	g.log("It is locked.")
+	g.lockedBump = &p
+	return true
+}
+
+// TakeLockedBump returns and clears the position of the locked door the
+// player just bumped, if any.
+func (g *Game) TakeLockedBump() (Pos, bool) {
+	if g.lockedBump == nil {
+		return Pos{}, false
+	}
+	p := *g.lockedBump
+	g.lockedBump = nil
+	return p, true
+}
+
+// KeyCount is how many keys the player carries (the C stacks them and offers
+// the count in the unlock prompt).
+func (g *Game) KeyCount() int {
+	n := 0
+	for _, it := range g.Inventory {
+		if it.Def != nil && it.Def.ID == "key" {
+			n++
+		}
+	}
+	return n
+}
+
+// HasCrowbar reports whether the player carries a crowbar — it changes both
+// the force prompt and the outcome (doors.c:300).
+func (g *Game) HasCrowbar() bool {
+	for _, it := range g.Inventory {
+		if it.Def != nil && it.Def.ID == "crowbar" {
+			return true
+		}
+	}
+	return false
+}
+
+// UnlockDoor spends one key on the locked door at p — the C's unlock_door
+// destroys the key and sets the tile straight to open (doors.c:470).
+func (g *Game) UnlockDoor(p Pos) {
+	if g.Dead || g.Won || !g.Level.InBounds(p) || !g.Level.At(p).Def.Locked {
+		return
+	}
+	for _, it := range g.Inventory {
+		if it.Def != nil && it.Def.ID == "key" {
+			g.removeInventory(it)
+			g.Level.Set(p, g.Content.Tiles["door_open"])
+			g.log("You unlock the door.")
+			g.advanceWorld()
+			return
+		}
+	}
+}
+
+// loudNoiseRadius approximates the C's draw_attention(noise_loud), which
+// floods 60 tiles out from the source; a radius-7 disc is close enough.
+const loudNoiseRadius = 7
+
+func (g *Game) loudNoise(p Pos) {
+	for _, m := range g.Level.Creatures {
+		if chebyshev(p, m.Pos) <= loudNoiseRadius {
+			m.RemoveEffect("sleep")
+		}
+	}
+}
+
+// ForceDoor breaks the locked door at p: a crowbar always works, bare hands
+// at the C's roll_xn(5,3) = 5 in 8 (doors.c:307). Success destroys the door
+// outright (the tile becomes floor); failure is loud. Either way the attempt
+// costs the turn.
+func (g *Game) ForceDoor(p Pos) {
+	if g.Dead || g.Won || !g.Level.InBounds(p) || !g.Level.At(p).Def.Locked {
+		return
+	}
+	switch {
+	case g.HasCrowbar():
+		g.log("You break the door open with your crowbar!")
+		g.Level.Set(p, g.Content.Tiles["floor"])
+	case g.RNG.Intn(8) < 5:
+		g.log("You break the door open!")
+		g.Level.Set(p, g.Content.Tiles["floor"])
+	default:
+		g.log("You fail to force the door.")
+		g.loudNoise(p)
+	}
+	g.advanceWorld()
+}
+
+// CloseDoor closes the open door at p (the C's close_door): anything standing
+// or lying in the doorway blocks it.
+func (g *Game) CloseDoor(p Pos) {
+	if g.Dead || g.Won || !g.Level.InBounds(p) {
+		return
+	}
+	t := g.Level.At(p)
+	if t.Def.ClosesTo == "" {
+		if t.Def.OpensTo != "" {
+			g.log("It is already closed.")
+		} else {
+			g.log("There is no door there.")
+		}
+		return
+	}
+	if g.Level.CreatureAt(p) != nil || g.Level.ItemAt(p) != nil || p == g.Player {
+		g.log("There is something in the way.")
+		return
+	}
+	closed, ok := g.Content.Tiles[t.Def.ClosesTo]
+	if !ok {
+		return
+	}
+	g.Level.Set(p, closed)
+	g.advanceWorld()
+}

--- a/internal/game/door.go
+++ b/internal/game/door.go
@@ -125,7 +125,7 @@ func (g *Game) ForceDoor(p Pos) {
 	case g.HasCrowbar():
 		g.log("You break the door open with your crowbar!")
 		g.Level.Set(p, g.Content.Tiles["floor"])
-	case g.RNG.Intn(8) < 5:
+	case g.rollXN(5, 3):
 		g.log("You break the door open!")
 		g.Level.Set(p, g.Content.Tiles["floor"])
 	default:
@@ -159,5 +159,41 @@ func (g *Game) CloseDoor(p Pos) {
 		return
 	}
 	g.Level.Set(p, closed)
+	// The C rolls stealth vs DOOR_STEALTH (rules.h:139) for a quiet close;
+	// slamming it is loud.
+	if g.rollXN(g.playerStealth(), doorStealth) {
+		g.log("You silently close the door.")
+	} else {
+		g.log("You slam the door shut.")
+		g.loudNoise(p)
+	}
 	g.advanceWorld()
+}
+
+// doorStealth is the C's DOOR_STEALTH (rules.h:139): the difficulty side of
+// the quiet-close roll.
+const doorStealth = 2
+
+// rollXN is the C's roll_xn (rolls.c:70): true with probability x in x+n,
+// clamping either side up to 1 by shifting the shortfall to the other.
+func (g *Game) rollXN(x, n int) bool {
+	if x < 1 {
+		n += 1 - x
+		x = 1
+	}
+	if n < 1 {
+		x += 1 - n
+		n = 1
+	}
+	return g.RNG.Intn(x+n) < x
+}
+
+// playerStealth sums worn stealth (the C's attr_stealth): dark cloak, padded
+// boots.
+func (g *Game) playerStealth() int {
+	s := 0
+	for _, it := range g.equippedGear() {
+		s += it.Def.Stealth
+	}
+	return s
 }

--- a/internal/game/doorchain_test.go
+++ b/internal/game/doorchain_test.go
@@ -1,0 +1,218 @@
+package game
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/c0ze/tsl-go/internal/content"
+	"github.com/c0ze/tsl-go/internal/rng"
+)
+
+func chainContent() *content.Content {
+	return &content.Content{
+		Tiles: map[string]*content.TileDef{
+			"floor":       {ID: "floor", Glyph: ".", Color: content.ColorNormal, Passable: true, Transparent: true},
+			"wall":        {ID: "wall", Glyph: "#", Color: content.ColorNormal},
+			"door_open":   {ID: "door_open", Glyph: "'", Color: content.ColorBrown, Passable: true, Transparent: true, ClosesTo: "door_closed"},
+			"door_closed": {ID: "door_closed", Glyph: "+", Color: content.ColorBrown, OpensTo: "door_open"},
+			"door_secret": {ID: "door_secret", Glyph: "#", Color: content.ColorNormal, Secret: true},
+			"door_locked": {ID: "door_locked", Glyph: "+", Color: content.ColorBrown, Locked: true},
+		},
+		Items: map[string]*content.ItemDef{
+			"key":     {ID: "key", Name: "key", Glyph: "'", Color: content.ColorNormal, Kind: "tool", Weight: 1},
+			"crowbar": {ID: "crowbar", Name: "crowbar", Glyph: ")", Color: content.ColorNormal, Kind: "weapon", Damage: "1d3"},
+		},
+	}
+}
+
+func chainGame(seed uint32) *Game {
+	c := chainContent()
+	l := NewLevel(7, 5, c.Tiles["floor"])
+	return &Game{Content: c, Level: l, Player: Pos{1, 1}, RNG: rng.NewWithSeed(seed), PlayerHP: 10, PlayerMax: 10}
+}
+
+func hasMsg(g *Game, want string) bool {
+	for _, m := range g.Messages {
+		if strings.Contains(m, want) {
+			return true
+		}
+	}
+	return false
+}
+
+// Bumping a secret door reveals it with the C's line (player.c:1620) and
+// maybe_locked_door makes it locked or closed at 50/50 (doors.c).
+func TestSecretDoorReveal(t *testing.T) {
+	gotLocked, gotClosed := false, false
+	for seed := uint32(1); seed <= 20; seed++ {
+		g := chainGame(seed)
+		g.Level.Set(Pos{2, 1}, g.Content.Tiles["door_secret"])
+
+		g.PlayerStep(DirE)
+
+		if !hasMsg(g, "You find a secret door!") {
+			t.Fatalf("seed %d: missing discovery message, got %v", seed, g.Messages)
+		}
+		if g.Player != (Pos{1, 1}) {
+			t.Fatalf("seed %d: player moved into the secret door, at %v", seed, g.Player)
+		}
+		switch g.Level.At(Pos{2, 1}).Def.ID {
+		case "door_locked":
+			gotLocked = true
+		case "door_closed":
+			gotClosed = true
+		default:
+			t.Fatalf("seed %d: secret door became %q", seed, g.Level.At(Pos{2, 1}).Def.ID)
+		}
+	}
+	if !gotLocked || !gotClosed {
+		t.Errorf("maybe_locked_door should land both ways over 20 seeds: locked=%v closed=%v", gotLocked, gotClosed)
+	}
+}
+
+// Bumping a locked door says so (doors.c:278) and parks the position for the
+// front-end's prompt chain; it never opens via the plain bump path.
+func TestLockedDoorBump(t *testing.T) {
+	g := chainGame(1)
+	g.Level.Set(Pos{2, 1}, g.Content.Tiles["door_locked"])
+
+	g.PlayerStep(DirE)
+
+	if !hasMsg(g, "It is locked.") {
+		t.Fatalf("missing locked message, got %v", g.Messages)
+	}
+	if g.Level.At(Pos{2, 1}).Def.ID != "door_locked" {
+		t.Errorf("bump must not open a locked door, got %q", g.Level.At(Pos{2, 1}).Def.ID)
+	}
+	pos, ok := g.TakeLockedBump()
+	if !ok || pos != (Pos{2, 1}) {
+		t.Errorf("TakeLockedBump = %v, %v; want {2 1}, true", pos, ok)
+	}
+	if _, again := g.TakeLockedBump(); again {
+		t.Error("TakeLockedBump should clear after one take")
+	}
+}
+
+// unlock_door (doors.c) destroys exactly one key and opens the door outright.
+func TestUnlockDoorConsumesOneKey(t *testing.T) {
+	g := chainGame(1)
+	g.Level.Set(Pos{2, 1}, g.Content.Tiles["door_locked"])
+	key := g.Content.Items["key"]
+	g.Inventory = append(g.Inventory, &Item{Def: key}, &Item{Def: key})
+
+	g.UnlockDoor(Pos{2, 1})
+
+	if !hasMsg(g, "You unlock the door.") {
+		t.Fatalf("missing unlock message, got %v", g.Messages)
+	}
+	if g.Level.At(Pos{2, 1}).Def.ID != "door_open" {
+		t.Errorf("unlocking should open the door (C sets tile_door_open), got %q", g.Level.At(Pos{2, 1}).Def.ID)
+	}
+	if n := g.KeyCount(); n != 1 {
+		t.Errorf("unlocking should consume exactly one key, %d left", n)
+	}
+}
+
+// A crowbar breaks a locked door open every time (doors.c:307), leaving floor.
+func TestForceDoorWithCrowbar(t *testing.T) {
+	g := chainGame(1)
+	g.Level.Set(Pos{2, 1}, g.Content.Tiles["door_locked"])
+	g.Inventory = append(g.Inventory, &Item{Def: g.Content.Items["crowbar"]})
+
+	g.ForceDoor(Pos{2, 1})
+
+	if !hasMsg(g, "You break the door open with your crowbar!") {
+		t.Fatalf("missing crowbar message, got %v", g.Messages)
+	}
+	if g.Level.At(Pos{2, 1}).Def.ID != "floor" {
+		t.Errorf("a broken door becomes floor, got %q", g.Level.At(Pos{2, 1}).Def.ID)
+	}
+}
+
+// Bare hands force at roll_xn(5,3) = 5 in 8; failure makes loud noise that
+// wakes nearby sleepers (doors.c:323 draw_attention).
+func TestForceDoorBareHands(t *testing.T) {
+	broke, failed := false, false
+	for seed := uint32(1); seed <= 40 && !(broke && failed); seed++ {
+		g := chainGame(seed)
+		g.Level.Set(Pos{2, 1}, g.Content.Tiles["door_locked"])
+		rat := &Creature{Def: &content.MonsterDef{ID: "rat", Name: "rat", HP: 3, Damage: "1d1"}, Pos: Pos{5, 3}, HP: 3}
+		rat.Effects = append(rat.Effects, Effect{Kind: "sleep", Turns: 99})
+		g.Level.Creatures = append(g.Level.Creatures, rat)
+
+		g.ForceDoor(Pos{2, 1})
+
+		switch g.Level.At(Pos{2, 1}).Def.ID {
+		case "floor":
+			if !hasMsg(g, "You break the door open!") {
+				t.Fatalf("seed %d: success without its message: %v", seed, g.Messages)
+			}
+			broke = true
+		case "door_locked":
+			if !hasMsg(g, "You fail to force the door.") {
+				t.Fatalf("seed %d: failure without its message: %v", seed, g.Messages)
+			}
+			if rat.HasEffect("sleep") {
+				t.Errorf("seed %d: the noise of a failed force should wake the rat", seed)
+			}
+			failed = true
+		default:
+			t.Fatalf("seed %d: door became %q", seed, g.Level.At(Pos{2, 1}).Def.ID)
+		}
+	}
+	if !broke || !failed {
+		t.Errorf("forcing should land both ways over 40 seeds: broke=%v failed=%v", broke, failed)
+	}
+}
+
+// close_door (doors.c): an open door closes unless something is in the way.
+func TestCloseDoor(t *testing.T) {
+	g := chainGame(1)
+	g.Level.Set(Pos{2, 1}, g.Content.Tiles["door_open"])
+
+	g.CloseDoor(Pos{2, 1})
+
+	if g.Level.At(Pos{2, 1}).Def.ID != "door_closed" {
+		t.Errorf("closing an open door should yield door_closed, got %q", g.Level.At(Pos{2, 1}).Def.ID)
+	}
+}
+
+func TestCloseDoorBlocked(t *testing.T) {
+	g := chainGame(1)
+	g.Level.Set(Pos{2, 1}, g.Content.Tiles["door_open"])
+	rat := &Creature{Def: &content.MonsterDef{ID: "rat", Name: "rat", HP: 3, Damage: "1d1"}, Pos: Pos{2, 1}, HP: 3}
+	g.Level.Creatures = append(g.Level.Creatures, rat)
+
+	g.CloseDoor(Pos{2, 1})
+
+	if !hasMsg(g, "There is something in the way.") {
+		t.Fatalf("missing blocked message, got %v", g.Messages)
+	}
+	if g.Level.At(Pos{2, 1}).Def.ID != "door_open" {
+		t.Error("a blocked door must stay open")
+	}
+
+	g2 := chainGame(1)
+	g2.Level.Set(Pos{2, 1}, g2.Content.Tiles["door_open"])
+	g2.Level.Items = append(g2.Level.Items, &Item{Def: g2.Content.Items["key"], Pos: Pos{2, 1}})
+	g2.CloseDoor(Pos{2, 1})
+	if g2.Level.At(Pos{2, 1}).Def.ID != "door_open" {
+		t.Error("an item in the doorway must block closing")
+	}
+}
+
+// Monsters never open locked or secret doors (doors.c bails for non-players).
+func TestMonsterBlockedByLockedDoor(t *testing.T) {
+	for _, tile := range []string{"door_locked", "door_secret"} {
+		g := chainGame(1)
+		g.Level.Set(Pos{2, 1}, g.Content.Tiles[tile])
+		rat := &Creature{Def: &content.MonsterDef{ID: "rat", Name: "rat", HP: 3, Damage: "1d1"}, Pos: Pos{3, 1}, HP: 3}
+		g.Level.Creatures = append(g.Level.Creatures, rat)
+
+		g.worldTick()
+
+		if got := g.Level.At(Pos{2, 1}).Def.ID; got != tile {
+			t.Errorf("a monster must not open %s, got %q", tile, got)
+		}
+	}
+}

--- a/internal/game/doorchain_test.go
+++ b/internal/game/doorchain_test.go
@@ -165,15 +165,36 @@ func TestForceDoorBareHands(t *testing.T) {
 	}
 }
 
-// close_door (doors.c): an open door closes unless something is in the way.
+// close_door (doors.c): an open door closes unless something is in the way,
+// and the DOOR_STEALTH roll decides a silent close vs a loud slam.
 func TestCloseDoor(t *testing.T) {
-	g := chainGame(1)
-	g.Level.Set(Pos{2, 1}, g.Content.Tiles["door_open"])
+	silent, slammed := false, false
+	for seed := uint32(1); seed <= 30 && !(silent && slammed); seed++ {
+		g := chainGame(seed)
+		g.Level.Set(Pos{2, 1}, g.Content.Tiles["door_open"])
+		rat := &Creature{Def: &content.MonsterDef{ID: "rat", Name: "rat", HP: 3, Damage: "1d1"}, Pos: Pos{5, 3}, HP: 3}
+		rat.Effects = append(rat.Effects, Effect{Kind: "sleep", Turns: 99})
+		g.Level.Creatures = append(g.Level.Creatures, rat)
 
-	g.CloseDoor(Pos{2, 1})
+		g.CloseDoor(Pos{2, 1})
 
-	if g.Level.At(Pos{2, 1}).Def.ID != "door_closed" {
-		t.Errorf("closing an open door should yield door_closed, got %q", g.Level.At(Pos{2, 1}).Def.ID)
+		if g.Level.At(Pos{2, 1}).Def.ID != "door_closed" {
+			t.Fatalf("seed %d: closing an open door should yield door_closed, got %q", seed, g.Level.At(Pos{2, 1}).Def.ID)
+		}
+		switch {
+		case hasMsg(g, "You silently close the door."):
+			silent = true
+		case hasMsg(g, "You slam the door shut."):
+			if rat.HasEffect("sleep") {
+				t.Errorf("seed %d: a slam is loud and should wake the rat", seed)
+			}
+			slammed = true
+		default:
+			t.Fatalf("seed %d: a successful close must report itself, got %v", seed, g.Messages)
+		}
+	}
+	if !silent || !slammed {
+		t.Errorf("the DOOR_STEALTH roll should land both ways over 30 seeds: silent=%v slammed=%v", silent, slammed)
 	}
 }
 

--- a/internal/game/game.go
+++ b/internal/game/game.go
@@ -119,6 +119,7 @@ type Game struct {
 	recallLevel  string // level id pinned by a mark scroll (see MarkRecall/Recall)
 	recallPos    Pos
 	recallSet    bool
+	lockedBump   *Pos // locked door just bumped, awaiting the front-end's prompt chain
 	Messages     []string
 	Dead         bool
 	Inventory    []*Item

--- a/internal/game/use.go
+++ b/internal/game/use.go
@@ -112,6 +112,22 @@ func (g *Game) PlayerUse(it *Item) {
 	case "amulet":
 		g.Amulet = it
 		g.log("You put on the %s.", it.Def.Name)
+	case "tool":
+		// Keys are the C's key_open (doors.c:420): applying one unlocks an
+		// adjacent locked door. Nothing else is an applicable tool yet.
+		if it.Def.ID == "key" {
+			for dy := -1; dy <= 1; dy++ {
+				for dx := -1; dx <= 1; dx++ {
+					q := Pos{g.Player.X + dx, g.Player.Y + dy}
+					if (dx != 0 || dy != 0) && g.Level.InBounds(q) && g.Level.At(q).Def.Locked {
+						g.UnlockDoor(q) // consumes a key and charges the turn
+						return
+					}
+				}
+			}
+		}
+		g.log("There is nothing there to unlock.")
+		return // a cancelled apply costs nothing (C key_open returns false)
 	case "potion", "food", "scroll":
 		if it.Def.Kind != "scroll" && g.gasProtected() {
 			g.log("You would have to remove your mask first.") // C: p_eat/p_drink while masked

--- a/internal/gen/gen.go
+++ b/internal/gen/gen.go
@@ -228,7 +228,7 @@ func LevelFromDef(r *rng.MT, c *content.Content, def *content.LevelDef) (*game.L
 		}
 	}
 	if def.Doors {
-		placeDoors(c, lvl, rooms)
+		placeDoors(r, c, lvl, rooms)
 	}
 	placeSpawnMonsters(r, c, lvl, rooms, def)
 	placeItems(r, c, lvl, rooms, lvl.Start)
@@ -363,11 +363,14 @@ func cutsOff(lvl *game.Level) bool {
 }
 
 // placeDoors converts each room's doorways — single-tile passages where a
-// corridor punched through the room's wall ring — into closed doors. Doorways
-// are detected on the original (door-free) layout so placement order can't
-// affect the result; stairs, the altar, traps, portals, and the start tile are
-// never overwritten.
-func placeDoors(c *content.Content, lvl *game.Level, rooms []rect) {
+// corridor punched through the room's wall ring — into doors, porting the
+// C's replace_doors (doors.c, called from level.c:363): every doorway starts
+// as a candidate, 3+1d5 per level stay secret, the rest convert 50% to bare
+// floor or a closed door, and half the closed doors lock (maybe_locked_door).
+// Doorways are detected on the original (door-free) layout so placement order
+// can't affect the result; stairs, the altar, traps, portals, and the start
+// tile are never overwritten.
+func placeDoors(r *rng.MT, c *content.Content, lvl *game.Level, rooms []rect) {
 	closed := c.Tiles["door_closed"]
 	if closed == nil {
 		return
@@ -386,8 +389,39 @@ func placeDoors(c *content.Content, lvl *game.Level, rooms []rect) {
 			}
 		}
 	}
+	spots := make([]game.Pos, 0, len(doorways))
 	for p := range doorways {
-		lvl.Set(p, closed)
+		spots = append(spots, p)
+	}
+	sort.Slice(spots, func(i, j int) bool { // deterministic order for the RNG stream
+		if spots[i].Y != spots[j].Y {
+			return spots[i].Y < spots[j].Y
+		}
+		return spots[i].X < spots[j].X
+	})
+	secret, locked := c.Tiles["door_secret"], c.Tiles["door_locked"]
+	if secret == nil || locked == nil { // content without the chain: plain doors
+		for _, p := range spots {
+			lvl.Set(p, closed)
+		}
+		return
+	}
+	for i := len(spots) - 1; i > 0; i-- { // who stays secret is the C's random pick
+		j := r.Intn(i + 1)
+		spots[i], spots[j] = spots[j], spots[i]
+	}
+	keep := 3 + r.Intn(5) + 1 // doors_to_keep = 3 + roll(1,5)
+	for i, p := range spots {
+		switch {
+		case i < keep:
+			lvl.Set(p, secret)
+		case r.Intn(2) == 0:
+			// converted to plain floor: a doorway with no door at all
+		case r.Intn(2) == 0:
+			lvl.Set(p, locked)
+		default:
+			lvl.Set(p, closed)
+		}
 	}
 }
 

--- a/internal/gen/gen_test.go
+++ b/internal/gen/gen_test.go
@@ -541,3 +541,41 @@ func TestMimicSpawnsDisguised(t *testing.T) {
 		t.Skip("no mimic placed this seed")
 	}
 }
+
+func TestLevelFromDefDealsDoorChain(t *testing.T) {
+	// With the chain tiles defined, placeDoors ports replace_doors: 3+1d5
+	// doorways stay secret, the rest split floor/closed, half the closed lock.
+	c := levelDefContent()
+	c.Tiles["door_open"] = &content.TileDef{ID: "door_open", Glyph: "'", Color: content.ColorBrown, Passable: true, Transparent: true, ClosesTo: "door_closed"}
+	c.Tiles["door_closed"] = &content.TileDef{ID: "door_closed", Glyph: "+", Color: content.ColorBrown, OpensTo: "door_open"}
+	c.Tiles["door_secret"] = &content.TileDef{ID: "door_secret", Glyph: "#", Color: content.ColorNormal, Secret: true}
+	c.Tiles["door_locked"] = &content.TileDef{ID: "door_locked", Glyph: "+", Color: content.ColorBrown, Locked: true}
+	def := &content.LevelDef{ID: "x", Name: "X", W: 60, H: 24, Links: []string{"y"}, Doors: true}
+	sawSecret, sawLocked, sawClosed := false, false, false
+	for seed := uint32(1); seed <= 8; seed++ {
+		lvl, err := LevelFromDef(rng.NewWithSeed(seed), c, def)
+		if err != nil {
+			t.Fatal(err)
+		}
+		secrets := 0
+		for y := 0; y < lvl.H; y++ {
+			for x := 0; x < lvl.W; x++ {
+				switch lvl.At(game.Pos{X: x, Y: y}).Def.ID {
+				case "door_secret":
+					secrets++
+					sawSecret = true
+				case "door_locked":
+					sawLocked = true
+				case "door_closed":
+					sawClosed = true
+				}
+			}
+		}
+		if secrets > 8 { // doors_to_keep caps at 3 + 5
+			t.Errorf("seed %d: %d secret doors, the C keeps at most 8", seed, secrets)
+		}
+	}
+	if !sawSecret || !sawLocked || !sawClosed {
+		t.Errorf("over 8 seeds the deal should produce every kind: secret=%v locked=%v closed=%v", sawSecret, sawLocked, sawClosed)
+	}
+}

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -48,6 +48,7 @@ const (
 	ActCast
 	ActTalk
 	ActSave
+	ActClose
 )
 
 // Action is a decoded player intent. Dir is meaningful only when Kind==ActMove.
@@ -114,6 +115,8 @@ func ActionForRune(r rune) (Action, bool) {
 		return Action{Kind: ActTalk}, true
 	case 'S':
 		return Action{Kind: ActSave}, true
+	case 'O': // the C's own default keymap binds action_close here (keymap.c:219)
+		return Action{Kind: ActClose}, true
 	case '>':
 		return Action{Kind: ActTravel}, true
 	}
@@ -241,6 +244,9 @@ func Run(g *game.Game, p Prompter, r Renderer) error {
 			return nil
 		case ActMove:
 			g.PlayerStep(a.Dir)
+			if pos, ok := g.TakeLockedBump(); ok {
+				promptLockedDoor(g, p, pos)
+			}
 		case ActPickup:
 			g.PlayerPickup()
 		case ActInventory:
@@ -257,6 +263,8 @@ func Run(g *game.Game, p Prompter, r Renderer) error {
 			g.Travel()
 		case ActTalk:
 			g.Talk()
+		case ActClose:
+			closeDoorPrompt(g, p)
 		case ActSave:
 			return ErrSaveRequested
 		case ActEat:
@@ -332,6 +340,74 @@ func Run(g *game.Game, p Prompter, r Renderer) error {
 			} else {
 				g.CastSpell(spell)
 			}
+		}
+	}
+}
+
+// promptLockedDoor drives the C's locked-door bump chain (doors.c:275): offer
+// to spend a key, then offer to break the door; declining both is the C's
+// "Never mind, then." (and costs nothing).
+func promptLockedDoor(g *game.Game, p Prompter, pos game.Pos) {
+	if n := g.KeyCount(); n > 0 {
+		word := "keys"
+		if n == 1 {
+			word = "key"
+		}
+		if idx, ok := p.Menu(MenuSpec{Title: fmt.Sprintf("Unlock it (%d %s)?", n, word), Items: []string{"Yes", "No"}}); ok && idx == 0 {
+			g.UnlockDoor(pos)
+			return
+		}
+	}
+	title := "Attempt to break it?"
+	if g.HasCrowbar() {
+		title = "Attempt to break it with your crowbar?"
+	}
+	if idx, ok := p.Menu(MenuSpec{Title: title, Items: []string{"Yes", "No"}}); ok && idx == 0 {
+		g.ForceDoor(pos)
+		return
+	}
+	g.Messages = append(g.Messages, "Never mind, then.")
+}
+
+// closeDirs orders the close-door menu the way the C's direction prompt reads.
+var closeDirs = []struct {
+	name   string
+	dx, dy int
+}{
+	{"North", 0, -1}, {"South", 0, 1}, {"West", -1, 0}, {"East", 1, 0},
+	{"Northwest", -1, -1}, {"Northeast", 1, -1}, {"Southwest", -1, 1}, {"Southeast", 1, 1},
+}
+
+// closeDoorPrompt is the close verb (the C's close_door): close the adjacent
+// open door, asking "Close which door?" only when several qualify.
+func closeDoorPrompt(g *game.Game, p Prompter) {
+	var names []string
+	var spots []game.Pos
+	alreadyClosed := false
+	for _, d := range closeDirs {
+		pos := game.Pos{X: g.Player.X + d.dx, Y: g.Player.Y + d.dy}
+		if !g.Level.InBounds(pos) {
+			continue
+		}
+		def := g.Level.At(pos).Def
+		switch {
+		case def.ClosesTo != "":
+			names = append(names, d.name)
+			spots = append(spots, pos)
+		case def.OpensTo != "":
+			alreadyClosed = true
+		}
+	}
+	switch {
+	case len(spots) == 0 && alreadyClosed:
+		g.Messages = append(g.Messages, "It is already closed.")
+	case len(spots) == 0:
+		g.Messages = append(g.Messages, "There is no door there.")
+	case len(spots) == 1:
+		g.CloseDoor(spots[0])
+	default:
+		if idx, ok := p.Menu(MenuSpec{Title: "Close which door?", Items: names}); ok && idx >= 0 && idx < len(spots) {
+			g.CloseDoor(spots[idx])
 		}
 	}
 }

--- a/internal/ui/ui_test.go
+++ b/internal/ui/ui_test.go
@@ -500,3 +500,11 @@ func TestRunSurfacesSaveRequest(t *testing.T) {
 		t.Errorf("Run should surface the save sentinel, got %v", err)
 	}
 }
+
+func TestCloseKeyBinding(t *testing.T) {
+	// 'O' is the C's own default binding for action_close (keymap.c:219).
+	a, ok := ActionForRune('O')
+	if !ok || a.Kind != ActClose {
+		t.Errorf("ActionForRune('O') = %+v, %v; want ActClose", a, ok)
+	}
+}


### PR DESCRIPTION
## Summary
The last audited remainder of #18, ported from `doors.c` / `player.c` / `level.c`. Grounding correction recorded along the way: locked doors are **not** rare in 0.40 — `replace_doors` runs at generation (level.c:363) and locks half of all ordinary closed doors, besides the secret-door chain.

- **Generation** ports `replace_doors`: every doorway is a candidate, 3+1d5 per level stay **secret**, the rest convert 50% to bare floor / 50% to closed doors, and `maybe_locked_door` locks half of those. The deal is drawn in deterministic doorway order so seeds reproduce.
- **Secret doors** wear the wall glyph until bumped: *"You find a secret door!"*, then 50/50 locked vs closed (player.c:1620). The C's two-bump blind discovery is noted as not reproduced.
- **Locked doors**: the bump logs *"It is locked."* and parks the position; the shared `ui.Run` drives the C's prompt chain with the existing `Menu` primitive — *"Unlock it (n key|keys)?"* (consumes ONE key; the C's `unlock_door` opens the door outright), then *"Attempt to break it (with your crowbar)?"* — a crowbar always works (PR #85's crowbar finally earns its keep), bare hands at `roll_xn(5,3)` = 5/8; success destroys the door to bare floor, failure is **loud**: sleepers wake within a radius-7 disc, the documented approximation of `draw_attention`'s 60-tile flood. Declining both: *"Never mind, then."*, no turn. The engine stays I/O-free throughout.
- **Keys** (treasure.c:343): weight 1, glyph `'`, kind tool, floor loot (the C deals 6/20 of item_table_supply; our uniform pick is the established approximation). Applying a key from the inventory is the C's `key_open`: unlocks an adjacent locked door, else *"There is nothing there to unlock."* at no cost.
- **Close verb on 'O'** — the C's own default keymap binding for `action_close` (keymap.c:219): closes the adjacent open door, asking *"Close which door?"* only when several qualify, with the C's refusal lines (*already closed / no door there / something in the way* — creatures and items both block).
- Monsters never open locked or secret doors (the C bails for non-players).

## Test plan
- Secret reveal lands both ways over 20 seeds with the C line; the player never steps through on the discovering bump.
- Locked bump parks exactly one prompt position; unlock consumes exactly one of two keys and opens the door; crowbar break is guaranteed; bare-handed forcing lands both ways over 40 seeds and a failure wakes a sleeping rat through the noise.
- Close: open→closed; a creature or an item in the doorway blocks with the C line.
- Gen: over 8 seeds the deal produces all three door kinds and never more than 8 secret doors per level; the legacy plain-door fallback still covers content without the chain tiles.
- Goldens for the four defs + key; `closes_to` cross-reference validated at load; 'O' binding test.
- gofmt + vet + full `go test ./...` green (11/11 packages).

Closes the implementation list of #18.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Secret doors now reveal as locked or closed when bumped; locked doors can be unlocked with keys or forced with a crowbar or bare hands.
  * Added a Close action (press O) to close adjacent open doors.
  * Keys and crowbars added as usable items; bumping a locked door triggers a prompt for unlock/force/dismiss.

* **Tests**
  * Added comprehensive tests for secret/locked/unlock/force/close behaviors.

* **Documentation**
  * Added design/spec for the door-chain mechanics and test plans.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->